### PR TITLE
:bug: Fix SpaceLessMiddleware un-escaping HTML entities in text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `SpaceLessMiddleware` no longer un-escapes HTML entities in page text.
+
 ## [3.0.0] - 2026-06-25
 
 ### Added

--- a/django_boost/utils/html.py
+++ b/django_boost/utils/html.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from html import escape
 from html.parser import HTMLParser
 from io import StringIO
 
@@ -14,7 +15,8 @@ class HTMLSpaceLessCompressor(HTMLParser):
     def handle_data(self, data):
         if self.pre_count == 0:
             data = data.strip()
-        self.buffer.write(data)
+        # convert_charrefs already decoded entities here; re-escape them.
+        self.buffer.write(escape(data, quote=False))
 
     def handle_starttag(self, tag, attrs):
         self.buffer.write("<%s" % tag)

--- a/tests/tests/utils/test_html.py
+++ b/tests/tests/utils/test_html.py
@@ -1,0 +1,16 @@
+from django_boost.test import TestCase
+from django_boost.utils.html import strip_spaces_between_tags
+
+
+class SpaceLessEntityEscapingTests(TestCase):
+    """Compression must not undo HTML escaping in text content."""
+
+    def test_named_entity_in_text_is_preserved(self):
+        self.assertEqual(
+            strip_spaces_between_tags('<p>a &amp; b</p>'),
+            '<p>a &amp; b</p>')
+
+    def test_escaped_markup_is_not_decoded_into_active_markup(self):
+        self.assertEqual(
+            strip_spaces_between_tags('<p>&lt;script&gt;</p>'),
+            '<p>&lt;script&gt;</p>')


### PR DESCRIPTION
HTMLParser decodes character references in text content (convert_charrefs is on by default), so HTMLSpaceLessCompressor emitted already-decoded entities verbatim, turning escaped markup like &lt;script&gt; back into active markup (XSS). Re-escape text in handle_data so the original escaping is preserved.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
