### PR TITLE
:bug: Fix SpaceLessMiddleware crash on non-UTF-8 HTML responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `SpaceLessMiddleware` no longer crashes on streaming HTML responses.
 - `SpaceLessMiddleware` no longer mangles valueless or quoted HTML attributes.
 - `SpaceLessMiddleware` no longer drops text after the final tag.
+- `SpaceLessMiddleware` no longer corrupts non-UTF-8 HTML responses.
 
 ## [3.0.0] - 2026-06-25
 

--- a/django_boost/middleware/html.py
+++ b/django_boost/middleware/html.py
@@ -37,6 +37,6 @@ class SpaceLessMiddleware(MiddlewareMixin):
                     strip_spaces_between_tags(content).encode(response.charset)]
             else:
                 response.content = strip_spaces_between_tags(
-                    response.content.decode())
+                    response.content.decode(response.charset))
                 response['Content-Length'] = str(len(response.content))
         return response

--- a/tests/tests/middleware/test_html.py
+++ b/tests/tests/middleware/test_html.py
@@ -1,4 +1,4 @@
-from django.http import StreamingHttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.test import RequestFactory, SimpleTestCase
 
 from django_boost.middleware.html import SpaceLessMiddleware
@@ -21,3 +21,22 @@ class SpaceLessMiddlewareStreamingTests(SimpleTestCase):
         self.assertTrue(response.streaming)
         self.assertEqual(b''.join(response.streaming_content),
                          b'<html><body>hi</body></html>')
+
+
+class SpaceLessMiddlewareCharsetTests(SimpleTestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_compresses_non_utf8_html_response(self):
+        html = '<html> <body>café</body> </html>'
+
+        def get_response(request):
+            return HttpResponse(html.encode('latin-1'),
+                                content_type='text/html; charset=latin-1')
+
+        middleware = SpaceLessMiddleware(get_response)
+        response = middleware(self.factory.get('/'))
+
+        self.assertEqual(response.content.decode('latin-1'),
+                         '<html><body>café</body></html>')


### PR DESCRIPTION
The non-streaming branch decoded response.content with no argument (UTF-8), so a response declaring a non-UTF-8 charset raised UnicodeDecodeError or mojibaked. Decode via response.charset; the content setter re-encodes with the same charset.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
