### PR TITLE
:bug: preserve UsernameField behavior in UserCreationForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `django_boost.admin.sites.register_all` now registers Django model classes correctly when scanning a models module.
 - The `next` template filter now works for iterators without a supplied default value.
+- `django_boost.forms.UserCreationForm` now preserves Django's `UsernameField` behavior for the active user model identifier field.
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/forms/__init__.py
+++ b/django_boost/forms/__init__.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.forms import UserCreationForm as BaseUserCreationForm
+from django.contrib.auth.forms import (
+    UserCreationForm as BaseUserCreationForm,
+    UsernameField,
+)
 
 from django_boost.forms.fields import ColorCodeField
 from django_boost.forms.mixins import FormUserKwargsMixin
@@ -13,11 +16,13 @@ __all__ = ("ColorCodeField", "ColorInput", "FormUserKwargsMixin",
 
 class UserCreationForm(BaseUserCreationForm):
     """
-    A form that creates a user, with no privileges, from the given
-    ``User.USERNAME_FIELD`` and password.
+    A form that creates a user, with no privileges, from the active user
+    model's ``USERNAME_FIELD`` and password.
     """
 
-    class Meta:
-        User = get_user_model()
-        model = User
-        fields = (User.USERNAME_FIELD,)
+    class Meta(BaseUserCreationForm.Meta):
+        model = get_user_model()
+        fields = (model.USERNAME_FIELD,)
+        field_classes = {
+            model.USERNAME_FIELD: UsernameField,
+        }

--- a/tests/tests/forms/tests.py
+++ b/tests/tests/forms/tests.py
@@ -10,3 +10,28 @@ class FormTest(TestCase):
                                  'password2': 'django_boost'
                                  })
         self.assertTrue(form.is_valid())
+
+    def test_user_creation_form_applies_usernamefield_to_identifier(self):
+        from django.contrib.auth import get_user_model
+        from django.contrib.auth.forms import UsernameField
+        from django_boost.forms import UserCreationForm
+
+        form = UserCreationForm()
+        identifier_field = get_user_model().USERNAME_FIELD
+
+        self.assertIsInstance(form.fields[identifier_field], UsernameField)
+
+    def test_user_creation_form_saves_user(self):
+        from django.contrib.auth import get_user_model
+        from django_boost.forms import UserCreationForm
+
+        form = UserCreationForm({'email': 'created@sample.com',
+                                 'password1': 'django_boost',
+                                 'password2': 'django_boost'
+                                 })
+        self.assertTrue(form.is_valid())
+        user = form.save()
+
+        self.assertEqual(user.email, 'created@sample.com')
+        self.assertTrue(
+            get_user_model().objects.filter(email='created@sample.com').exists())


### PR DESCRIPTION
Fix the custom auth form so the active user-model identifier uses Django's UsernameField semantics and add regression coverage.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
