### PR TITLE
:sparkles: Preserve Django delete semantics for logical deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
   the extra `forms.py` and `urls.py` on top, so generated apps inherit Django's
   defaults (such as `default_auto_field`). The previously bundled `apps.py`
   `ready()` stub and `views.py` generic-view imports are no longer added.
+- Make logical deletion follow Django's deletion collector so `CASCADE`,
+  `PROTECT`, `SET_NULL`, delete signals, queryset restrictions, and
+  `(count, details)` delete return values are preserved.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ The field `deleted_at` is added to hold the date of the logical deletion.
 By default, the deletion process for models that inherit from this class is a logical deletion.
 If you want to do physical deletion, please pass `hard=True` as a `delete` method argument.
 
+Logical deletion follows Django's deletion collector for normal `delete` behavior:
+`CASCADE`, `PROTECT`, `SET_NULL`, delete signals, queryset restrictions, and the
+`(count, details)` return value are preserved. Related models that do not inherit
+`LogicalDeletionMixin` are physically deleted when Django's cascade handling deletes them,
+because they have no `deleted_at` field to update.
+
 ```py
 Store.objects.delete()  # logical deletion.
 

--- a/django_boost/models/deletion.py
+++ b/django_boost/models/deletion.py
@@ -1,0 +1,158 @@
+import inspect
+from collections import Counter
+from functools import reduce
+from operator import attrgetter, or_
+
+from django.core.exceptions import FieldDoesNotExist
+from django.db import models, transaction
+from django.db.models import signals, sql
+from django.db.models.deletion import Collector
+
+
+_COLLECTOR_ACCEPTS_ORIGIN = 'origin' in inspect.signature(Collector.__init__).parameters
+
+
+def get_logical_delete_field(model):
+    if not hasattr(model, 'get_deleted_value'):
+        return None
+
+    get_field_name = getattr(model._default_manager, 'get_deleted_flag_field_name', None)
+    if callable(get_field_name):
+        field_name = get_field_name()
+    else:
+        field_name = getattr(model._default_manager, 'delete_flag_field', 'deleted_at')
+
+    try:
+        return model._meta.get_field(field_name)
+    except FieldDoesNotExist:
+        return None
+
+
+class LogicalDeletionCollector(Collector):
+
+    def __init__(self, using, origin=None, deleted_at=None):
+        if _COLLECTOR_ACCEPTS_ORIGIN:
+            super().__init__(using=using, origin=origin)
+        else:
+            super().__init__(using=using)
+        self.origin = origin
+        self.deleted_at = deleted_at
+
+    def can_fast_delete(self, objs, from_field=None):
+        model = getattr(objs, 'model', None)
+        if model is None:
+            if hasattr(objs, '_meta'):
+                model = objs._meta.model
+            elif objs:
+                model = objs[0].__class__
+        if model is not None and get_logical_delete_field(model) is not None:
+            return False
+        return super().can_fast_delete(objs, from_field=from_field)
+
+    def get_deleted_value(self, model):
+        if self.deleted_at is not None:
+            return self.deleted_at
+        return model.get_deleted_value()
+
+    def delete(self):
+        for model, instances in self.data.items():
+            self.data[model] = sorted(instances, key=attrgetter('pk'))
+
+        self.sort()
+        deleted_counter = Counter()
+
+        with transaction.atomic(using=self.using, savepoint=False):
+            for model, obj in self.instances_with_model():
+                if not model._meta.auto_created:
+                    self._send_delete_signal(signals.pre_delete, model, obj)
+
+            for qs in self.fast_deletes:
+                count = qs._raw_delete(using=self.using)
+                if count:
+                    deleted_counter[qs.model._meta.label] += count
+
+            self._apply_field_updates()
+
+            for instances in self.data.values():
+                instances.reverse()
+
+            for model, instances in self.data.items():
+                pk_list = [obj.pk for obj in instances]
+                if not pk_list:
+                    continue
+
+                field = get_logical_delete_field(model)
+                if field is None:
+                    count = self._delete_batch(model, pk_list)
+                else:
+                    deleted_value = self.get_deleted_value(model)
+                    count = self._logical_delete_batch(model, field, pk_list, deleted_value)
+                    for obj in instances:
+                        setattr(obj, field.attname, deleted_value)
+
+                if count:
+                    deleted_counter[model._meta.label] += count
+
+                if not model._meta.auto_created:
+                    for obj in instances:
+                        self._send_delete_signal(signals.post_delete, model, obj)
+
+        for model, instances in self.data.items():
+            if get_logical_delete_field(model) is not None:
+                continue
+            for instance in instances:
+                setattr(instance, model._meta.pk.attname, None)
+
+        return sum(deleted_counter.values()), dict(deleted_counter)
+
+    def _send_delete_signal(self, signal, model, obj):
+        kwargs = {'sender': model, 'instance': obj, 'using': self.using}
+        if _COLLECTOR_ACCEPTS_ORIGIN:
+            kwargs['origin'] = self.origin
+        signal.send(**kwargs)
+
+    def _iter_field_updates(self):
+        for key, value in self.field_updates.items():
+            if isinstance(key, tuple):
+                field, field_value = key
+                if isinstance(value, (list, tuple)):
+                    instances_list = value
+                else:
+                    instances_list = [value]
+                yield field, field_value, instances_list
+                continue
+
+            field = key
+            for field_value, instances in value.items():
+                yield field, field_value, [instances]
+
+    def _apply_field_updates(self):
+        for field, value, instances_list in self._iter_field_updates():
+            updates = []
+            objs = []
+            for instances in instances_list:
+                if isinstance(instances, models.QuerySet) and instances._result_cache is None:
+                    updates.append(instances)
+                else:
+                    objs.extend(instances)
+
+            if updates:
+                combined_updates = reduce(or_, updates)
+                combined_updates.update(**{field.name: value})
+
+            if objs:
+                model = objs[0].__class__
+                pk_list = list({obj.pk for obj in objs})
+                query = sql.UpdateQuery(model)
+                query.update_batch(pk_list, {field.name: value}, self.using)
+                for obj in objs:
+                    setattr(obj, field.attname, value)
+
+    def _delete_batch(self, model, pk_list):
+        query = sql.DeleteQuery(model)
+        return query.delete_batch(pk_list, self.using)
+
+    def _logical_delete_batch(self, model, field, pk_list, deleted_value):
+        query = sql.UpdateQuery(model)
+        query.update_batch(pk_list, {field.name: deleted_value}, self.using)
+        return len(pk_list)

--- a/django_boost/models/deletion.py
+++ b/django_boost/models/deletion.py
@@ -1,15 +1,11 @@
-import inspect
 from collections import Counter
 from functools import reduce
 from operator import attrgetter, or_
 
-from django.core.exceptions import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db import models, transaction
 from django.db.models import signals, sql
 from django.db.models.deletion import Collector
-
-
-_COLLECTOR_ACCEPTS_ORIGIN = 'origin' in inspect.signature(Collector.__init__).parameters
 
 
 def get_logical_delete_field(model):
@@ -24,17 +20,17 @@ def get_logical_delete_field(model):
 
     try:
         return model._meta.get_field(field_name)
-    except FieldDoesNotExist:
-        return None
+    except FieldDoesNotExist as exc:
+        raise ImproperlyConfigured(
+            "%s uses logical deletion but its delete flag field '%s' does not "
+            "exist." % (model._meta.label, field_name)
+        ) from exc
 
 
 class LogicalDeletionCollector(Collector):
 
     def __init__(self, using, origin=None, deleted_at=None):
-        if _COLLECTOR_ACCEPTS_ORIGIN:
-            super().__init__(using=using, origin=origin)
-        else:
-            super().__init__(using=using)
+        super().__init__(using=using, origin=origin)
         self.origin = origin
         self.deleted_at = deleted_at
 
@@ -106,28 +102,13 @@ class LogicalDeletionCollector(Collector):
         return sum(deleted_counter.values()), dict(deleted_counter)
 
     def _send_delete_signal(self, signal, model, obj):
-        kwargs = {'sender': model, 'instance': obj, 'using': self.using}
-        if _COLLECTOR_ACCEPTS_ORIGIN:
-            kwargs['origin'] = self.origin
-        signal.send(**kwargs)
-
-    def _iter_field_updates(self):
-        for key, value in self.field_updates.items():
-            if isinstance(key, tuple):
-                field, field_value = key
-                if isinstance(value, (list, tuple)):
-                    instances_list = value
-                else:
-                    instances_list = [value]
-                yield field, field_value, instances_list
-                continue
-
-            field = key
-            for field_value, instances in value.items():
-                yield field, field_value, [instances]
+        signal.send(sender=model, instance=obj, using=self.using, origin=self.origin)
 
     def _apply_field_updates(self):
-        for field, value, instances_list in self._iter_field_updates():
+        # Mirror Django's Collector.delete() field-update block: field_updates is
+        # {(field, value): [objs, ...]}. The extra in-memory write-back below
+        # keeps already-loaded related instances consistent with the DB update.
+        for (field, value), instances_list in self.field_updates.items():
             updates = []
             objs = []
             for instances in instances_list:

--- a/django_boost/models/manager.py
+++ b/django_boost/models/manager.py
@@ -10,7 +10,7 @@ class LogicalDeletionManager(Manager):
         return self.delete_flag_field
 
     def get_queryset(self):
-        return LogicalDeletionQuerySet(self.model)
+        return LogicalDeletionQuerySet(self.model, using=self._db, hints=self._hints)
 
     def delete(self, hard=False, deleted_at=None):
         return self.get_queryset().delete(hard=hard, deleted_at=deleted_at)

--- a/django_boost/models/mixins.py
+++ b/django_boost/models/mixins.py
@@ -1,9 +1,11 @@
 import uuid
 
 from django.db import models
+from django.db import router
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 
+from django_boost.models.deletion import LogicalDeletionCollector
 from django_boost.models.manager import LogicalDeletionManager
 from django_boost.utils.functions import json_to_model, model_to_json
 
@@ -59,8 +61,15 @@ class LogicalDeletionMixin(models.Model):
     def delete(self, using=None, keep_parents=False, hard=False, deleted_at=None):
         if hard:
             return super().delete(using=using, keep_parents=keep_parents)
-        self.deleted_at = deleted_at if deleted_at is not None else self.get_deleted_value()
-        return self.save()
+        if self.pk is None:
+            raise ValueError(
+                "%s object can't be deleted because its %s attribute is set "
+                "to None." % (self._meta.object_name, self._meta.pk.attname)
+            )
+        using = using or router.db_for_write(self.__class__, instance=self)
+        collector = LogicalDeletionCollector(using=using, origin=self, deleted_at=deleted_at)
+        collector.collect([self], keep_parents=keep_parents)
+        return collector.delete()
 
     def revive(self, force_update=False, using=None):
         """Revive logical deleted item."""

--- a/django_boost/models/query.py
+++ b/django_boost/models/query.py
@@ -1,5 +1,7 @@
 from django.db.models.query import QuerySet
 
+from django_boost.models.deletion import LogicalDeletionCollector
+
 
 class LogicalDeletionQuerySet(QuerySet):
     delete_flag_field = "deleted_at"
@@ -10,9 +12,34 @@ class LogicalDeletionQuerySet(QuerySet):
     def delete(self, hard=False, deleted_at=None):
         if hard:
             return super().delete()
-        field_name = self.get_delete_flag_field_name()
-        deleted_value = deleted_at if deleted_at is not None else self.model.get_deleted_value()
-        return super().update(**{field_name: deleted_value})
+        if hasattr(self, '_not_support_combined_queries'):
+            self._not_support_combined_queries('delete')
+        if self.query.is_sliced:
+            raise TypeError("Cannot use 'limit' or 'offset' with delete().")
+        if self.query.distinct or getattr(self.query, 'distinct_fields', ()):
+            raise TypeError("Cannot call delete() after .distinct().")
+        if getattr(self, '_fields', None) is not None:
+            raise TypeError("Cannot call delete() after .values() or .values_list()")
+
+        del_query = self._chain()
+        del_query._for_write = True
+        del_query.query.select_for_update = False
+        del_query.query.select_related = False
+        try:
+            del_query.query.clear_ordering(force=True)
+        except TypeError:
+            del_query.query.clear_ordering(force_empty=True)
+
+        collector = LogicalDeletionCollector(
+            using=del_query.db, origin=self, deleted_at=deleted_at)
+        collector.collect(del_query)
+        deleted, rows_count = collector.delete()
+
+        self._result_cache = None
+        return deleted, rows_count
+
+    delete.alters_data = True
+    delete.queryset_only = True
 
     def alive(self):
         field_name = self.get_delete_flag_field_name()

--- a/django_boost/models/query.py
+++ b/django_boost/models/query.py
@@ -1,3 +1,4 @@
+import django
 from django.db.models.query import QuerySet
 
 from django_boost.models.deletion import LogicalDeletionCollector
@@ -16,7 +17,12 @@ class LogicalDeletionQuerySet(QuerySet):
             self._not_support_combined_queries('delete')
         if self.query.is_sliced:
             raise TypeError("Cannot use 'limit' or 'offset' with delete().")
-        if self.query.distinct or getattr(self.query, 'distinct_fields', ()):
+        # Match Django's per-version guard: <5.0 rejects any .distinct(); 5.0+
+        # rejects only .distinct(*fields).
+        if django.VERSION >= (5, 0):
+            if self.query.distinct_fields:
+                raise TypeError("Cannot call delete() after .distinct(*fields).")
+        elif self.query.distinct or self.query.distinct_fields:
             raise TypeError("Cannot call delete() after .distinct().")
         if getattr(self, '_fields', None) is not None:
             raise TypeError("Cannot call delete() after .values() or .values_list()")
@@ -25,10 +31,7 @@ class LogicalDeletionQuerySet(QuerySet):
         del_query._for_write = True
         del_query.query.select_for_update = False
         del_query.query.select_related = False
-        try:
-            del_query.query.clear_ordering(force=True)
-        except TypeError:
-            del_query.query.clear_ordering(force_empty=True)
+        del_query.query.clear_ordering(force=True)
 
         collector = LogicalDeletionCollector(
             using=del_query.db, origin=self, deleted_at=deleted_at)

--- a/docs/model_mixins.rst
+++ b/docs/model_mixins.rst
@@ -73,6 +73,12 @@ By default, the deletion process for models that inherit from this class is a lo
 
 If you want to do physical deletion, please pass ``hard=True`` as a ``delete`` method argument.
 
+Logical deletion follows Django's deletion collector for normal ``delete`` behavior:
+``CASCADE``, ``PROTECT``, ``SET_NULL``, delete signals, queryset restrictions, and
+the ``(count, details)`` return value are preserved. Related models that do not inherit
+``LogicalDeletionMixin`` are physically deleted when Django's cascade handling deletes them,
+because they have no ``deleted_at`` field to update.
+
 ::
 
   Store.objects.delete() # logical deletion.

--- a/tests/tests/logical_deletion/models.py
+++ b/tests/tests/logical_deletion/models.py
@@ -5,3 +5,35 @@ from django_boost.models.mixins import LogicalDeletionMixin
 
 class LogicalDeletionModel(LogicalDeletionMixin):
     name = models.CharField(max_length=8)
+
+
+class LogicalDeletionParent(LogicalDeletionMixin):
+    name = models.CharField(max_length=8)
+
+
+class LogicalDeletionChild(LogicalDeletionMixin):
+    parent = models.ForeignKey(
+        LogicalDeletionParent, related_name='children',
+        on_delete=models.CASCADE)
+    name = models.CharField(max_length=8)
+
+
+class LogicalDeletionProtectedChild(models.Model):
+    parent = models.ForeignKey(
+        LogicalDeletionParent, related_name='protected_children',
+        on_delete=models.PROTECT)
+    name = models.CharField(max_length=8)
+
+
+class LogicalDeletionNullableChild(LogicalDeletionMixin):
+    parent = models.ForeignKey(
+        LogicalDeletionParent, related_name='nullable_children',
+        null=True, on_delete=models.SET_NULL)
+    name = models.CharField(max_length=8)
+
+
+class PhysicalCascadeChild(models.Model):
+    parent = models.ForeignKey(
+        LogicalDeletionParent, related_name='physical_children',
+        on_delete=models.CASCADE)
+    name = models.CharField(max_length=8)

--- a/tests/tests/logical_deletion/models.py
+++ b/tests/tests/logical_deletion/models.py
@@ -32,8 +32,39 @@ class LogicalDeletionNullableChild(LogicalDeletionMixin):
     name = models.CharField(max_length=8)
 
 
+def _detach_parent():
+    return None
+
+
+class LogicalDeletionSetChild(LogicalDeletionMixin):
+    # on_delete=SET(callable) is non-lazy, so Django evaluates the related
+    # queryset during collect() and the FK update is applied to materialized
+    # instances (unlike the lazy SET_NULL handler).
+    parent = models.ForeignKey(
+        LogicalDeletionParent, related_name='set_children',
+        null=True, on_delete=models.SET(_detach_parent))
+    name = models.CharField(max_length=8)
+
+
 class PhysicalCascadeChild(models.Model):
     parent = models.ForeignKey(
         LogicalDeletionParent, related_name='physical_children',
+        on_delete=models.CASCADE)
+    name = models.CharField(max_length=8)
+
+
+class NonFastPhysicalChild(models.Model):
+    # A non-logical child that is NOT fast-deletable: it owns its own cascade
+    # grandchild, so Django routes it through Collector.data (not fast_deletes),
+    # exercising the physical-delete branch for non-logical models in data.
+    parent = models.ForeignKey(
+        LogicalDeletionParent, related_name='nonfast_children',
+        on_delete=models.CASCADE)
+    name = models.CharField(max_length=8)
+
+
+class NonFastPhysicalGrandChild(models.Model):
+    parent = models.ForeignKey(
+        NonFastPhysicalChild, related_name='grandchildren',
         on_delete=models.CASCADE)
     name = models.CharField(max_length=8)

--- a/tests/tests/logical_deletion/tests.py
+++ b/tests/tests/logical_deletion/tests.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+from django.db.models.deletion import ProtectedError
+from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
 from django.test import TestCase, override_settings
 from django.utils.timezone import now
 
@@ -24,8 +26,10 @@ class TestLogicalDeletionMixin(TestCase):
     def test_delete(self):
         self._register_items(*[str(i) for i in range(10)])
         item = self.model.objects.get(name="0")
-        item.delete()
+        deleted = item.delete()
         self.assertNotEqual(item.deleted_at, None)
+        self.assertEqual(deleted[0], 1)
+        self.assertEqual(deleted[1], {self.model._meta.label: 1})
 
     def test_delete_with_deleted_at(self):
         self._register_items(*[str(i) for i in range(10)])
@@ -34,6 +38,13 @@ class TestLogicalDeletionMixin(TestCase):
         item.delete(deleted_at=deleted_at)
         item.refresh_from_db()
         self.assertEqual(item.deleted_at, deleted_at)
+
+    def test_delete_unsaved_item_raises_value_error(self):
+        item = self.model(name="0")
+        with self.assertRaises(ValueError):
+            item.delete()
+        self.assertIsNone(item.pk)
+        self.assertEqual(self.model.objects.count(), 0)
 
     def test_hard_delete(self):
         self._register_items(*[str(i) for i in range(10)])
@@ -91,8 +102,10 @@ class TestLogicalDeletionManager(TestCase):
 
     def test_delete(self):
         self._register_items(*[str(i) for i in range(10)])
-        self.model.objects.delete()
+        deleted = self.model.objects.delete()
         self.assertEqual(len(self.model.objects.dead()), 10)
+        self.assertEqual(deleted[0], 10)
+        self.assertEqual(deleted[1], {self.model._meta.label: 10})
         self._hard_delete()
 
     def test_delete_with_deleted_at(self):
@@ -110,6 +123,20 @@ class TestLogicalDeletionManager(TestCase):
         self.assertEqual(len(self.model.objects.dead()), 2)
         for item in self.model.objects.dead():
             self.assertEqual(item.deleted_at, deleted_at)
+        self._hard_delete()
+
+    def test_distinct_queryset_delete_raises_type_error(self):
+        self._register_items(*[str(i) for i in range(10)])
+        with self.assertRaises(TypeError):
+            self.model.objects.distinct().delete()
+        self.assertEqual(len(self.model.objects.alive()), 10)
+        self._hard_delete()
+
+    def test_values_queryset_delete_raises_type_error(self):
+        self._register_items(*[str(i) for i in range(10)])
+        with self.assertRaises(TypeError):
+            self.model.objects.values("id").delete()
+        self.assertEqual(len(self.model.objects.alive()), 10)
         self._hard_delete()
 
     def test_hard_delete(self):
@@ -132,3 +159,124 @@ class TestLogicalDeletionManager(TestCase):
         self.assertEqual(len(self.model.objects.alive()), 10)
         self.assertEqual(len(self.model.objects.all()), 10)
         self._hard_delete()
+
+
+class TestLogicalDeletionDjangoDeleteCompatibility(TestCase):
+    from .models import (LogicalDeletionChild, LogicalDeletionNullableChild,
+                         LogicalDeletionParent, LogicalDeletionProtectedChild,
+                         PhysicalCascadeChild)
+
+    parent_model = LogicalDeletionParent
+    child_model = LogicalDeletionChild
+    nullable_child_model = LogicalDeletionNullableChild
+    protected_child_model = LogicalDeletionProtectedChild
+    physical_child_model = PhysicalCascadeChild
+
+    def test_instance_delete_sends_delete_signals_without_save_signals(self):
+        parent = self.parent_model.objects.create(name="parent")
+        events = []
+
+        def receiver(name):
+            def _receiver(sender, instance, **kwargs):
+                if sender is self.parent_model:
+                    events.append(name)
+            return _receiver
+
+        receivers = [
+            (pre_delete, receiver("pre_delete")),
+            (post_delete, receiver("post_delete")),
+            (pre_save, receiver("pre_save")),
+            (post_save, receiver("post_save")),
+        ]
+        for signal, handler in receivers:
+            signal.connect(handler, weak=False)
+        try:
+            parent.delete()
+        finally:
+            for signal, handler in receivers:
+                signal.disconnect(handler)
+
+        self.assertEqual(events, ["pre_delete", "post_delete"])
+
+    def test_instance_delete_cascades_to_logical_children(self):
+        deleted_at = now() - timedelta(days=1)
+        parent = self.parent_model.objects.create(name="parent")
+        child = self.child_model.objects.create(parent=parent, name="child")
+
+        deleted = parent.delete(deleted_at=deleted_at)
+
+        parent.refresh_from_db()
+        child.refresh_from_db()
+        self.assertEqual(parent.deleted_at, deleted_at)
+        self.assertEqual(child.deleted_at, deleted_at)
+        self.assertEqual(deleted[0], 2)
+        self.assertEqual(deleted[1], {
+            self.parent_model._meta.label: 1,
+            self.child_model._meta.label: 1,
+        })
+
+    def test_queryset_delete_cascades_to_logical_children(self):
+        deleted_at = now() - timedelta(days=1)
+        parent = self.parent_model.objects.create(name="parent")
+        child = self.child_model.objects.create(parent=parent, name="child")
+
+        deleted = self.parent_model.objects.filter(pk=parent.pk).delete(
+            deleted_at=deleted_at)
+
+        parent.refresh_from_db()
+        child.refresh_from_db()
+        self.assertEqual(parent.deleted_at, deleted_at)
+        self.assertEqual(child.deleted_at, deleted_at)
+        self.assertEqual(deleted[0], 2)
+        self.assertEqual(deleted[1], {
+            self.parent_model._meta.label: 1,
+            self.child_model._meta.label: 1,
+        })
+
+    def test_instance_delete_honors_protected_related_objects(self):
+        parent = self.parent_model.objects.create(name="parent")
+        self.protected_child_model.objects.create(parent=parent, name="child")
+
+        with self.assertRaises(ProtectedError):
+            parent.delete()
+
+        parent.refresh_from_db()
+        self.assertIsNone(parent.deleted_at)
+
+    def test_queryset_delete_honors_protected_related_objects(self):
+        parent = self.parent_model.objects.create(name="parent")
+        self.protected_child_model.objects.create(parent=parent, name="child")
+
+        with self.assertRaises(ProtectedError):
+            self.parent_model.objects.filter(pk=parent.pk).delete()
+
+        parent.refresh_from_db()
+        self.assertIsNone(parent.deleted_at)
+
+    def test_instance_delete_applies_set_null_related_updates(self):
+        parent = self.parent_model.objects.create(name="parent")
+        child = self.nullable_child_model.objects.create(
+            parent=parent, name="child")
+
+        parent.delete()
+
+        child.refresh_from_db()
+        self.assertIsNone(child.parent_id)
+        self.assertIsNone(child.deleted_at)
+
+    def test_instance_delete_physically_cascades_non_logical_children(self):
+        parent = self.parent_model.objects.create(name="parent")
+        child = self.physical_child_model.objects.create(
+            parent=parent, name="child")
+
+        deleted = parent.delete()
+
+        parent.refresh_from_db()
+        self.assertTrue(parent.is_dead())
+        self.assertFalse(self.physical_child_model.objects.filter(
+            pk=child.pk).exists())
+        self.assertEqual(deleted[0], 2)
+        self.assertEqual(deleted[1], {
+            self.parent_model._meta.label: 1,
+            self.physical_child_model._meta.label: 1,
+        })

--- a/tests/tests/logical_deletion/tests.py
+++ b/tests/tests/logical_deletion/tests.py
@@ -1,9 +1,16 @@
 from datetime import timedelta
 
+import django
+from django.core.exceptions import ImproperlyConfigured
+from django.db import models
 from django.db.models.deletion import ProtectedError
 from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
 from django.test import TestCase, override_settings
+from django.test.utils import isolate_apps
 from django.utils.timezone import now
+
+from django_boost.models.deletion import get_logical_delete_field
+from django_boost.models.mixins import LogicalDeletionMixin
 
 
 @override_settings(
@@ -125,17 +132,38 @@ class TestLogicalDeletionManager(TestCase):
             self.assertEqual(item.deleted_at, deleted_at)
         self._hard_delete()
 
-    def test_distinct_queryset_delete_raises_type_error(self):
+    def test_distinct_fields_queryset_delete_raises_type_error(self):
+        # .distinct(*fields) is rejected on every supported Django version.
         self._register_items(*[str(i) for i in range(10)])
         with self.assertRaises(TypeError):
-            self.model.objects.distinct().delete()
+            self.model.objects.distinct("name").delete()
         self.assertEqual(len(self.model.objects.alive()), 10)
+        self._hard_delete()
+
+    def test_plain_distinct_queryset_delete_matches_django_version(self):
+        # Django <5.0 rejects a plain .distinct().delete(); 5.0+ allows it.
+        self._register_items(*[str(i) for i in range(10)])
+        if django.VERSION >= (5, 0):
+            self.model.objects.distinct().delete()
+            self.assertEqual(len(self.model.objects.dead()), 10)
+        else:
+            with self.assertRaises(TypeError):
+                self.model.objects.distinct().delete()
+            self.assertEqual(len(self.model.objects.alive()), 10)
         self._hard_delete()
 
     def test_values_queryset_delete_raises_type_error(self):
         self._register_items(*[str(i) for i in range(10)])
         with self.assertRaises(TypeError):
             self.model.objects.values("id").delete()
+        self.assertEqual(len(self.model.objects.alive()), 10)
+        self._hard_delete()
+
+    def test_sliced_queryset_delete_raises_type_error(self):
+        # Django rejects delete() on a sliced queryset; logical delete matches.
+        self._register_items(*[str(i) for i in range(10)])
+        with self.assertRaises(TypeError):
+            self.model.objects.all()[:2].delete()
         self.assertEqual(len(self.model.objects.alive()), 10)
         self._hard_delete()
 
@@ -164,13 +192,17 @@ class TestLogicalDeletionManager(TestCase):
 class TestLogicalDeletionDjangoDeleteCompatibility(TestCase):
     from .models import (LogicalDeletionChild, LogicalDeletionNullableChild,
                          LogicalDeletionParent, LogicalDeletionProtectedChild,
-                         PhysicalCascadeChild)
+                         LogicalDeletionSetChild, NonFastPhysicalChild,
+                         NonFastPhysicalGrandChild, PhysicalCascadeChild)
 
     parent_model = LogicalDeletionParent
     child_model = LogicalDeletionChild
     nullable_child_model = LogicalDeletionNullableChild
+    set_child_model = LogicalDeletionSetChild
     protected_child_model = LogicalDeletionProtectedChild
     physical_child_model = PhysicalCascadeChild
+    nonfast_child_model = NonFastPhysicalChild
+    nonfast_grandchild_model = NonFastPhysicalGrandChild
 
     def test_instance_delete_sends_delete_signals_without_save_signals(self):
         parent = self.parent_model.objects.create(name="parent")
@@ -280,3 +312,78 @@ class TestLogicalDeletionDjangoDeleteCompatibility(TestCase):
             self.parent_model._meta.label: 1,
             self.physical_child_model._meta.label: 1,
         })
+
+    def test_instance_delete_physically_cascades_non_fast_deletable_child(self):
+        # The grandchild makes the non-logical child non-fast-deletable, so it is
+        # physically deleted through Collector.data rather than fast_deletes,
+        # while the logical parent is soft-deleted. Matches Django physical delete.
+        parent = self.parent_model.objects.create(name="parent")
+        child = self.nonfast_child_model.objects.create(parent=parent, name="c")
+        grandchild = self.nonfast_grandchild_model.objects.create(
+            parent=child, name="gc")
+
+        deleted = parent.delete()
+
+        parent.refresh_from_db()
+        self.assertTrue(parent.is_dead())
+        self.assertFalse(
+            self.nonfast_child_model.objects.filter(pk=child.pk).exists())
+        self.assertFalse(
+            self.nonfast_grandchild_model.objects.filter(pk=grandchild.pk).exists())
+        self.assertEqual(deleted[0], 3)
+        self.assertEqual(deleted[1], {
+            self.parent_model._meta.label: 1,
+            self.nonfast_child_model._meta.label: 1,
+            self.nonfast_grandchild_model._meta.label: 1,
+        })
+
+    def test_instance_delete_applies_set_callable_related_updates(self):
+        # on_delete=SET(callable) is non-lazy: Django evaluates the related
+        # queryset during collect() and applies the value to the materialized
+        # instances. The child's FK is set, and the child itself is not deleted.
+        parent = self.parent_model.objects.create(name="parent")
+        child = self.set_child_model.objects.create(parent=parent, name="child")
+
+        parent.delete()
+
+        child.refresh_from_db()
+        self.assertIsNone(child.parent_id)
+        self.assertIsNone(child.deleted_at)
+
+
+class GetLogicalDeleteFieldTests(TestCase):
+
+    def test_resolves_field_via_manager_attribute_fallback(self):
+        # A logical model whose default manager exposes only the delete_flag_field
+        # attribute (no get_deleted_flag_field_name method) still resolves its
+        # delete-flag field, so the collector soft-deletes instead of hard-deleting.
+        with isolate_apps("tests"):
+            class AttrManager(models.Manager):
+                delete_flag_field = "deleted_at"
+
+            class PlainManagerModel(LogicalDeletionMixin):
+                objects = AttrManager()
+
+                class Meta:
+                    app_label = "tests"
+
+            field = get_logical_delete_field(PlainManagerModel)
+
+        self.assertIsNotNone(field)
+        self.assertEqual(field.name, "deleted_at")
+
+    def test_raises_when_delete_flag_field_does_not_exist(self):
+        # A misconfigured delete flag field fails loud instead of silently
+        # degrading to a physical delete.
+        with isolate_apps("tests"):
+            class MissingFieldManager(models.Manager):
+                delete_flag_field = "missing_field"
+
+            class MisconfiguredModel(LogicalDeletionMixin):
+                objects = MissingFieldManager()
+
+                class Meta:
+                    app_label = "tests"
+
+            with self.assertRaises(ImproperlyConfigured):
+                get_logical_delete_field(MisconfiguredModel)


### PR DESCRIPTION
Route LogicalDeletionMixin and LogicalDeletionQuerySet through a custom collector so logical deletes preserve Django deletion behavior for cascades, protected relations, SET_NULL updates, delete signals, queryset restrictions, and delete return values.

Document the collector-backed behavior in README, docs, and CHANGELOG, and cover the compatibility cases with focused logical deletion tests.

Verification:
- devcontainer exec --workspace-folder . -- python manage.py test
- devcontainer exec --workspace-folder . -- flake8 .
- devcontainer exec --workspace-folder . -- sphinx-build -M html docs docs/_build
- git diff --check

- [x] Does this have tests?  
- [x] Does this have documentation?  
- [x] Does this break the public API (Requires major version bump)?  
- [x] Is this a new feature (Requires minor version bump)?  
