### PR TITLE
:construction_worker: Upload coverage via codecov-action with token

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,8 @@ omit = django_boost/management/commands/*
 [report]
 show_missing = True
 skip_covered = True
+
+[paths]
+source =
+    django_boost/
+    */site-packages/django_boost/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,13 @@ jobs:
     - name: Report
       run: |
         coverage report
-    - name: codecov
+    - name: Coverage XML
       run: |
-        codecov
+        coverage xml
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        name: py${{ matrix.python-version }}-dj${{ matrix.django-version }}
+        fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,17 +62,41 @@ jobs:
         tox
     - name: Test
       run: |
-        coverage run manage.py test
-    - name: Report
+        coverage run --parallel-mode manage.py test
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-data-${{ strategy.job-index }}
+        path: .coverage.*
+        include-hidden-files: true
+        if-no-files-found: error
+
+  coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12.x'
+    - name: Install coverage
       run: |
+        pip install -U pip
+        pip install coverage
+    - name: Download coverage data
+      uses: actions/download-artifact@v4
+      with:
+        pattern: coverage-data-*
+        merge-multiple: true
+    - name: Combine and report
+      run: |
+        coverage combine
         coverage report
-    - name: Coverage XML
-      run: |
         coverage xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
-        name: py${{ matrix.python-version }}-dj${{ matrix.django-version }}
         fail_ci_if_error: false

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -2,5 +2,5 @@ wheel
 setuptools
 pillow
 tox-travis
-codecov
+coverage
 user-agents>=2.0


### PR DESCRIPTION
The 14-job matrix uploaded coverage through the deprecated `codecov` pip uploader without a token, sharing Codecov's global tokenless rate limit and intermittently returning HTTP 429. Replace it with codecov/codecov-action@v5 using CODECOV_TOKEN, generate coverage.xml explicitly, and drop the dead `codecov` dependency.
