### PR TITLE
Release 1.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
         if: ${{ steps.create_release.outputs.created == 'true' }}
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools twine
+          pip install setuptools twine wheel
       - name: Build and publish
         if: ${{ steps.create_release.outputs.created == 'true' }}
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          python setup.py sdist
+          python setup.py sdist bdist_wheel
           twine upload dist/*

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,15 @@
 
 ## Versions  
 
+### 1.7
+
+- Add
+  - `revive` method to `django_boost.models.mixins.LogicalDeletionMixin`
+  - `is_dead` method to `django_boost.models.mixins.LogicalDeletionMixin`
+  - `is_alive` method to `django_boost.models.mixins.LogicalDeletionMixin`
+- Fix
+  - `django_boost.utils.attribute.getattr_chain`
+
 ### 1.6.2
 
 - Update

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -1,6 +1,6 @@
 from django_boost.utils.version import get_version
 
-VERSION = (1, 6, 3, 'alpha', 0)
+VERSION = (1, 7, 0, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
- Add
  - `revive` method to `django_boost.models.mixins.LogicalDeletionMixin`
  - `is_dead` method to `django_boost.models.mixins.LogicalDeletionMixin`
  - `is_alive` method to `django_boost.models.mixins.LogicalDeletionMixin`
- Fix
  - `django_boost.utils.attribute.getattr_chain`

- [x] Does this have tests?  
- [x] Does this have documentation?  
- [x] Does this break the public API (Requires major version bump)?  
- [x] Is this a new feature (Requires minor version bump)?  
