### PR TITLE
:memo: Add supported version badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Django Boost is a collection of custom extensions for the Django Framework.
 
 [![PyPI - License](https://img.shields.io/pypi/l/django_boost)](https://pypi.org/project/django-boost/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django_boost)](https://pypi.org/project/django-boost/)
+[![PyPI - Django Version](https://img.shields.io/pypi/djversions/django_boost)](https://pypi.org/project/django-boost/)
 [![Test](https://github.com/ChanTsune/django-boost/actions/workflows/test.yml/badge.svg)](https://github.com/ChanTsune/django-boost/actions/workflows/test.yml)
 [![Documentation Status](https://readthedocs.org/projects/django-boost/badge/?version=latest)](https://django-boost.readthedocs.io/en/latest/?badge=latest)
 [![PyPI](https://img.shields.io/pypi/v/django_boost)](https://pypi.org/project/django-boost/)


### PR DESCRIPTION
Add PyPI badge links that show the supported Python and Django versions from the package classifiers so readers can quickly see compatibility from the README header.

