### PR TITLE
:label: Type the itertools helpers (take, chunked)

### DIFF
--- a/django_boost/utils/itertools.py
+++ b/django_boost/utils/itertools.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator
 from functools import partial
 from itertools import islice
+from typing import TypeVar
+
+_T = TypeVar("_T")
 
 
-def take(n, iterable):
+def take(n: int, iterable: Iterable[_T]) -> list[_T]:
     """Return first *n* items of the iterable as a list.
 
     example ::
@@ -20,7 +24,7 @@ def take(n, iterable):
     return list(islice(iterable, n))
 
 
-def chunked(iterable, n):
+def chunked(iterable: Iterable[_T], n: int) -> Iterator[list[_T]]:
     """Break *iterable* into lists of length *n*:
 
     example ::

--- a/mypy.ini
+++ b/mypy.ini
@@ -42,3 +42,9 @@ ignore_errors = False
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
+
+[mypy-django_boost.utils.itertools]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True


### PR DESCRIPTION
Annotate take/chunked with a TypeVar (take(n: int, Iterable[_T]) -> list[_T]; chunked(Iterable[_T], n: int) -> Iterator[list[_T]]) and register the module in mypy.ini's TYPED-MODULE REGISTRY. Driven test-first: a failing assert_type contract check (Any vs list[int]/Iterator[list[int]]) drove the annotations red->green. Verified mypy-green with and without the django-stubs plugin (no Django dependency); existing TestItertools behavior unchanged.

- [ ] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
