### PR TITLE
Fix HTTP 510 and 511 status messages

### DIFF
--- a/django_boost/http/__init__.py
+++ b/django_boost/http/__init__.py
@@ -65,4 +65,5 @@ STATUS_MESSAGES.update({
     506: 'Variant Also Negotiates',
     507: 'Insufficient Storage',
     508: 'Loop Detected',
-    510: 'Not Extended510 Nottwork Authentication Required'})
+    510: 'Not Extended',
+    511: 'Network Authentication Required'})

--- a/tests/tests/test_http.py
+++ b/tests/tests/test_http.py
@@ -1,0 +1,12 @@
+from django_boost.http import STATUS_MESSAGES
+from django_boost.test import TestCase
+
+
+class TestStatusMessages(TestCase):
+
+    def test_http_510_and_511_messages(self):
+        self.assertEqual(STATUS_MESSAGES[510], 'Not Extended')
+        self.assertEqual(STATUS_MESSAGES[511], 'Network Authentication Required')
+
+    def test_unknown_status_message_falls_back_to_empty_string(self):
+        self.assertEqual(STATUS_MESSAGES[509], '')


### PR DESCRIPTION
Fixes #244.

`STATUS_MESSAGES` currently has the 510 and 511 reason phrases collapsed into the 510 entry, so 510 renders as `Not Extended510 Nottwork Authentication Required` and 511 falls through to the empty default. This splits the table entries back into the registered phrases while keeping the `defaultdict(lambda: "")` behavior for non-standard codes such as 509.

I added a focused test for the two registered messages and the fallback case so this table does not regress again.

Checked locally:

- `.\.venv\Scripts\python manage.py test tests.tests.test_http -v 2`
- `.\.venv\Scripts\python manage.py test tests.tests.test_utils -v 1`
- `.\.venv\Scripts\python manage.py test -v 1`
- `.\.venv\Scripts\python -m py_compile django_boost\http\__init__.py tests\tests\test_http.py`
- `git diff --check`