### PR TITLE
:memo: Replace Travis badge with GitHub Actions test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Django Boost is a collection of custom extensions for the Django Framework.
 
 [![PyPI - License](https://img.shields.io/pypi/l/django_boost)](https://pypi.org/project/django-boost/)
-[![Build Status](https://travis-ci.org/ChanTsune/django-boost.svg?branch=master)](https://travis-ci.org/ChanTsune/django-boost)
+[![Test](https://github.com/ChanTsune/django-boost/actions/workflows/test.yml/badge.svg)](https://github.com/ChanTsune/django-boost/actions/workflows/test.yml)
 [![Documentation Status](https://readthedocs.org/projects/django-boost/badge/?version=latest)](https://django-boost.readthedocs.io/en/latest/?badge=latest)
 [![PyPI](https://img.shields.io/pypi/v/django_boost)](https://pypi.org/project/django-boost/)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/django_boost)](https://pypi.org/project/django-boost/)


### PR DESCRIPTION
Summary:
- Update the README CI badge from the retired Travis CI endpoint to the GitHub Actions Test workflow badge.
- Point the badge link to the repository's test.yml workflow run page so readers can inspect current CI results.
