### PR TITLE
:bug: Fix SpaceLessMiddleware mangling HTML attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `SpaceLessMiddleware` no longer un-escapes HTML entities in page text.
 - `SpaceLessMiddleware` no longer crashes on streaming HTML responses.
+- `SpaceLessMiddleware` no longer mangles valueless or quoted HTML attributes.
 
 ## [3.0.0] - 2026-06-25
 

--- a/django_boost/utils/html.py
+++ b/django_boost/utils/html.py
@@ -43,7 +43,9 @@ class HTMLSpaceLessCompressor(HTMLParser):
         self.buffer.write("<!%s>" % data)
 
     def _render_attrs(self, attrs):
-        return ' '.join('%s="%s"' % attr for attr in attrs)
+        return ' '.join(
+            name if value is None else '%s="%s"' % (name, escape(value))
+            for name, value in attrs)
 
     def compress(self, data):
         self.feed(data)

--- a/tests/tests/utils/test_html.py
+++ b/tests/tests/utils/test_html.py
@@ -14,3 +14,17 @@ class SpaceLessEntityEscapingTests(TestCase):
         self.assertEqual(
             strip_spaces_between_tags('<p>&lt;script&gt;</p>'),
             '<p>&lt;script&gt;</p>')
+
+
+class SpaceLessAttributeRenderingTests(TestCase):
+    """Attributes must round-trip without inventing values or breaking quotes."""
+
+    def test_valueless_attribute_renders_without_a_value(self):
+        self.assertEqual(
+            strip_spaces_between_tags('<input disabled>'),
+            '<input disabled>')
+
+    def test_attribute_value_is_escaped(self):
+        self.assertEqual(
+            strip_spaces_between_tags('<a title="x&quot;y">z</a>'),
+            '<a title="x&quot;y">z</a>')


### PR DESCRIPTION
Valueless attributes (e.g. <input disabled>) were rendered as disabled="None", and attribute values were emitted unescaped so a value containing a quote broke out of the attribute. Render valueless attributes as the bare name and escape attribute values.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
