### PR TITLE
Release 2.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         pip install -U pip
         pip install -r requirements/ci.txt
         pip install django==$DJANGO_VERSION
-        python setup.py install
+        pip install .
     - name: Tox
       run: |
         tox

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,13 @@
 
 ## Versions  
 
+## 2.1.1
+- Fix
+  - restore compatibility with Python 3.8 and 3.9 by constraining the `ua-parser` dependency
+- Update
+  - declare support for Python 3.11 and 3.12
+  - declare support for Django 4.1 and 4.2
+
 ## 2.1.0
 - Update
   - support django 4.1

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -1,6 +1,6 @@
 from django_boost.utils.version import get_version
 
-VERSION = (2, 1, 0, 'final', 0)
+VERSION = (2, 1, 1, 'final', 0)
 
 
 __version__ = get_version()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,3 @@
 Django>=3.0,<5
 user-agents>=2.0
+ua-parser<1.0; python_version < "3.10"

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,13 @@ for dirpath, dirnames, filenames in os.walk(extensions_dir):
         package_files.extend([os.path.join(path, f) for f in filenames])
 
 
-requires = ["Django>=3.0", "user-agents>=2.0"]
+requires = [
+    "Django>=3.0",
+    "user-agents>=2.0",
+    # ua-parser 1.0 (a user-agents dependency) requires Python 3.10+
+    # (it uses dataclass(slots=...)); keep older Pythons on the 0.x line.
+    'ua-parser<1.0; python_version < "3.10"',
+]
 
 
 def read(fname):
@@ -77,11 +83,15 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Framework :: Django',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
         'License :: OSI Approved :: MIT License',
     ],
 )


### PR DESCRIPTION
- Fix
  - restore compatibility with Python 3.8 and 3.9 by constraining the ua-parser dependency
- Update
  - declare support for Python 3.11 and 3.12
  - declare support for Django 4.1 and 4.2
