### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-06-22
+
 ### Added
 
 - Support passing `deleted_at` to logical deletion APIs so callers can set a
@@ -278,7 +280,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - First release.
 
-[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v2.1.2...HEAD
+[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/ChanTsune/django-boost/compare/v2.1.2...v2.2.0
 [2.1.2]: https://github.com/ChanTsune/django-boost/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/ChanTsune/django-boost/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/ChanTsune/django-boost/compare/v2.0.0...v2.1.0

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -1,6 +1,6 @@
 from django_boost.utils.version import get_version
 
-VERSION = (2, 1, 2, 'final', 0)
+VERSION = (2, 2, 0, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
- Added
  - Support passing deleted_at to logical deletion APIs
- Changed
  - Document the planned django-boost 3.0 baseline and useragent extra
- Deprecated
  - zip template filter
  - django_boost.models.fields.JsonField
  - `support_heroku` management command.
