### PR TITLE
:sparkles: Add strict invalid template variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Added
+
+- Add `django_boost.template.StrictInvalidTemplateVariable` for raising an
+  exception when Django renders invalid or missing template variables.
+
 ### Changed
 
 - Start the django-boost 3.0 development line by requiring Python 3.10+,

--- a/README.md
+++ b/README.md
@@ -291,6 +291,30 @@ These information is obtained using [user-agents](https://github.com/selwin/pyth
 In django-boost 3.0, user-agent detection is planned to move behind the
 optional `useragent` extra: `pip install django-boost[useragent]`.
 
+### Strict invalid template variables
+
+`StrictInvalidTemplateVariable` provides Jinja2 `StrictUndefined`-like behavior
+for Django templates. Use it when you want missing template variables to raise
+an exception instead of rendering as empty strings.
+
+```py
+from django_boost.template import StrictInvalidTemplateVariable
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "string_if_invalid": StrictInvalidTemplateVariable(),
+        },
+    },
+]
+```
+
+It only raises on Django's `string_if_invalid` resolution path, so it is not
+strict everywhere -- `{% if %}` / `{% for %}` and `alters_data` methods are not
+covered. See the docs for details.
+
 ### AllowContentTypeMixin
 
 Restrict the content type of http request.

--- a/django_boost/template/__init__.py
+++ b/django_boost/template/__init__.py
@@ -1,0 +1,3 @@
+from django_boost.template.base import StrictInvalidTemplateVariable
+
+__all__ = ("StrictInvalidTemplateVariable",)

--- a/django_boost/template/base.py
+++ b/django_boost/template/base.py
@@ -1,0 +1,35 @@
+class StrictInvalidTemplateVariable(str):
+    """
+    Raise an exception when Django renders an invalid template variable.
+
+    Intended for Django's ``string_if_invalid`` template engine option.
+
+    The instance value is ``'%s'`` on purpose. Django renders an invalid
+    variable as ``string_if_invalid % var`` only when ``'%s' in
+    string_if_invalid``; carrying exactly that value routes resolution through
+    ``__mod__``, where this class raises instead of substituting. An empty or
+    ``%s``-free value would silently disable the hook.
+    """
+
+    default_message = "Template variable or property '{name}' is invalid or missing."
+
+    def __new__(cls, message=None, exception_class=ValueError):
+        if not (isinstance(exception_class, type) and issubclass(exception_class, Exception)):
+            raise TypeError("exception_class must be an Exception subclass, "
+                            "got %r." % (exception_class,))
+        message = cls.default_message if message is None else message
+        # Validate the template at construction time so an unknown or stray
+        # placeholder fails where the option is configured, rather than masking
+        # the invalid-variable error with a KeyError/IndexError during render.
+        try:
+            message.format(name="")
+        except (KeyError, IndexError, ValueError) as exc:
+            raise ValueError("message may only reference the {name} "
+                             "placeholder: %s" % exc)
+        obj = super().__new__(cls, '%s')
+        obj.message = message
+        obj.exception_class = exception_class
+        return obj
+
+    def __mod__(self, missing):
+        raise self.exception_class(self.message.format(name=missing))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,7 @@ User-agent detection is planned to move behind an optional extra:
    routing_utilitys
    admin_site_utilitys
    utility_functions
+   template
    template_context
    template_tags
    commands

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -1,0 +1,65 @@
+Template
+========
+
+:synopsis: template utilities in django-boost
+
+Strict invalid template variables
+---------------------------------
+
+``StrictInvalidTemplateVariable`` raises an exception when a Django template
+tries to render an invalid or missing variable.
+
+It provides Jinja2 ``StrictUndefined``-like behavior for Django templates,
+which is useful when you want missing template variables to fail fast instead
+of rendering as empty strings.
+
+Use it as Django's ``string_if_invalid`` template option::
+
+  from django_boost.template import StrictInvalidTemplateVariable
+
+  TEMPLATES = [
+      {
+          "BACKEND": "django.template.backends.django.DjangoTemplates",
+          "DIRS": [],
+          "APP_DIRS": True,
+          "OPTIONS": {
+              "string_if_invalid": StrictInvalidTemplateVariable(),
+          },
+      },
+  ]
+
+By default, missing variables raise ``ValueError`` with the missing template
+variable name in the message.
+
+You can customize the message or exception class::
+
+  class TemplateVariableError(Exception):
+      pass
+
+
+  TEMPLATES = [
+      {
+          "BACKEND": "django.template.backends.django.DjangoTemplates",
+          "APP_DIRS": True,
+          "OPTIONS": {
+              "string_if_invalid": StrictInvalidTemplateVariable(
+                  message="Missing template variable: {name}",
+                  exception_class=TemplateVariableError,
+              ),
+          },
+      },
+  ]
+
+Limitations
+-----------
+
+``StrictInvalidTemplateVariable`` only raises on the resolution path Django
+routes through ``string_if_invalid % var``. It does not cover every invalid
+lookup, so unlike Jinja2 ``StrictUndefined`` it is not strict everywhere:
+
+- Tags that resolve variables while ignoring failures -- ``{% if %}``,
+  ``{% for %}``, ``{% firstof %}`` and the like -- never reach it, so a missing
+  variable there is still treated as falsy/empty instead of raising.
+- A method marked ``alters_data`` or one that requires arguments yields
+  Django's invalid marker without the ``%`` step, so it renders the literal
+  ``%s`` rather than raising.

--- a/tests/tests/test_template.py
+++ b/tests/tests/test_template.py
@@ -1,0 +1,116 @@
+from django.template import Context, Engine, engines
+from django.test import override_settings
+
+from django_boost.template import StrictInvalidTemplateVariable
+from django_boost.test import TestCase
+
+
+class TemplateError(Exception):
+    pass
+
+
+class TestStrictInvalidTemplateVariable(TestCase):
+
+    def test_render_existing_variable(self):
+        engine = Engine(string_if_invalid=StrictInvalidTemplateVariable())
+        template = engine.from_string("{{ name }}")
+
+        self.assertEqual(template.render(Context({"name": "django-boost"})), "django-boost")
+
+    def test_raise_value_error_for_missing_variable(self):
+        engine = Engine(string_if_invalid=StrictInvalidTemplateVariable())
+        template = engine.from_string("{{ missing }}")
+
+        with self.assertRaisesMessage(
+                ValueError,
+                "Template variable or property 'missing' is invalid or missing."):
+            template.render(Context({}))
+
+    def test_custom_message(self):
+        engine = Engine(string_if_invalid=StrictInvalidTemplateVariable(
+            message="Missing template variable: {name}"
+        ))
+        template = engine.from_string("{{ user.name }}")
+
+        with self.assertRaisesMessage(ValueError, "Missing template variable: user.name"):
+            template.render(Context({}))
+
+    def test_custom_exception_class(self):
+        engine = Engine(string_if_invalid=StrictInvalidTemplateVariable(
+            exception_class=TemplateError
+        ))
+        template = engine.from_string("{{ missing }}")
+
+        with self.assertRaises(TemplateError):
+            template.render(Context({}))
+
+    def test_non_exception_class_raises_at_construction(self):
+        with self.assertRaises(TypeError):
+            StrictInvalidTemplateVariable(exception_class=str)
+
+    def test_message_with_unknown_placeholder_raises_at_construction(self):
+        with self.assertRaises(ValueError):
+            StrictInvalidTemplateVariable(message="Missing {unknown}")
+
+    def test_message_with_stray_brace_raises_at_construction(self):
+        with self.assertRaises(ValueError):
+            StrictInvalidTemplateVariable(message="json {} here")
+
+    def test_variable_placeholder_is_not_supported(self):
+        with self.assertRaises(ValueError):
+            StrictInvalidTemplateVariable(message="Missing {variable}")
+
+    def test_dotted_lookup_reported_with_full_path(self):
+        engine = Engine(string_if_invalid=StrictInvalidTemplateVariable())
+        template = engine.from_string("{{ user.name }}")
+
+        with self.assertRaisesMessage(
+                ValueError,
+                "Template variable or property 'user.name' is invalid or missing."):
+            template.render(Context({}))
+
+    def test_filter_on_missing_variable_raises(self):
+        engine = Engine(string_if_invalid=StrictInvalidTemplateVariable())
+        template = engine.from_string("{{ missing|upper }}")
+
+        with self.assertRaises(ValueError):
+            template.render(Context({}))
+
+    def test_default_filter_does_not_suppress_missing_variable(self):
+        # The variable resolves through ``string_if_invalid`` before the
+        # ``default`` filter runs, so a missing value still raises.
+        engine = Engine(string_if_invalid=StrictInvalidTemplateVariable())
+        template = engine.from_string('{{ missing|default:"fallback" }}')
+
+        with self.assertRaises(ValueError):
+            template.render(Context({}))
+
+    def test_existing_falsy_values_render_without_raising(self):
+        # "Invalid" means unresolvable, not falsy: empty string and 0 render.
+        engine = Engine(string_if_invalid=StrictInvalidTemplateVariable())
+        template = engine.from_string("[{{ empty }}][{{ zero }}]")
+
+        self.assertEqual(template.render(Context({"empty": "", "zero": 0})), "[][0]")
+
+    def test_if_tag_with_missing_variable_does_not_raise(self):
+        # Tags that resolve with ignore_failures bypass string_if_invalid.
+        engine = Engine(string_if_invalid=StrictInvalidTemplateVariable())
+        template = engine.from_string("{% if missing %}yes{% else %}no{% endif %}")
+
+        self.assertEqual(template.render(Context({})), "no")
+
+    def test_for_tag_with_missing_iterable_does_not_raise(self):
+        engine = Engine(string_if_invalid=StrictInvalidTemplateVariable())
+        template = engine.from_string("{% for x in missing %}{{ x }}{% endfor %}")
+
+        self.assertEqual(template.render(Context({})), "")
+
+    @override_settings(TEMPLATES=[{
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "OPTIONS": {"string_if_invalid": StrictInvalidTemplateVariable()},
+    }])
+    def test_raises_through_templates_setting(self):
+        template = engines["django"].from_string("{{ missing }}")
+
+        with self.assertRaises(ValueError):
+            template.render({})


### PR DESCRIPTION
Add django_boost.template.StrictInvalidTemplateVariable for Django's string_if_invalid option so projects can fail fast on missing template variables without exposing Django's internal '%s' sentinel.

Document the settings and README usage, including the Jinja2 StrictUndefined-like behavior, and cover default message, custom message, and custom exception behavior with template rendering tests.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [x] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [x] Is this a new feature (Requires minor version bump)?  
