### PR TITLE
Make devcontainer reproducible for headless agent verification

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "postCreateCommand": "python -m pip install --upgrade pip && python -m pip install -e . -r requirements/develop.txt -r requirements/ci.txt -r requirements/docs.txt",
+  "onCreateCommand": "python -m pip install --upgrade pip && python -m pip install -e . -r requirements/develop.txt -r requirements/ci.txt",
+  "postCreateCommand": "python -m pip install -r requirements/docs.txt && pip install \"django==${DJANGO_VERSION:-4.2.*}\"",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -26,6 +27,7 @@
     }
   },
   "remoteEnv": {
-    "PIP_DISABLE_PIP_VERSION_CHECK": "1"
+    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+    "DJANGO_VERSION": "${localEnv:DJANGO_VERSION}"
   }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
 envlist = flake8
 skipsdist = true
-[textenv]
-commands = py.test
-deps = pytest
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Split the create-time hook so test/lint requirements install via onCreateCommand and docs requirements via postCreateCommand, isolating a docs-install failure from the test-critical setup. Honor a DJANGO_VERSION env var, applied last (after docs.txt re-pins base.txt's Django<5 cap) so a specific Django version can be reproduced in-container.

Also drop the dead [textenv] block in tox.ini: a [testenv] typo referencing an unused pytest setup, which never ran and implied matrix support that does not exist.
