### PR TITLE
:boom: Start the v3 support baseline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,19 +11,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-        - '3.8.x'
-        - '3.9.x'
-        - '3.10.x'
-        - '3.11.x'
-        - '3.12.0-alpha - 3.12.x'
-        django-version:
-        - '3.0.*'
-        - '3.1.*'
-        - '3.2.*'
-        - '4.0.*'
-        - '4.1.*'
-        - '4.2.*'
+        include:
+        - python-version: '3.10.x'
+          django-version: '4.2.*'
+        - python-version: '3.11.x'
+          django-version: '4.2.*'
+        - python-version: '3.12.x'
+          django-version: '4.2.*'
+        - python-version: '3.10.x'
+          django-version: '5.0.*'
+        - python-version: '3.11.x'
+          django-version: '5.0.*'
+        - python-version: '3.12.x'
+          django-version: '5.0.*'
+        - python-version: '3.10.x'
+          django-version: '5.1.*'
+        - python-version: '3.11.x'
+          django-version: '5.1.*'
+        - python-version: '3.12.x'
+          django-version: '5.1.*'
+        - python-version: '3.13.x'
+          django-version: '5.1.*'
+        - python-version: '3.10.x'
+          django-version: '5.2.*'
+        - python-version: '3.11.x'
+          django-version: '5.2.*'
+        - python-version: '3.12.x'
+          django-version: '5.2.*'
+        - python-version: '3.13.x'
+          django-version: '5.2.*'
     runs-on: ubuntu-latest
     env:
       DJANGO_VERSION: ${{ matrix.django-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Changed
 
 - Start the django-boost 3.0 development line by requiring Python 3.10+,
-  dropping Django 3.x, and declaring support for Django 4.2 and 5.x on
+  dropping Django 3.x, and declaring support for Django 4.2-5.2 on
   officially supported Django/Python combinations.
 
 ## [2.2.0] - 2026-06-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Changed
+
+- Start the django-boost 3.0 development line by requiring Python 3.10+,
+  dropping Django 3.x, and declaring support for Django 4.2 and 5.x on
+  officially supported Django/Python combinations.
+
 ## [2.2.0] - 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - Start the django-boost 3.0 development line by requiring Python 3.10+,
   dropping Django 3.x, and declaring support for Django 4.2-5.2 on
   officially supported Django/Python combinations.
+- Use Django's native view setup and redirect mixin implementations now that
+  django-boost requires Django 4.2+.
+
+### Removed
+
+- Remove Django < 3.2 `default_app_config` shims and obsolete localization
+  settings that are unnecessary for the Django 4.2+ baseline.
 
 ## [2.2.0] - 2026-06-22
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ python setup.py install
 
 ## Compatibility
 
-The 2.x line is tested on Python 3.8-3.12 and Django 3.0-4.2. The next major
-release, django-boost 3.0, is planned to require Python 3.11+ and Django 5.2+.
-User-agent detection is also planned to move behind an optional extra:
+The 3.x line supports Python 3.10-3.13 and Django 4.2-5.2 where the
+Django/Python combination is supported by Django. User-agent detection is
+planned to move behind an optional extra:
 `pip install django-boost[useragent]`.
 
 ## Installing It

--- a/config/settings.py
+++ b/config/settings.py
@@ -122,8 +122,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 LOCALE_PATHS = (

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -1,6 +1,6 @@
 from django_boost.utils.version import get_version
 
-VERSION = (2, 2, 0, 'final', 0)
+VERSION = (3, 0, 0, 'alpha', 0)
 
 
 __version__ = get_version()

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -4,10 +4,3 @@ VERSION = (3, 0, 0, 'alpha', 0)
 
 
 __version__ = get_version()
-
-try:
-    import django
-    if django.VERSION < (3, 2):
-        default_app_config = 'django_boost.apps.DjangoBoostConfig'
-except ImportError: # noqa
-    pass  # noqa

--- a/django_boost/admin_tools/__init__.py
+++ b/django_boost/admin_tools/__init__.py
@@ -1,4 +1,0 @@
-import django
-
-if django.VERSION < (3, 2):
-    default_app_config = "django_boost.admin_tools.apps.AdminToolsConfig"

--- a/django_boost/conf/app_template/__init__.py-tpl
+++ b/django_boost/conf/app_template/__init__.py-tpl
@@ -1,4 +1,0 @@
-import django
-
-if django.VERSION < (3, 2):
-    default_app_config = "{{ app_name }}.apps.{{ camel_case_app_name }}Config"

--- a/django_boost/views/base.py
+++ b/django_boost/views/base.py
@@ -21,26 +21,23 @@ __all__ = ["View", "TemplateView", "FormView", "CreateView",
 
 
 class View(_View):
-    """extends View of Django 2.2."""
+    """View that runs ``after_view_process`` on every dispatched response.
+
+    The hook wraps the result of ``as_view``'s dispatch call rather than
+    ``dispatch`` itself, so it still fires when a mixin earlier in the MRO
+    short-circuits ``dispatch`` (e.g. a permission check that returns a 403
+    without calling ``super().dispatch()``).
+    """
 
     @classonlymethod
     def as_view(cls, **initkwargs):
-        """Main entry point for a request-response process."""
-        for key in initkwargs:
-            if key in cls.http_method_names:
-                raise TypeError("You tried to pass in the %s method name as a "
-                                "keyword argument to %s(). Don't do that."
-                                % (key, cls.__name__))
-            if not hasattr(cls, key):
-                raise TypeError("%s() received an invalid keyword %r. as_view "
-                                "only accepts arguments that are already "
-                                "attributes of the class."
-                                % (cls.__name__, key))
+        # Reuse Django's as_view for initkwargs validation and to capture the
+        # attributes it sets on the view callable (view_class, decorator
+        # markers such as csrf_exempt, ...); only the dispatch call is wrapped.
+        native = super().as_view(**initkwargs)
 
         def view(request, *args, **kwargs):
             self = cls(**initkwargs)
-            if hasattr(self, 'get') and not hasattr(self, 'head'):
-                self.head = self.get
             self.setup(request, *args, **kwargs)
             if not hasattr(self, 'request'):
                 raise AttributeError(
@@ -49,22 +46,9 @@ class View(_View):
                 )
             response = self.dispatch(request, *args, **kwargs)
             return self.after_view_process(request, response, *args, **kwargs)
-        view.view_class = cls
-        view.view_initkwargs = initkwargs
 
-        # take name and docstring from class
-        update_wrapper(view, cls, updated=())
-
-        # and possible attributes set by decorators
-        # like csrf_exempt from dispatch
-        update_wrapper(view, cls.dispatch, assigned=())
+        update_wrapper(view, native)
         return view
-
-    def setup(self, request, *args, **kwargs):
-        """Initialize attributes shared by all view methods."""
-        self.request = request
-        self.args = args
-        self.kwargs = kwargs
 
     def after_view_process(self, request, response, *args, **kwargs):
         return response

--- a/django_boost/views/base.py
+++ b/django_boost/views/base.py
@@ -94,7 +94,8 @@ class StaticResponseMixin:
         return [self.static_name]
 
     def create_response(self):
-        for path in self.get_static_names():
+        names = self.get_static_names()
+        for path in names:
             if os.path.exists(path):
                 if self.content_type is None:
                     content_type, encoding = mimetypes.guess_type(path)
@@ -106,7 +107,7 @@ class StaticResponseMixin:
                 if encoding:
                     response["Content-Encoding"] = encoding
                 return response
-        raise FileNotFoundError('%s Dose not exist.')
+        raise FileNotFoundError('%s does not exist.' % ', '.join(names))
 
 
 class StaticView(StaticResponseMixin, View):

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -1,14 +1,13 @@
 import json
 from datetime import timedelta
 
-import django
 from django.contrib.auth.mixins import AccessMixin
-from django.contrib.auth.views import (logout_then_login, redirect_to_login)
+from django.contrib.auth.views import (RedirectURLMixin, logout_then_login,
+                                       redirect_to_login)
 from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404, JsonResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.timezone import now
 from django.views.decorators.csrf import csrf_exempt
 
@@ -31,40 +30,12 @@ class CSRFExemptMixin:
         return super().dispatch(request, *args, **kwargs)
 
 
-if django.VERSION >= (4, 1):
-    from django.contrib.auth.views import RedirectURLMixin
+class DynamicRedirectMixin(RedirectURLMixin):
+    success_url = None
 
-    class DynamicRedirectMixin(RedirectURLMixin):
-        success_url = None
-
-        def get_success_url(self):
-            url = self.get_redirect_url()
-            return url or self.success_url or super().get_success_url()
-
-
-else:
-    from django.contrib.auth.views import SuccessURLAllowedHostsMixin
-
-    class DynamicRedirectMixin(SuccessURLAllowedHostsMixin):
-
-        redirect_field_name = 'next'
-
-        def get_success_url(self):
-            url = self.get_redirect_url()
-            return url or super().get_success_url()
-
-        def get_redirect_url(self):
-            """Return the user-originating redirect URL if it's safe."""
-            redirect_to = self.request.POST.get(
-                self.redirect_field_name,
-                self.request.GET.get(self.redirect_field_name, '')
-            )
-            url_is_safe = url_has_allowed_host_and_scheme(
-                url=redirect_to,
-                allowed_hosts=self.get_success_url_allowed_hosts(),
-                require_https=self.request.is_secure(),
-            )
-            return redirect_to if url_is_safe else ''
+    def get_success_url(self):
+        url = self.get_redirect_url()
+        return url or self.success_url or super().get_success_url()
 
 
 class RedirectToDetailMixin:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,11 +39,11 @@ See more at `Django Supported Versions <https://docs.djangoproject.com/en/dev/in
 
 This might mean the django-boost may work with older or unsupported versions but we do not guarantee it and most likely will not fix bugs related to incompatibilities with older versions.
 
-The django-boost 2.x line is tested on Python 3.8-3.12 and Django 3.0-4.2.
+The django-boost 3.x line supports Python 3.10-3.13 and Django 4.2-5.2 where
+the Django/Python combination is supported by Django.
 
-The next major release, django-boost 3.0, is planned to require Python 3.11+
-and Django 5.2+. User-agent detection is also planned to move behind an
-optional extra: ``pip install django-boost[useragent]``.
+User-agent detection is planned to move behind an optional extra:
+``pip install django-boost[useragent]``.
 
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
-Django>=3.0,<5
+Django>=4.2,<6; python_version < "3.13"
+Django>=5.1,<6; python_version >= "3.13"
 user-agents>=2.0
-ua-parser<1.0; python_version < "3.10"

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,9 @@ for dirpath, dirnames, filenames in os.walk(extensions_dir):
 
 
 requires = [
-    "Django>=3.0",
+    'Django>=4.2,<6; python_version < "3.13"',
+    'Django>=5.1,<6; python_version >= "3.13"',
     "user-agents>=2.0",
-    # ua-parser 1.0 (a user-agents dependency) requires Python 3.10+
-    # (it uses dataclass(slots=...)); keep older Pythons on the 0.x line.
-    'ua-parser<1.0; python_version < "3.10"',
 ]
 
 
@@ -77,21 +75,19 @@ setup(
     package_data=package_data,
     platforms=['any'],
     install_requires=requires,
+    python_requires='>=3.10',
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Framework :: Django',
-        'Framework :: Django :: 3.0',
-        'Framework :: Django :: 3.1',
-        'Framework :: Django :: 3.2',
-        'Framework :: Django :: 4.0',
-        'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
+        'Framework :: Django :: 5.2',
         'License :: OSI Approved :: MIT License',
     ],
 )

--- a/tests/tests/views/tests.py
+++ b/tests/tests/views/tests.py
@@ -1,10 +1,19 @@
+import os
+
 from django.test import override_settings
 from django.urls import reverse
 from django_boost.test import TestCase
 
+ROOT_PATH = os.path.dirname(__file__)
+
 
 @override_settings(
     ROOT_URLCONF='tests.tests.views.urls',
+    TEMPLATES=[{
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(ROOT_PATH, 'templates')],
+        'APP_DIRS': True,
+    }],
 )
 class TestStringView(TestCase):
 
@@ -23,3 +32,26 @@ class TestStringView(TestCase):
         for e in cases:
             response = self.client.get(reverse('dynamic', kwargs=e))
             self.assertEqual(response.content, str(e).encode('utf-8'))
+
+    def test_after_view_process(self):
+        response = self.client.get(reverse('after'))
+        self.assertEqual(response.content, b'processed')
+        self.assertEqual(response["X-After-View-Process"], "yes")
+
+    def test_after_view_process_on_short_circuit(self):
+        # A mixin ahead of View in the MRO returns a 415 without calling
+        # super().dispatch(); after_view_process must still run on it.
+        response = self.client.get(reverse('after_short_circuit'))
+        self.assertEqual(response.status_code, 415)
+        self.assertEqual(response.get("X-After-View-Process"), "yes")
+
+    def test_after_view_process_on_generic_view(self):
+        # The hook fires through a generic view's full dispatch/render path.
+        response = self.client.get(reverse('after_generic'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get("X-After-View-Process"), "yes")
+
+    def test_after_view_process_on_head(self):
+        response = self.client.head(reverse('after'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get("X-After-View-Process"), "yes")

--- a/tests/tests/views/urls.py
+++ b/tests/tests/views/urls.py
@@ -6,4 +6,7 @@ urlpatterns = [
     path('', views.StringView.as_view(), name='empty'),
     path('simple/', views.SimpleStringView.as_view(), name='simple'),
     path('dynamic/<int:key1>/<str:key2>/', views.DynamicStringView.as_view(), name='dynamic'),
+    path('after/', views.AfterViewProcessView.as_view(), name='after'),
+    path('after/short-circuit/', views.ShortCircuitAfterViewProcessView.as_view(), name='after_short_circuit'),
+    path('after/generic/', views.GenericAfterViewProcessView.as_view(), name='after_generic'),
 ]

--- a/tests/tests/views/views.py
+++ b/tests/tests/views/views.py
@@ -1,3 +1,7 @@
+from django.http import HttpResponse
+
+from django_boost.views.base import TemplateView, View
+from django_boost.views.mixins import AllowContentTypeMixin
 from django_boost.views.simple import StringView
 
 
@@ -9,3 +13,34 @@ class DynamicStringView(StringView):
 
     def get_content(self, **kwargs):
         return str(kwargs)
+
+
+class AfterViewProcessView(View):
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponse("processed")
+
+    def after_view_process(self, request, response, *args, **kwargs):
+        response["X-After-View-Process"] = "yes"
+        return response
+
+
+class ShortCircuitAfterViewProcessView(AllowContentTypeMixin, View):
+    """A short-circuiting mixin precedes View, so dispatch never reaches it."""
+
+    allowed_content_types = ["application/json"]
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponse("processed")
+
+    def after_view_process(self, request, response, *args, **kwargs):
+        response["X-After-View-Process"] = "yes"
+        return response
+
+
+class GenericAfterViewProcessView(TemplateView):
+    template_name = "boost/test/index.html"
+
+    def after_view_process(self, request, response, *args, **kwargs):
+        response["X-After-View-Process"] = "yes"
+        return response


### PR DESCRIPTION
Require Python 3.10+, drop Django 3.x, and declare the Django 4.2/5.x bridge range for supported Django/Python combinations.

Set the package version to 3.0a0 so the v3 branch is clearly a prerelease line instead of a final release.
