### PR TITLE
:fire: Remove deprecated JsonField model field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - Remove Django < 3.2 `default_app_config` shims and obsolete localization
   settings that are unnecessary for the Django 4.2+ baseline.
 - Remove the deprecated `support_heroku` management command.
+- Remove the deprecated `django_boost.models.fields.JsonField`.
 
 ## [2.2.0] - 2026-06-22
 

--- a/django_boost/models/fields/__init__.py
+++ b/django_boost/models/fields/__init__.py
@@ -1,27 +1,11 @@
-from warnings import warn
-
 from django import forms
 from django.db import models
-from django.db.models.fields import CharField, TextField
+from django.db.models.fields import CharField
 
 from django_boost.forms import fields
 from django_boost.models.fields.related_descriptors import (
     AutoReverseOneToOneDescriptor)
-from django_boost.validators import validate_color_code, validate_json
-
-
-class JsonField(TextField):
-    """TextField with json validation."""
-
-    empty_strings_allowed = False
-    default_validators = [validate_json]
-
-    def __init__(self, *args, **kwargs):
-        warn("django_boost JsonField is deprecated and will be removed in "
-             "django-boost 3.0. Use django.db.models.JSONField instead "
-             "(available since Django 3.1).",
-             DeprecationWarning, stacklevel=2)
-        super().__init__(*args, **kwargs)
+from django_boost.validators import validate_color_code
 
 
 class ColorCodeFiled(CharField):

--- a/docs/model_fields.rst
+++ b/docs/model_fields.rst
@@ -3,19 +3,6 @@ Model fields
 
 :synopsis: Model fields in django-boost
 
-JsonField
-----------
-
-.. warning::
-
-  ``django_boost.models.fields.JsonField`` is deprecated and will be removed in
-  django-boost 3.0. Use Django's native ``django.db.models.JSONField`` instead,
-  available since Django 3.1.
-
-Existing projects that store JSON through the legacy text-based field should
-plan a schema and data migration to Django's native ``JSONField`` before
-upgrading to django-boost 3.0.
-
 AutoOneToOneField
 ------------------
 

--- a/tests/tests/test_deprecations.py
+++ b/tests/tests/test_deprecations.py
@@ -1,8 +1,0 @@
-from django_boost.test import TestCase
-
-
-class JsonFieldDeprecationTests(TestCase):
-    def test_jsonfield_init_warns(self):
-        from django_boost.models.fields import JsonField
-        with self.assertWarnsRegex(DeprecationWarning, r"Django 3\.1"):
-            JsonField()


### PR DESCRIPTION
JsonField was deprecated in v2.2.0 and is removed for the v3.0 line (roadmap Task B5). validate_json / JsonValidator stay in validators.py for standalone JSON validation.

Projects storing JSON through the legacy text column must migrate to Django's native JSONField (data migration: text -> json/jsonb column, str -> object values) before upgrading to django-boost 3.0.

The PR should summarize what was changed and why. Here are some questions to help you if you're not sure:  

Checklist - While not every PR needs it, new features should consider this list:  

- [ ] Does this have tests?  
- [ ] Does this have documentation?  
- [x] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
