### PR TITLE
:bug: Fix SpaceLessMiddleware dropping trailing text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `SpaceLessMiddleware` no longer un-escapes HTML entities in page text.
 - `SpaceLessMiddleware` no longer crashes on streaming HTML responses.
 - `SpaceLessMiddleware` no longer mangles valueless or quoted HTML attributes.
+- `SpaceLessMiddleware` no longer drops text after the final tag.
 
 ## [3.0.0] - 2026-06-25
 

--- a/django_boost/utils/html.py
+++ b/django_boost/utils/html.py
@@ -49,7 +49,8 @@ class HTMLSpaceLessCompressor(HTMLParser):
 
     def compress(self, data):
         self.feed(data)
-        self.reset()
+        # close() flushes trailing buffered text; reset() would drop it.
+        self.close()
         return self.buffer.getvalue()
 
 

--- a/tests/tests/utils/test_html.py
+++ b/tests/tests/utils/test_html.py
@@ -28,3 +28,14 @@ class SpaceLessAttributeRenderingTests(TestCase):
         self.assertEqual(
             strip_spaces_between_tags('<a title="x&quot;y">z</a>'),
             '<a title="x&quot;y">z</a>')
+
+
+class SpaceLessTrailingDataTests(TestCase):
+    """Text the parser buffers at end-of-input must not be silently dropped."""
+
+    def test_trailing_text_ending_in_an_ampersand_is_kept(self):
+        # A trailing "&" looks like the start of an entity, so the parser
+        # holds the run until close(); without close() it is dropped.
+        self.assertEqual(
+            strip_spaces_between_tags('<p>x</p>price is 5 USD &'),
+            '<p>x</p>price is 5 USD &amp;')


### PR DESCRIPTION
HTMLSpaceLessCompressor.compress called reset() instead of close() before reading the buffer, so text the parser holds at end-of-input (e.g. a trailing run that could begin an entity) was never flushed and was silently dropped. Close the parser before returning.

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
