### PR TITLE
:bug: Fix backwards argument-count message in replace_parameters tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - Fix `adminsitelog` user-name fallback for custom user models without a
   `username` attribute.
+- Fix the `replace_parameters` template tag error message, which stated the
+  argument count must be "odd" when it must be even.
 
 ## [2.2.0] - 2026-06-22
 

--- a/django_boost/templatetags/boost_url.py
+++ b/django_boost/templatetags/boost_url.py
@@ -27,7 +27,7 @@ def replace_parameters(request, *args):
     arg_len = len(args)
     if arg_len % 2 != 0:
         raise LookupError(
-            "The number of arguments must be odd, but %s was given" % arg_len)
+            "The number of arguments must be even, but %s was given" % arg_len)
     url_dict = request.GET.copy()
     for k, v in chunked(args, 2):
         url_dict[k] = str(v)

--- a/tests/tests/templatetags/test_boost_url.py
+++ b/tests/tests/templatetags/test_boost_url.py
@@ -39,7 +39,7 @@ class TestBoostUrlTemplateTag(TestCase):
             for e in expected:
                 self.assertIn(e, actual)
 
-        with self.assertRaises(LookupError):
+        with self.assertRaisesRegex(LookupError, "must be even"):
             request = factory.request()
             replace_parameters(request, 'q')
 


### PR DESCRIPTION
The guard rejects an odd argument count (key/value pairs require an even count), but the LookupError said the count must be "odd". Correct the message to "even" and assert it in the existing test.

The PR should summarize what was changed and why. Here are some questions to help you if you're not sure:  

- What behavior was changed?  
- What code was refactored / updated to support this change?  
- What issues are related to this PR? Or why was this change introduced?  

Checklist - While not every PR needs it, new features should consider this list:  

- [ ] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
