### PR TITLE
Deprecate the support_heroku management command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `zip` template filter. Use the `zip` template tag instead.
 - `django_boost.models.fields.JsonField`. Use `django.db.models.JSONField`
   instead, available since Django 3.1.
+- `support_heroku` management command. It will be removed in django-boost 3.0.
 
 ## [2.1.2] - 2026-06-21
 

--- a/README.md
+++ b/README.md
@@ -898,18 +898,3 @@ python manage.py adminsitelog --delete
 ```
 
 It is also possible to delete only the logs narrowed down by `--filter` and `--exclude`.
-
-#### support_heroku
-
-```bash
-python manage.py support_heroku
-```
-
-Create heroku config files.
-`Procfile`,`runtime.txt`,`requirements.txt`
-
-For more details.
-
-```bash
-python manage.py support_heroku -h
-```

--- a/django_boost/management/commands/support_heroku.py
+++ b/django_boost/management/commands/support_heroku.py
@@ -1,6 +1,8 @@
 import sys
 from os import path
 from platform import python_version
+from warnings import warn
+
 try:
     from pip._internal.commands import freeze
 except ImportError:
@@ -54,6 +56,8 @@ class Command(QuitOptionMixin, BaseCommand):
         self.add_quit_option(parser)
 
     def handle(self, *args, **options):
+        warn("The `support_heroku` management command is deprecated and will "
+             "be removed in django-boost 3.0.", DeprecationWarning, stacklevel=2)
         EXEC_PATH = sys.argv[0]
         ROOT_DIR = path.dirname(path.abspath(EXEC_PATH))
         make_all = _make_all(**options)

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -99,6 +99,10 @@ It is also possible to delete only the logs narrowed down by ``--filter`` and ``
 support_heroku
 ---------------
 
+.. warning::
+
+  ``support_heroku`` is deprecated and will be removed in django-boost 3.0.
+
 ::
 
   $ python manage.py support_heroku

--- a/tests/tests/test_deprecations.py
+++ b/tests/tests/test_deprecations.py
@@ -1,3 +1,5 @@
+from django.core.management import call_command
+
 from django_boost.test import TestCase
 
 
@@ -14,3 +16,20 @@ class JsonFieldDeprecationTests(TestCase):
         from django_boost.models.fields import JsonField
         with self.assertWarnsRegex(DeprecationWarning, r"Django 3\.1"):
             JsonField()
+
+
+class SupportHerokuDeprecationTests(TestCase):
+    def test_support_heroku_warns(self):
+        with self.assertWarnsRegex(DeprecationWarning, r"support_heroku.*django-boost 3\.0"):
+            call_command("support_heroku")
+
+    @classmethod
+    def tearDownClass(cls):
+        import os
+        from django.conf import settings
+
+        for name in ["Procfile", "runtime.txt", "requirements.txt"]:
+            fp = os.path.join(settings.BASE_DIR, name)
+            if os.path.exists(fp):
+                os.remove(fp)
+        super().tearDownClass()


### PR DESCRIPTION
The PR should summarize what was changed and why. Here are some questions to help you if you're not sure:  

- What behavior was changed?  
- What code was refactored / updated to support this change?  
- What issues are related to this PR? Or why was this change introduced?  

Checklist - While not every PR needs it, new features should consider this list:  

- [ ] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
