### PR TITLE
:white_check_mark: Route example app through DatabaseRouter in tests

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -87,12 +87,18 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
+    },
+    'example': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'example.sqlite3'),
+    },
 }
 
 DATABASE_ROUTERS = ['django_boost.db.router.DatabaseRouter']
 
-DATABASE_APPS_MAPPING = {}
+DATABASE_APPS_MAPPING = {
+    'example': 'example',
+}
 
 AUTH_USER_MODEL = 'django_boost.EmailUser'
 

--- a/example/tests.py
+++ b/example/tests.py
@@ -32,6 +32,7 @@ class TemporaryMediaRootMixin:
 
 
 class CustomerExampleFlowTests(TestCase):
+    databases = {"default", "example"}
 
     def test_customer_create_detail_and_update_flow(self):
         response = self.client.get(reverse("index"))
@@ -94,6 +95,7 @@ class JsonExampleFlowTests(TestCase):
 
 
 class ArticleExampleFlowTests(TemporaryMediaRootMixin, TestCase):
+    databases = {"default", "example"}
 
     def test_article_crud_and_deleted_archive_flow(self):
         category = Category.objects.create(name="News")

--- a/tests/tests/db/test_router.py
+++ b/tests/tests/db/test_router.py
@@ -9,6 +9,7 @@ from django.db import connections
 from django.test import SimpleTestCase, override_settings
 
 from django_boost.db.router import DatabaseRouter
+from example.models import Customer
 
 
 def clear_router_test_connection(alias):
@@ -46,6 +47,17 @@ class DatabaseRouterAllowMigrateTests(SimpleTestCase):
         # business: defer so unmapped apps can still migrate onto it.
         router = DatabaseRouter()
         self.assertIsNone(router.allow_migrate('otherdb', 'auth'))
+
+
+class DatabaseRouterConfiguredExampleTests(SimpleTestCase):
+
+    def test_example_app_routes_to_configured_example_database(self):
+        router = DatabaseRouter()
+        self.assertEqual(router.db_for_read(Customer), 'example')
+        self.assertEqual(router.db_for_write(Customer), 'example')
+        self.assertTrue(router.allow_migrate('example', 'example'))
+        self.assertFalse(router.allow_migrate('default', 'example'))
+        self.assertFalse(router.allow_migrate('example', 'contenttypes'))
 
 
 class DatabaseRouterMigrationTests(UnitTestCase):


### PR DESCRIPTION
Give the test project a permanent example database mapping so the example CRUD flows exercise DatabaseRouter end to end. Allow those flow tests to access both default and example databases, and add a focused router assertion for the configured example app mapping.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
