### PR TITLE
:bug: Fix DatabaseRouter blocking unmapped apps on the default database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `SpaceLessMiddleware` no longer mangles valueless or quoted HTML attributes.
 - `SpaceLessMiddleware` no longer drops text after the final tag.
 - `SpaceLessMiddleware` no longer corrupts non-UTF-8 HTML responses.
+- `DatabaseRouter.allow_migrate` no longer blocks unmapped apps from migrating on the `default` database.
 
 ## [3.0.0] - 2026-06-25
 

--- a/django_boost/db/router.py
+++ b/django_boost/db/router.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from django.conf import settings
+from django.db import DEFAULT_DB_ALIAS
 
 
 class DatabaseRouter:
+    """Route Django apps to database aliases from DATABASE_APPS_MAPPING."""
 
     def __init__(self):
         self.db_map = getattr(settings, "DATABASE_APPS_MAPPING", {})
@@ -22,7 +24,8 @@ class DatabaseRouter:
         return None
 
     def allow_migrate(self, db, app_label, model=None, **hints):
-        if db in self.db_map.values():
-            return self.db_map.get(app_label) == db
-        elif app_label in self.db_map:
+        if app_label in self.db_map:
+            return self.db_map[app_label] == db
+        if db != DEFAULT_DB_ALIAS and db in self.db_map.values():
             return False
+        return None

--- a/docs/multiple_database.rst
+++ b/docs/multiple_database.rst
@@ -1,33 +1,80 @@
-Multiple database
-=========================
+Multiple databases
+==================
 
-:synopsis: Use multiple database
+:synopsis: Route Django apps to separate databases
 
-Use multiple database
-------------------------
+``django_boost.db.router.DatabaseRouter`` is a small app-label based database
+router. Use it when whole Django apps should be assigned to specific database
+aliases while the rest of the project stays on ``default``.
 
-Switch the database used for each application.
+Configuration
+-------------
 
-settings.py ::
+Add every database alias to ``DATABASES``, enable the router, and map app labels
+to database aliases with ``DATABASE_APPS_MAPPING``::
 
   DATABASES = {
       'default': {
           'ENGINE': 'django.db.backends.sqlite3',
           'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
       },
-      'db2': {
+      'reports': {
           'ENGINE': 'django.db.backends.sqlite3',
-          'NAME': os.path.join(BASE_DIR, 'db2.sqlite3'),
-      }
+          'NAME': os.path.join(BASE_DIR, 'reports.sqlite3'),
+      },
   }
 
   DATABASE_ROUTERS = ['django_boost.db.router.DatabaseRouter']
 
   DATABASE_APPS_MAPPING = {
-      "myapp" : "db2",
-      "myapp2" : "db2"
+      'billing': 'default',
+      'reports': 'reports',
+      'audit_log': 'reports',
   }
 
-In the above example, application `myapp` and `myapp2` will use the database `db2`.
+The keys in ``DATABASE_APPS_MAPPING`` are Django app labels, not model names or
+dotted Python paths. In most projects the label is the final component of the
+app package name, but a custom ``AppConfig.label`` can override it.
 
-Other applications use the default database.
+Routing behavior
+----------------
+
+With the configuration above:
+
+* models in the ``reports`` and ``audit_log`` apps use the ``reports`` database;
+* models in the ``billing`` app use the ``default`` database explicitly;
+* apps that are not listed are left to Django's normal routing behavior, which
+  uses ``default`` when no other router chooses a database;
+* mapped apps migrate only on their configured database;
+* unmapped apps migrate on ``default`` and are not created on mapped
+  non-default databases.
+
+This router works at app granularity. If one app needs to split different
+models across different databases, use separate apps or write a custom Django
+database router for that policy.
+
+Migrations
+----------
+
+Django runs migrations for one database at a time. Run migrations for
+``default`` as usual, then run them for each additional alias that contains
+mapped apps::
+
+  python manage.py migrate
+  python manage.py migrate --database=reports
+
+For the example configuration, the ``reports`` and ``audit_log`` migrations run
+on ``reports``. Unmapped apps such as Django's ``auth`` and ``sessions`` stay on
+``default``.
+
+System checks
+-------------
+
+django-boost registers checks for common configuration mistakes when
+``django_boost`` is in ``INSTALLED_APPS``. Run them with::
+
+  python manage.py check --tag django_boost
+
+The checks warn when ``DATABASE_APPS_MAPPING`` is missing or names an app label
+that is not installed, and report an error when it is not a dict or points to an
+unknown database alias. See :doc:`checks` for the full list of check IDs.

--- a/tests/tests/db/test_router.py
+++ b/tests/tests/db/test_router.py
@@ -1,0 +1,89 @@
+import warnings
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase as UnitTestCase
+
+from django.conf import settings
+from django.core.management import call_command
+from django.db import connections
+from django.test import SimpleTestCase, override_settings
+
+from django_boost.db.router import DatabaseRouter
+
+
+def clear_router_test_connection(alias):
+    connection = getattr(connections._connections, alias, None)
+    if connection is not None:
+        connection.close()
+        delattr(connections._connections, alias)
+    connections.databases.pop(alias, None)
+
+
+class DatabaseRouterAllowMigrateTests(SimpleTestCase):
+
+    @override_settings(DATABASE_APPS_MAPPING={'shop': 'default'})
+    def test_unmapped_app_is_not_blocked_on_default(self):
+        # An app mapped to 'default' must not stop unmapped apps (auth,
+        # sessions, ...) from migrating there. Defer with None, not False.
+        router = DatabaseRouter()
+        self.assertIsNone(router.allow_migrate('default', 'auth'))
+
+    @override_settings(DATABASE_APPS_MAPPING={'shop': 'shopdb'})
+    def test_mapped_app_is_confined_to_its_database(self):
+        router = DatabaseRouter()
+        self.assertTrue(router.allow_migrate('shopdb', 'shop'))
+        self.assertFalse(router.allow_migrate('default', 'shop'))
+
+    @override_settings(DATABASE_APPS_MAPPING={'shop': 'shopdb'})
+    def test_unmapped_app_is_blocked_on_mapped_non_default_database(self):
+        router = DatabaseRouter()
+        self.assertIsNone(router.allow_migrate('default', 'auth'))
+        self.assertFalse(router.allow_migrate('shopdb', 'auth'))
+
+    @override_settings(DATABASE_APPS_MAPPING={'shop': 'shopdb'})
+    def test_unmapped_app_defers_on_unmapped_non_default_database(self):
+        # A non-default database that no app maps to is none of the router's
+        # business: defer so unmapped apps can still migrate onto it.
+        router = DatabaseRouter()
+        self.assertIsNone(router.allow_migrate('otherdb', 'auth'))
+
+
+class DatabaseRouterMigrationTests(UnitTestCase):
+
+    def test_migrate_keeps_unmapped_apps_off_a_mapped_database(self):
+        # End-to-end check that the router is wired into migrate, not just
+        # exercised in isolation like the unit tests above. django_content_type
+        # is the negative control because contenttypes is installed and would
+        # migrate here if the router allowed it (unlike auth_user, which
+        # AUTH_USER_MODEL swaps out regardless of the router). The
+        # 'default'-database regression is covered by those unit tests; migrate
+        # cannot exercise it without replacing the test runner's own 'default'
+        # connection.
+        alias = 'router_test'
+        tmpdir = TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+
+        databases = dict(settings.DATABASES)
+        databases[alias] = {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': str(Path(tmpdir.name) / 'router-test.sqlite3'),
+        }
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore',
+                message=r'Overriding setting DATABASES can lead to unexpected behavior\.',
+                category=UserWarning,
+            )
+            with override_settings(
+                DATABASES=databases,
+                DATABASE_ROUTERS=['django_boost.db.router.DatabaseRouter'],
+                DATABASE_APPS_MAPPING={'sessions': alias},
+            ):
+                connections.databases[alias] = connections.configure_settings(databases)[alias]
+                self.addCleanup(clear_router_test_connection, alias)
+                connection = connections[alias]
+                call_command('migrate', database=alias, verbosity=0, interactive=False)
+                tables = set(connection.introspection.table_names())
+
+        self.assertIn('django_session', tables)
+        self.assertNotIn('django_content_type', tables)


### PR DESCRIPTION
allow_migrate keyed off the mapping's values, so when any app mapped to 'default' it returned False for every unmapped app — core tables (auth, sessions, admin) never migrated. Constrain only mapped apps; defer (None) otherwise.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
