### PR TITLE
♻️ Keep zip template filter supported 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
   officially supported Django/Python combinations.
 - Use Django's native view setup and redirect mixin implementations now that
   django-boost requires Django 4.2+.
+- Keep the `zip` template filter supported for backward compatibility and
+  remove its v3 deprecation warning.
 - Move user-agent detection behind the optional `useragent` extra. Core
   installs no longer include `user-agents`; install `django-boost[useragent]`
   before using `django_boost.context_processors.user_agent` or

--- a/django_boost/templatetags/boost.py
+++ b/django_boost/templatetags/boost.py
@@ -2,7 +2,6 @@
 
 from ast import literal_eval
 from itertools import chain, zip_longest
-from warnings import warn
 
 from django.template import Library
 
@@ -216,9 +215,6 @@ def _vars(obj):
 
 @register.filter(name="zip")
 def _zip(arg1, arg2):
-    warn("The `zip` template filter is deprecated and will be removed in "
-         "django-boost 3.0. Use the `zip` template tag instead.",
-         DeprecationWarning, stacklevel=2)
     return zip(arg1, arg2)
 
 

--- a/docs/template_tags.rst
+++ b/docs/template_tags.rst
@@ -87,12 +87,16 @@ zip
 ~~~~
 Combine iterable objects.
 
-The ``zip`` template filter is deprecated and will be removed in django-boost
-3.0. Use the ``zip`` template tag instead.
+The ``zip`` helper is available both as a template filter for two iterables and
+as a template tag for two or more iterables.
 
 ::
 
   {% load boost %}
+
+  {% for value1, value2 in list1|zip:list2 %}
+    {{ value1 }} {{ value2 }}
+  {% endfor %}
 
   {% zip list1 list2 as zipped_list %}
 

--- a/docs/template_tags.rst
+++ b/docs/template_tags.rst
@@ -87,8 +87,9 @@ zip
 ~~~~
 Combine iterable objects.
 
-The ``zip`` helper is available both as a template filter for two iterables and
-as a template tag for two or more iterables.
+Use the ``zip`` template filter when combining two iterables inline. If you
+need to combine three or more iterables at the same time, use the ``zip``
+template tag instead.
 
 ::
 
@@ -98,10 +99,10 @@ as a template tag for two or more iterables.
     {{ value1 }} {{ value2 }}
   {% endfor %}
 
-  {% zip list1 list2 as zipped_list %}
+  {% zip list1 list2 list3 as zipped_list %}
 
-  {% for value1, value2 in zipped_list %}
-    {{ value1 }} {{ value2 }}
+  {% for value1, value2, value3 in zipped_list %}
+    {{ value1 }} {{ value2 }} {{ value3 }}
   {% endfor %}
 
 

--- a/tests/tests/test_deprecations.py
+++ b/tests/tests/test_deprecations.py
@@ -3,14 +3,6 @@ from django.core.management import call_command
 from django_boost.test import TestCase
 
 
-class ZipFilterDeprecationTests(TestCase):
-    def test_zip_filter_warns(self):
-        from django_boost.templatetags.boost import _zip
-        with self.assertWarns(DeprecationWarning):
-            result = _zip([1, 2], [3, 4])
-        self.assertEqual(list(result), [(1, 3), (2, 4)])
-
-
 class JsonFieldDeprecationTests(TestCase):
     def test_jsonfield_init_warns(self):
         from django_boost.models.fields import JsonField

--- a/tests/tests/test_template_tags.py
+++ b/tests/tests/test_template_tags.py
@@ -99,6 +99,18 @@ class TestBoostQueryTemplateTag(TestCase):
 
         self.assertEqual(_bool(1), True)
 
+    def test_zip_filter(self):
+        import warnings
+
+        from django_boost.templatetags.boost import _zip
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _zip([1, 2], [3, 4])
+
+        self.assertEqual(caught, [])
+        self.assertEqual(list(result), [(1, 3), (2, 4)])
+
 
 class TestMimeTypeTempleteTag(TestCase):
 


### PR DESCRIPTION
Remove the v3 deprecation warning from the zip template filter after issue https://github.com/ChanTsune/django-boost/issues/250 changed the v3 policy to keep the filter for backward compatibility.

Move its coverage back to the template tag tests and update the docs to describe both the filter and tag entry points.