### PR TITLE
:label: Type the example app harness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,4 +130,4 @@ jobs:
         pip install "django==${{ matrix.django-version }}"
         pip install -e .
     - name: Mypy
-      run: mypy django_boost
+      run: mypy django_boost example

--- a/django_boost/views/generic.py
+++ b/django_boost/views/generic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from django.db import models
 from django.urls import path, reverse
 
 from django_boost.views.base import (
@@ -36,7 +37,7 @@ class JsonView(JsonRequestMixin, JsonResponseMixin, View):
 
 
 class BaseModelCLUDViews:
-    model = None
+    model: type[models.Model] | None = None
     success_url = None
     list_view = None
     create_view = None

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import timedelta
+from typing import Sequence
 
 from django.contrib.auth.mixins import AccessMixin
 from django.contrib.auth.views import (RedirectURLMixin, logout_then_login,
@@ -41,9 +42,9 @@ class DynamicRedirectMixin(RedirectURLMixin):
 
 class RedirectToDetailMixin:
 
-    success_url_name = None
-    url_kwarg = 'pk'
-    object_field_name = 'pk'
+    success_url_name: str | None = None
+    url_kwarg: str = 'pk'
+    object_field_name: str = 'pk'
 
     def get_success_url(self):
         field = getattr(self.object, self.object_field_name)
@@ -54,7 +55,7 @@ class RedirectToDetailMixin:
 class AllowContentTypeMixin:
     """Mixin to restrict content type at the time of access."""
 
-    allowed_content_types = None
+    allowed_content_types: Sequence[str] | None = None
     strictly = True
 
     def dispatch(self, request, *args, **kwargs):
@@ -181,7 +182,7 @@ class ReAuthenticationRequiredMixin(AccessMixin):
     ``logout=False``, Do not logout Even if the specified time limit has passed.
     """
 
-    interval = None
+    interval: int | timedelta | None = None
     logout = False
 
     def get_interval(self):
@@ -256,9 +257,9 @@ class ViewUserKwargsMixin:
 
 class UserAgentMixin:
 
-    pc_template_name = None
-    tablet_template_name = None
-    mobile_template_name = None
+    pc_template_name: str | None = None
+    tablet_template_name: str | None = None
+    mobile_template_name: str | None = None
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)

--- a/example/forms.py
+++ b/example/forms.py
@@ -1,15 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
 from django import forms
+
 from django_boost.forms.widgets import StarRateSelect
+
 from .models import Article, Customer
 
 
 class CustomerForm(forms.ModelForm):
     SELECT = (
-        (1,1),
-        (2,2),
-        (3,3),
-        (4,4),
-        (5,5),
+        (1, 1),
+        (2, 2),
+        (3, 3),
+        (4, 4),
+        (5, 5),
     )
 
     radio = forms.ChoiceField(
@@ -27,7 +33,7 @@ class CustomerForm(forms.ModelForm):
             'color': 'Favorite color',
         }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         if not self.is_bound and not self.instance.pk:
             self.fields['color'].initial = '#0F9F7D'

--- a/example/models.py
+++ b/example/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db import models
 
 from django_boost.models.mixins import JsonMixin
@@ -10,7 +12,8 @@ from django_boost.models.mixins import (UUIDModelMixin, TimeStampModelMixin,
 class Article(UUIDModelMixin, TimeStampModelMixin, LogicalDeletionMixin):
     title = models.CharField(max_length=128)
     text = models.TextField()
-    tags = models.ManyToManyField(to="Tag", related_name="articles")
+    tags: models.ManyToManyField[Tag, Article] = models.ManyToManyField(
+        to="Tag", related_name="articles")
     image = models.ImageField(upload_to='img')
 
 

--- a/example/templates/example/customer_form.html
+++ b/example/templates/example/customer_form.html
@@ -5,7 +5,7 @@
 {% block body %}
 <section class="page-title">
     <h1>Customer form</h1>
-    <p>Generated create/update route for a model using <code>ColorCodeFiled</code>.</p>
+    <p>Generated create/update route for a model using <code>ColorCodeField</code>.</p>
     <div class="actions">
         <a class="button" href="/views/">Back to Customer CRUD</a>
     </div>

--- a/example/templates/example/index.html
+++ b/example/templates/example/index.html
@@ -105,7 +105,7 @@
 <pre><code>from django_boost.views.generic import JsonView, ModelCRUDViews
 from django_boost.views.mixins import LimitedTermMixin
 from django_boost.models.mixins import UUIDModelMixin, TimeStampModelMixin, LogicalDeletionMixin
-from django_boost.models.fields import ColorCodeFiled</code></pre>
+from django_boost.models.fields import ColorCodeField</code></pre>
     </div>
 </section>
 {% endblock body %}

--- a/example/tests.py
+++ b/example/tests.py
@@ -1,3 +1,147 @@
-from django.test import TestCase
+import tempfile
 
-# Create your tests here.
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from example.models import Article, Category, Customer, Tag
+
+
+GIF_IMAGE = (
+    b"GIF89a\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00"
+    b"\xff\xff\xff!\xf9\x04\x01\x00\x00\x00\x00,"
+    b"\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02"
+    b"D\x01\x00;"
+)
+
+
+class TemporaryMediaRootMixin:
+
+    @classmethod
+    def setUpClass(cls):
+        cls._media_root = tempfile.TemporaryDirectory()
+        cls._media_override = override_settings(MEDIA_ROOT=cls._media_root.name)
+        cls._media_override.enable()
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls._media_override.disable()
+        cls._media_root.cleanup()
+
+
+class CustomerExampleFlowTests(TestCase):
+
+    def test_customer_create_detail_and_update_flow(self):
+        response = self.client.get(reverse("index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Customer form")
+
+        response = self.client.post(reverse("index"), {
+            "name": "Ada Lovelace",
+            "color": "#0f9f7d",
+            "radio": "5",
+        })
+        self.assertRedirects(response, reverse("index"))
+
+        customer = Customer.objects.get(name="Ada Lovelace")
+        self.assertEqual(customer.color, "#0F9F7D")
+
+        response = self.client.get(reverse("customer_detail", args=[customer.pk]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Ada Lovelace")
+
+        response = self.client.post(reverse("customer_update", args=[customer.pk]), {
+            "name": "Ada Byron",
+            "color": "#224466",
+            "radio": "4",
+        })
+        self.assertRedirects(response, reverse("customer_detail", args=[customer.pk]))
+
+        customer.refresh_from_db()
+        self.assertEqual(customer.name, "Ada Byron")
+        self.assertEqual(customer.color, "#224466")
+
+    def test_generated_customer_crud_list_is_reachable(self):
+        Customer.objects.create(name="Grace Hopper", color="#112233")
+
+        response = self.client.get("/views/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Grace Hopper")
+
+
+class JsonExampleFlowTests(TestCase):
+
+    def test_json_views_round_trip_payloads(self):
+        response = self.client.get("/json/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"json": True})
+
+        response = self.client.post(
+            "/json/post/",
+            data=b'{"status": "ok"}',
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_content_type_guard_returns_415(self):
+        response = self.client.get(reverse("content_type"))
+
+        self.assertEqual(response.status_code, 415)
+
+
+class ArticleExampleFlowTests(TemporaryMediaRootMixin, TestCase):
+
+    def test_article_crud_and_deleted_archive_flow(self):
+        category = Category.objects.create(name="News")
+        tag = Tag.objects.create(
+            name="Release",
+            category=category,
+            color="#123456",
+        )
+
+        response = self.client.get(reverse("article_list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "No articles yet")
+
+        response = self.client.post(reverse("article_create"), {
+            "title": "Typed example app",
+            "text": "The example app exercises django-boost integrations.",
+            "tags": [str(tag.pk)],
+            "image": SimpleUploadedFile("article.gif", GIF_IMAGE, "image/gif"),
+        })
+        self.assertRedirects(response, reverse("article_list"))
+
+        article = Article.objects.get(title="Typed example app")
+        self.assertEqual(list(article.tags.values_list("name", flat=True)), ["Release"])
+
+        response = self.client.get(reverse("article_detail", args=[article.pk]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Typed example app")
+
+        response = self.client.post(reverse("article_update", args=[article.pk]), {
+            "title": "Typed example app updated",
+            "text": "The update view keeps the sample executable.",
+            "tags": [str(tag.pk)],
+        })
+        self.assertRedirects(response, reverse("article_list"))
+
+        article.refresh_from_db()
+        self.assertEqual(article.title, "Typed example app updated")
+
+        response = self.client.get(reverse("article_delete", args=[article.pk]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Delete article")
+
+        response = self.client.post(reverse("article_delete", args=[article.pk]))
+        self.assertRedirects(response, reverse("article_list"))
+
+        article.refresh_from_db()
+        self.assertTrue(article.is_dead())
+
+        response = self.client.get(reverse("article_deleted_list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Typed example app updated")

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, cast
 
 from django.urls import path, include
 from django_boost.urls import UrlSet, include_static_files
@@ -35,7 +36,7 @@ urlpatterns = [
          views.CustomerDetailView.as_view(), name='customer_detail'),
     path('customer/<int:pk>/update/',
          views.CustomerUpdateView.as_view(), name='customer_update'),
-    path('json/', include(JsonSampleUrlSet)),
+    path('json/', include(cast(Any, JsonSampleUrlSet))),
     path('start/', views.StartLimitView.as_view()),
     path('end/', views.EndLimitView.as_view()),
     path('se/', views.SELimitView.as_view()),
@@ -43,7 +44,7 @@ urlpatterns = [
     path('google/', views.Http301View.as_view(), name='redirect_to_google'),
 
     path('switch/', views.SwitchView.as_view(), name="switch_by_user_agent"),
-    path('exception/', include(ExceptionUrlSet)),
+    path('exception/', include(cast(Any, ExceptionUrlSet))),
     path('allow/', views.ContentTypeView.as_view(), name='content_type'),
     path('blog/article/', view_blog.ArticleListView.as_view(), name="article_list"),
     path('blog/article/deleted/',

--- a/example/views/__init__.py
+++ b/example/views/__init__.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
 from datetime import datetime, timedelta
 
-from django.shortcuts import render
 from django.views.generic import TemplateView, CreateView, UpdateView, DetailView
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
 from django.utils.timezone import now
 from django_boost.views.generic import JsonView, ModelCRUDViews
@@ -11,7 +13,6 @@ from django_boost.views.mixins import RedirectToDetailMixin
 from django_boost.views.mixins import LimitedTermMixin
 from django_boost.views.mixins import UserAgentMixin
 from django_boost.views.mixins import AllowContentTypeMixin
-from django_boost.http.response import Http409
 
 from example.models import Customer
 from example.forms import CustomerForm
@@ -45,24 +46,24 @@ class ReloginView(ReAuthenticationRequiredMixin, TemplateView):
 class StartLimitView(LimitedTermMixin, TemplateView):
     template_name = "example/index.html"
 
-    def get_start_datetime(self):
+    def get_start_datetime(self) -> datetime:
         return now() + timedelta(hours=1)
 
 
 class EndLimitView(LimitedTermMixin, TemplateView):
     template_name = "example/index.html"
 
-    def get_end_datetime(self):
+    def get_end_datetime(self) -> datetime:
         return now() - timedelta(hours=1)
 
 
 class SELimitView(LimitedTermMixin, TemplateView):
     template_name = "example/index.html"
 
-    def get_start_datetime(self):
+    def get_start_datetime(self) -> datetime:
         return now() - timedelta(hours=1)
 
-    def get_end_datetime(self):
+    def get_end_datetime(self) -> datetime:
         return now() + timedelta(hours=1)
 
 
@@ -72,9 +73,8 @@ class CustomerViews(ModelCRUDViews):
 
 class JsonSampleView(JsonView):
 
-    def get_context_data(self, **kwargs):
-        context = self.json
-        return context
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        return cast(dict[str, Any], self.json)
 
 
 class SwitchView(UserAgentMixin, TemplateView):
@@ -86,11 +86,9 @@ class SwitchView(UserAgentMixin, TemplateView):
 class Http301View(TemplateView):
     template_name = "example/index.html"
 
-    def get_context_data(self, **kwargs):
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         from django_boost.http.response import Http301
-        context = super().get_context_data(**kwargs)
         raise Http301('http://google.com')
-        return context
 
 
 class ContentTypeView(AllowContentTypeMixin, TemplateView):

--- a/example/views/exception.py
+++ b/example/views/exception.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
+from typing import Any, NoReturn
+
 from django_boost.views.generic import TemplateView
 from django_boost.http.response import Http415
 
 
 class E415View(TemplateView):
 
-    def get_context_data(self, **kwargs):
+    def get_context_data(self, **kwargs: Any) -> NoReturn:
         raise Http415

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,7 +5,7 @@ namespace_packages = True
 warn_unused_ignores = True
 warn_redundant_casts = True
 exclude = (?x)(
-    ^example/
+    ^example/tests\.py$
     | ^tests/
     | ^config/
     | ^docs/
@@ -56,6 +56,15 @@ disallow_incomplete_defs = True
 warn_return_any = True
 
 [mypy-django_boost.utils.html]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
+# example/ is a development harness, but keep it type-checked so the sample app
+# continues to compile against django-boost's public APIs. Tests and migrations
+# are excluded above.
+[mypy-example.*]
 ignore_errors = False
 disallow_untyped_defs = True
 disallow_incomplete_defs = True


### PR DESCRIPTION
Register the example app on mypy.ini's typed-module ratchet and include it in the CI typecheck command. Add the annotations needed for the sample app to compile against django-boost's public API, including more precise class attribute types on the generic view helpers that the example subclasses.

Backfill request-level flow tests for the example app's customer, JSON, content-type, and article CRUD surfaces so template, URL, form, model, and view drift is caught by the normal Django test suite.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
