### PR TITLE
:sparkles: Allow custom logical deletion timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,40 @@ posted_at = models.DateTimeField(auto_now_add=True)
 updated_at = models.DateTimeField(auto_now=True)
 ```
 
+### LogicalDeletionMixin
+
+```py
+from django.db import models
+from django_boost.models.mixins import LogicalDeletionMixin
+
+class Store(LogicalDeletionMixin):
+    name = models.CharField(max_length=128)
+```
+
+The field `deleted_at` is added to hold the date of the logical deletion.
+
+By default, the deletion process for models that inherit from this class is a logical deletion.
+If you want to do physical deletion, please pass `hard=True` as a `delete` method argument.
+
+```py
+Store.objects.delete()  # logical deletion.
+
+Store.objects.delete(hard=True)  # physical deletion.
+```
+
+If you want to specify when the object was logically deleted, pass `deleted_at`.
+This is available on model instances, querysets, and managers.
+
+```py
+from django.utils.timezone import now
+
+deleted_at = now()
+
+store.delete(deleted_at=deleted_at)
+Store.objects.filter(name="Store 1").delete(deleted_at=deleted_at)
+Store.objects.delete(deleted_at=deleted_at)
+```
+
 ### ColorCodeField
 
 ```py

--- a/django_boost/models/manager.py
+++ b/django_boost/models/manager.py
@@ -12,8 +12,8 @@ class LogicalDeletionManager(Manager):
     def get_queryset(self):
         return LogicalDeletionQuerySet(self.model)
 
-    def delete(self, hard=False):
-        return self.get_queryset().delete(hard=hard)
+    def delete(self, hard=False, deleted_at=None):
+        return self.get_queryset().delete(hard=hard, deleted_at=deleted_at)
 
     def alive(self):
         """Return not logically deleted items qureyset."""

--- a/django_boost/models/mixins.py
+++ b/django_boost/models/mixins.py
@@ -56,10 +56,10 @@ class LogicalDeletionMixin(models.Model):
     def get_deleted_value(cls):
         return now()
 
-    def delete(self, using=None, keep_parents=False, hard=False):
+    def delete(self, using=None, keep_parents=False, hard=False, deleted_at=None):
         if hard:
             return super().delete(using=using, keep_parents=keep_parents)
-        self.deleted_at = self.get_deleted_value()
+        self.deleted_at = deleted_at if deleted_at is not None else self.get_deleted_value()
         return self.save()
 
     def revive(self, force_update=False, using=None):

--- a/django_boost/models/query.py
+++ b/django_boost/models/query.py
@@ -7,11 +7,11 @@ class LogicalDeletionQuerySet(QuerySet):
     def get_delete_flag_field_name(self):
         return self.delete_flag_field
 
-    def delete(self, hard=False):
+    def delete(self, hard=False, deleted_at=None):
         if hard:
             return super().delete()
         field_name = self.get_delete_flag_field_name()
-        deleted_value = self.model.get_deleted_value()
+        deleted_value = deleted_at if deleted_at is not None else self.model.get_deleted_value()
         return super().update(**{field_name: deleted_value})
 
     def alive(self):

--- a/docs/model_mixins.rst
+++ b/docs/model_mixins.rst
@@ -79,6 +79,19 @@ If you want to do physical deletion, please pass ``hard=True`` as a ``delete`` m
 
   Store.objects.delete(hard=True) # physical deletion.
 
+If you want to specify when the object was logically deleted, pass ``deleted_at``.
+This is available on model instances, querysets, and managers.
+
+::
+
+  from django.utils.timezone import now
+
+  deleted_at = now()
+
+  store.delete(deleted_at=deleted_at)
+  Store.objects.filter(name="Store 1").delete(deleted_at=deleted_at)
+  Store.objects.delete(deleted_at=deleted_at)
+
 
 ``all`` method will get all the data as usual, including the logically deleted items.
 

--- a/example/templates/blog/article_delete.html
+++ b/example/templates/blog/article_delete.html
@@ -5,7 +5,7 @@
 {% block body %}
 <section class="page-title">
     <h1>Delete article</h1>
-    <p>DeleteView demonstrates logical deletion; the deleted archive still has a dedicated list view.</p>
+    <p>DeleteView demonstrates logical deletion by storing the deletion time in <code>deleted_at</code>; the deleted archive still has a dedicated list view.</p>
 </section>
 
 <section class="section panel">

--- a/example/templates/example/index.html
+++ b/example/templates/example/index.html
@@ -104,7 +104,7 @@
         </div>
 <pre><code>from django_boost.views.generic import JsonView, ModelCRUDViews
 from django_boost.views.mixins import LimitedTermMixin
-from django_boost.models.mixins import UUIDModelMixin, TimeStampModelMixin
+from django_boost.models.mixins import UUIDModelMixin, TimeStampModelMixin, LogicalDeletionMixin
 from django_boost.models.fields import ColorCodeFiled</code></pre>
     </div>
 </section>

--- a/tests/tests/logical_deletion/tests.py
+++ b/tests/tests/logical_deletion/tests.py
@@ -1,4 +1,7 @@
+from datetime import timedelta
+
 from django.test import TestCase, override_settings
+from django.utils.timezone import now
 
 
 @override_settings(
@@ -23,6 +26,14 @@ class TestLogicalDeletionMixin(TestCase):
         item = self.model.objects.get(name="0")
         item.delete()
         self.assertNotEqual(item.deleted_at, None)
+
+    def test_delete_with_deleted_at(self):
+        self._register_items(*[str(i) for i in range(10)])
+        deleted_at = now() - timedelta(days=1)
+        item = self.model.objects.get(name="0")
+        item.delete(deleted_at=deleted_at)
+        item.refresh_from_db()
+        self.assertEqual(item.deleted_at, deleted_at)
 
     def test_hard_delete(self):
         self._register_items(*[str(i) for i in range(10)])
@@ -82,6 +93,23 @@ class TestLogicalDeletionManager(TestCase):
         self._register_items(*[str(i) for i in range(10)])
         self.model.objects.delete()
         self.assertEqual(len(self.model.objects.dead()), 10)
+        self._hard_delete()
+
+    def test_delete_with_deleted_at(self):
+        self._register_items(*[str(i) for i in range(10)])
+        deleted_at = now() - timedelta(days=1)
+        self.model.objects.delete(deleted_at=deleted_at)
+        for item in self.model.objects.dead():
+            self.assertEqual(item.deleted_at, deleted_at)
+        self._hard_delete()
+
+    def test_queryset_delete_with_deleted_at(self):
+        self._register_items(*[str(i) for i in range(10)])
+        deleted_at = now() - timedelta(days=1)
+        self.model.objects.filter(name__in=["0", "1"]).delete(deleted_at=deleted_at)
+        self.assertEqual(len(self.model.objects.dead()), 2)
+        for item in self.model.objects.dead():
+            self.assertEqual(item.deleted_at, deleted_at)
         self._hard_delete()
 
     def test_hard_delete(self):


### PR DESCRIPTION
Support deleted_at on logical deletion delete methods for model instances, querysets, and managers so callers can preserve an explicit deletion time. Document the API in README/docs and align sample app references.
