### PR TITLE
:bookmark: Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-06-25
+
 ### Added
 
 - Add `csv` and `tsv` output formats to the `adminsitelog` management command.
@@ -353,7 +355,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - First release.
 
-[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/ChanTsune/django-boost/compare/v2.2.0...v3.0.0
 [2.2.0]: https://github.com/ChanTsune/django-boost/compare/v2.1.2...v2.2.0
 [2.1.2]: https://github.com/ChanTsune/django-boost/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/ChanTsune/django-boost/compare/v2.1.0...v2.1.1

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from django_boost.utils.version import get_version
 
-VERSION = (3, 0, 0, 'alpha', 0)
+VERSION = (3, 0, 0, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
- Added
  - csv and tsv output formats for adminsitelog
  - django-boost system checks for router, middleware, user-agent, logical deletion, and admin_tools configuration
  - StrictInvalidTemplateVariable for failing on invalid template variables
  - Correctly-spelled ColorCodeField model field
- Changed
  - Move admin_tools and adminsitelog into django_boost.contrib.admin_tools with deprecated compatibility aliases
  - Expand listsuperuser output and formats
  - Require Python 3.10+ and Django 4.2-5.2 for the 3.0 line
  - Use Django native view setup and redirect mixin implementations
  - Move user-agent detection behind the optional useragent extra
  - Build startapp_plus on Django current app template
  - Preserve Django deletion collector semantics for logical deletion
- Deprecated
  - ColorCodeFiled in favor of ColorCodeField
- Removed
  - Django < 3.2 default_app_config and localization shims
  - support_heroku management command
  - JsonField model field
- Fixed
  - adminsitelog user-name fallback for custom user models without username
  - replace_parameters argument-count error message
