### PR TITLE
:bug: Fix SpaceLessMiddleware crash on streaming HTML responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Fixed
 
 - `SpaceLessMiddleware` no longer un-escapes HTML entities in page text.
+- `SpaceLessMiddleware` no longer crashes on streaming HTML responses.
 
 ## [3.0.0] - 2026-06-25
 

--- a/django_boost/middleware/html.py
+++ b/django_boost/middleware/html.py
@@ -31,8 +31,10 @@ class SpaceLessMiddleware(MiddlewareMixin):
         response = self.get_response(request)
         if 'text/html' in response.get('Content-Type', ''):
             if response.streaming:
-                response.streaming_content = strip_spaces_between_tags(
-                    response.streaming_content.decode())
+                content = b''.join(response.streaming_content).decode(
+                    response.charset)
+                response.streaming_content = [
+                    strip_spaces_between_tags(content).encode(response.charset)]
             else:
                 response.content = strip_spaces_between_tags(
                     response.content.decode())

--- a/tests/tests/middleware/test_html.py
+++ b/tests/tests/middleware/test_html.py
@@ -1,0 +1,23 @@
+from django.http import StreamingHttpResponse
+from django.test import RequestFactory, SimpleTestCase
+
+from django_boost.middleware.html import SpaceLessMiddleware
+
+
+class SpaceLessMiddlewareStreamingTests(SimpleTestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_compresses_streaming_html_response(self):
+        def get_response(request):
+            return StreamingHttpResponse(
+                [b'<html>  <body>  hi  </body>  </html>'],
+                content_type='text/html')
+
+        middleware = SpaceLessMiddleware(get_response)
+        response = middleware(self.factory.get('/'))
+
+        self.assertTrue(response.streaming)
+        self.assertEqual(b''.join(response.streaming_content),
+                         b'<html><body>hi</body></html>')


### PR DESCRIPTION
streaming_content is an iterator of byte chunks (a map object) with no .decode(), so every text/html StreamingHttpResponse raised AttributeError. Join the chunks, decode via response.charset, compress, and re-wrap as a list of bytes.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
