### PR TITLE
:construction_worker: Add mypy + django-stubs type-check CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,3 +100,34 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
         fail_ci_if_error: false
+
+  typecheck:
+    # No continue-on-error: a broken setup or a typed-module regression should
+    # surface red here (the mypy.ini allowlist keeps the baseline green, so red
+    # is meaningful). A single django-stubs release can't span Django 4.2..5.2,
+    # so each cell pins its own (mypy, django-stubs) pair.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - django-version: '5.2.*'
+          mypy-version: '2.1.0'
+          stubs-version: '6.0.6'
+        - django-version: '4.2.*'
+          mypy-version: '1.15.0'
+          stubs-version: '5.1.3'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12.x'
+    - name: Install dependencies
+      run: |
+        pip install -U pip
+        pip install "mypy==${{ matrix.mypy-version }}" "django-stubs[compatible-mypy]==${{ matrix.stubs-version }}" "django-stubs-ext==${{ matrix.stubs-version }}"
+        pip install "django==${{ matrix.django-version }}"
+        pip install -e .
+    - name: Mypy
+      run: mypy django_boost

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,18 @@ $ python manage.py test
 This project uses PEP8 as the format for the code.
 It is recommended to use autopep8.
 
+## Type hints
+
+Type hints are being added incrementally (see issue #164).
+
+- Annotate using `from __future__ import annotations` (already in every shipped
+  module) with PEP 585/604 syntax — `list[str]`, `str | None`.
+- Don't add runtime typing dependencies (e.g. `typing_extensions`) to
+  `install_requires`; keep type-only imports under `if TYPE_CHECKING:`.
+- When a module is fully typed, register it in the TYPED-MODULE REGISTRY in
+  `mypy.ini` (a `[mypy-django_boost.<module>]` block with `disallow_untyped_defs`)
+  so it is checked and can't silently lose its annotations. Unregistered modules
+  are not checked.
 ## Development Flow
 
 This project uses a development flow based on GitHub flow.

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django_boost.utils.version import get_version
 
 VERSION = (3, 0, 0, 'alpha', 0)

--- a/django_boost/admin/__init__.py
+++ b/django_boost/admin/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 

--- a/django_boost/admin/actions.py
+++ b/django_boost/admin/actions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib import messages
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import model_ngettext

--- a/django_boost/admin/filters.py
+++ b/django_boost/admin/filters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib import admin
 
 

--- a/django_boost/admin/mixins.py
+++ b/django_boost/admin/mixins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .actions import hard_delete_selected
 from .filters import LogicalDeletedFilter
 

--- a/django_boost/admin/sites.py
+++ b/django_boost/admin/sites.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from inspect import getmembers, isclass
 
 from django.contrib import admin

--- a/django_boost/admin_tools/apps.py
+++ b/django_boost/admin_tools/apps.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.apps import AppConfig
 
 

--- a/django_boost/admin_tools/management/commands/listsuperuser.py
+++ b/django_boost/admin_tools/management/commands/listsuperuser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.auth import get_user_model
 
 from django_boost.core.management import BaseCommand

--- a/django_boost/apps.py
+++ b/django_boost/apps.py
@@ -1,5 +1,7 @@
 """This module provides django_boost application configuration."""
 
+from __future__ import annotations
+
 from django.apps import AppConfig
 from django.core import checks
 

--- a/django_boost/checks.py
+++ b/django_boost/checks.py
@@ -1,5 +1,7 @@
 """This module provides django_boost application check functions."""
 
+from __future__ import annotations
+
 from importlib.util import find_spec
 
 from django.apps import apps

--- a/django_boost/context_processors.py
+++ b/django_boost/context_processors.py
@@ -1,5 +1,7 @@
 """This module provides template context functions."""
 
+from __future__ import annotations
+
 from django_boost.user_agents import parse_user_agent
 
 

--- a/django_boost/core/__init__.py
+++ b/django_boost/core/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django_boost import __version__ as VERSION
 
 

--- a/django_boost/core/management.py
+++ b/django_boost/core/management.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.core.management import base
 
 from django_boost.core import get_version

--- a/django_boost/db/router.py
+++ b/django_boost/db/router.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.conf import settings
 
 

--- a/django_boost/forms/__init__.py
+++ b/django_boost/forms/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm as BaseUserCreationForm
 

--- a/django_boost/forms/fields.py
+++ b/django_boost/forms/fields.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.forms import BooleanField, CharField
 
 from django_boost.forms.widgets import (ColorInput, InvertCheckboxInput,

--- a/django_boost/forms/mixins.py
+++ b/django_boost/forms/mixins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.core.exceptions import (ImproperlyConfigured,
                                     MultipleObjectsReturned,
                                     ObjectDoesNotExist)

--- a/django_boost/forms/widgets.py
+++ b/django_boost/forms/widgets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.forms.widgets import CheckboxInput, Input, RadioSelect
 
 __all__ = ["ColorInput", "InvertCheckboxInput", "PhoneNumberInput"]

--- a/django_boost/http/__init__.py
+++ b/django_boost/http/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 
 from django_boost.http.response import HttpResponseUnsupportedMediaType

--- a/django_boost/http/response.py
+++ b/django_boost/http/response.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.http import (HttpResponse, HttpResponseBadRequest,
                          HttpResponseForbidden, HttpResponseGone,
                          HttpResponseNotAllowed, HttpResponsePermanentRedirect,

--- a/django_boost/management/commands/adminsitelog.py
+++ b/django_boost/management/commands/adminsitelog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 from io import StringIO
 

--- a/django_boost/management/commands/deletemigrations.py
+++ b/django_boost/management/commands/deletemigrations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from django.db.migrations.loader import MIGRATIONS_MODULE_NAME

--- a/django_boost/management/commands/startapp_plus.py
+++ b/django_boost/management/commands/startapp_plus.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django_boost.management.templates import TemplateCommand
 
 

--- a/django_boost/management/mixins.py
+++ b/django_boost/management/mixins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from io import StringIO
 
 

--- a/django_boost/management/templates.py
+++ b/django_boost/management/templates.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 import tempfile

--- a/django_boost/middleware/__init__.py
+++ b/django_boost/middleware/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.conf import settings
 from django.http import HttpResponsePermanentRedirect
 from django.template.exceptions import TemplateDoesNotExist

--- a/django_boost/middleware/html.py
+++ b/django_boost/middleware/html.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.utils.deprecation import MiddlewareMixin
 
 from django_boost.utils.html import strip_spaces_between_tags

--- a/django_boost/models/__init__.py
+++ b/django_boost/models/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.auth.models import AbstractUser, UnicodeUsernameValidator
 from django.db import models
 from django.utils.translation import gettext_lazy as _

--- a/django_boost/models/deletion.py
+++ b/django_boost/models/deletion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import Counter
 from functools import reduce
 from operator import attrgetter, or_

--- a/django_boost/models/fields/__init__.py
+++ b/django_boost/models/fields/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django import forms
 from django.db import models
 from django.db.models.fields import CharField

--- a/django_boost/models/fields/related_descriptors.py
+++ b/django_boost/models/fields/related_descriptors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db.models.fields.related_descriptors import (
     ReverseOneToOneDescriptor)
 from django.db.transaction import atomic

--- a/django_boost/models/manager.py
+++ b/django_boost/models/manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db.models.manager import Manager
 
 from .query import LogicalDeletionQuerySet

--- a/django_boost/models/mixins.py
+++ b/django_boost/models/mixins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import uuid
 
 from django.db import models

--- a/django_boost/models/query.py
+++ b/django_boost/models/query.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import django
 from django.db.models.query import QuerySet
 

--- a/django_boost/shortcuts.py
+++ b/django_boost/shortcuts.py
@@ -4,6 +4,8 @@ of MVC. In other words, these functions/classes introduce controlled coupling
 for convenience's sake.
 """
 
+from __future__ import annotations
+
 __all__ = ['get_object_or_default', 'get_object_or_exception',
            'get_list_or_default', 'get_list_or_exception']
 

--- a/django_boost/template/__init__.py
+++ b/django_boost/template/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django_boost.template.base import StrictInvalidTemplateVariable
 
 __all__ = ("StrictInvalidTemplateVariable",)

--- a/django_boost/template/base.py
+++ b/django_boost/template/base.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class StrictInvalidTemplateVariable(str):
     """
     Raise an exception when Django renders an invalid template variable.

--- a/django_boost/templatetags/boost.py
+++ b/django_boost/templatetags/boost.py
@@ -1,5 +1,7 @@
 """This module provides python build-in functions for django template."""
 
+from __future__ import annotations
+
 from ast import literal_eval
 from itertools import chain, zip_longest
 

--- a/django_boost/templatetags/boost_query.py
+++ b/django_boost/templatetags/boost_query.py
@@ -1,5 +1,7 @@
 """This module provides queryset methods for django template."""
 
+from __future__ import annotations
+
 from django import template
 
 register = template.Library()

--- a/django_boost/templatetags/boost_url.py
+++ b/django_boost/templatetags/boost_url.py
@@ -1,5 +1,7 @@
 """This module provides URL utility for django template."""
 
+from __future__ import annotations
+
 from urllib import parse
 
 from django.template import Library

--- a/django_boost/templatetags/mimetype.py
+++ b/django_boost/templatetags/mimetype.py
@@ -1,5 +1,7 @@
 """This module provides mimetypes utility for django template."""
 
+from __future__ import annotations
+
 from mimetypes import guess_type
 
 from django.template import Library

--- a/django_boost/test/__init__.py
+++ b/django_boost/test/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django_boost.test.testcase import TestCase
 
 __all__ = ["TestCase"]

--- a/django_boost/test/testcase.py
+++ b/django_boost/test/testcase.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.test import TestCase as DjangoTestCase
 
 

--- a/django_boost/urls/__init__.py
+++ b/django_boost/urls/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django_boost.urls.converters import (
     BinIntConverter, BinStrConverter,
     DateConverter,

--- a/django_boost/urls/converters/__init__.py
+++ b/django_boost/urls/converters/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.urls import register_converter
 
 from django_boost.urls.converters.date import DateConverter

--- a/django_boost/urls/converters/date.py
+++ b/django_boost/urls/converters/date.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import ClassVar
 
 REGEX_LEAP_YEAR = r"(([48](00)?)|(([2468][048]|[13579][26])(00)?)|([1-9][0-9]?(0[48]|[2468][048]|[13579][26])))"
 NON_ZERO_YEAR = r"[1-9]([0-9]){,3}"
@@ -31,14 +32,14 @@ REGEX_DATE = REGEX_DATE.format(
 
 
 class DateConverter:
-    regex = REGEX_DATE
+    regex: ClassVar[str] = REGEX_DATE
 
-    def to_url(self, value):
+    def to_url(self, value: datetime | str) -> str:
         if isinstance(value, datetime):
             return datetime.strftime(value, "%Y/%m/%d")
         return str(value)
 
-    def to_python(self, value):
+    def to_python(self, value: datetime | str) -> datetime:
         if isinstance(value, datetime):
             return value
         return datetime.strptime(value, "%Y/%m/%d")

--- a/django_boost/urls/converters/date.py
+++ b/django_boost/urls/converters/date.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 REGEX_LEAP_YEAR = r"(([48](00)?)|(([2468][048]|[13579][26])(00)?)|([1-9][0-9]?(0[48]|[2468][048]|[13579][26])))"

--- a/django_boost/urls/static.py
+++ b/django_boost/urls/static.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from django import urls

--- a/django_boost/user_agents.py
+++ b/django_boost/user_agents.py
@@ -5,6 +5,8 @@ inside the function rather than at module load to keep core installs free of
 it.
 """
 
+from __future__ import annotations
+
 from django.core.exceptions import ImproperlyConfigured
 
 

--- a/django_boost/utils/__init__.py
+++ b/django_boost/utils/__init__.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class Loop:
     """Django template like loop object."""
 

--- a/django_boost/utils/attribute.py
+++ b/django_boost/utils/attribute.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django_boost.core import EMPTY, is_empty
 
 

--- a/django_boost/utils/functions.py
+++ b/django_boost/utils/functions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db import models
 
 

--- a/django_boost/utils/html.py
+++ b/django_boost/utils/html.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from html.parser import HTMLParser
 from io import StringIO
 

--- a/django_boost/utils/itertools.py
+++ b/django_boost/utils/itertools.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from itertools import islice
 

--- a/django_boost/utils/version.py
+++ b/django_boost/utils/version.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 
 def get_version(version=None):

--- a/django_boost/validators.py
+++ b/django_boost/validators.py
@@ -1,5 +1,7 @@
 """This module collects validation functions and classes."""
 
+from __future__ import annotations
+
 import json
 import uuid
 from json.decoder import JSONDecodeError

--- a/django_boost/views/base.py
+++ b/django_boost/views/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import mimetypes
 import os
 from functools import update_wrapper

--- a/django_boost/views/generic.py
+++ b/django_boost/views/generic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.urls import path, reverse
 
 from django_boost.views.base import (

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from datetime import timedelta
 

--- a/django_boost/views/simple.py
+++ b/django_boost/views/simple.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.http import HttpResponse
 from django.views.generic import View
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,9 +37,8 @@ ignore_missing_imports = True
 [mypy-django_boost.*]
 ignore_errors = True
 
-# Example — add a block like this when a module is typed:
-# [mypy-django_boost.urls.converters.date]
-# ignore_errors = False
-# disallow_untyped_defs = True
-# disallow_incomplete_defs = True
-# warn_return_any = True
+[mypy-django_boost.urls.converters.date]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,45 @@
+[mypy]
+plugins = mypy_django_plugin.main
+python_version = 3.10
+namespace_packages = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+exclude = (?x)(
+    ^example/
+    | ^tests/
+    | ^config/
+    | ^docs/
+    | ^build/
+    | ^dist/
+    | /migrations/
+    | ^django_boost/conf/
+    | ^manage\.py$
+    | ^setup\.py$
+  )
+
+[mypy.plugins.django-stubs]
+django_settings_module = config.settings
+
+# config/ is the throwaway test project (pulled in via django_settings_module),
+# not shipped — don't gate on it.
+[mypy-config.*]
+ignore_errors = True
+
+# Provided only by the optional `useragent` extra, so it may be absent.
+[mypy-user_agents.*]
+ignore_missing_imports = True
+
+# === TYPED-MODULE REGISTRY (the ratchet) ===
+# Baseline is green: errors in the package are not reported until a module is
+# typed and registered. To adopt a module, add a block for it below (most
+# specific match wins over this wildcard), flip ignore_errors off, and turn on
+# strictness. This list IS the tracked set of typed modules.
+[mypy-django_boost.*]
+ignore_errors = True
+
+# Example — add a block like this when a module is typed:
+# [mypy-django_boost.urls.converters.date]
+# ignore_errors = False
+# disallow_untyped_defs = True
+# disallow_incomplete_defs = True
+# warn_return_any = True

--- a/requirements/develop.txt
+++ b/requirements/develop.txt
@@ -2,3 +2,8 @@
 tox
 autopep8
 user-agents>=2.0
+# Pinned to the primary type-check (Django 5.2); CI also runs a Django 4.2 cell
+# on its own stubs pin — see .github/workflows/test.yml.
+mypy==2.1.0
+django-stubs[compatible-mypy]==6.0.6
+django-stubs-ext==6.0.6


### PR DESCRIPTION
Stand up the type-hint foundation (#164) without typing the codebase yet.

- mypy.ini: wires the django-stubs plugin to config.settings, sets python_version=3.10 to enforce the syntax floor, and uses an allowlist ratchet (errors ignored per package module until each is typed and registered) so the baseline is green.
- requirements/develop.txt: mypy + django-stubs as CI/dev-only deps (kept out of setup.py install_requires and base.txt).
- test.yml: a typecheck job over Django 5.2 and 4.2, each on its own django-stubs pin. Failures are visible (no continue-on-error); the job is not a required status check yet, so it does not block merges.

The PR should summarize what was changed and why. Here are some questions to help you if you're not sure:  

- What behavior was changed?  
- What code was refactored / updated to support this change?  
- What issues are related to this PR? Or why was this change introduced?  

Checklist - While not every PR needs it, new features should consider this list:  

- [ ] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
