### PR TITLE
:sparkles: Improve template helper discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Added
+
+- `iter`, `list`, `dict`, `set`, `tuple` and `frozenset` filters in the
+  `boost` template library, exposing the corresponding Python built-ins.
+
 ### Fixed
 
 - `django_boost.admin.sites.register_all` now registers Django model classes correctly when scanning a models module.

--- a/django_boost/templatetags/boost.py
+++ b/django_boost/templatetags/boost.py
@@ -66,6 +66,11 @@ def _delattr(obj, name):
     return obj
 
 
+@register.filter(name="dict")
+def _dict(value):
+    return dict(value)
+
+
 @register.filter(name="dir")
 def _dir(obj):
     return dir(obj)
@@ -91,6 +96,11 @@ def _format(value, format_spec=None):
     if format_spec is None:
         return format(value)
     return format(value, format_spec)
+
+
+@register.filter(name="frozenset")
+def _frozenset(iterable):
+    return frozenset(iterable)
 
 
 @register.filter(name="getattr")
@@ -123,9 +133,19 @@ def _int(value, base=10):
     return int(value, base)
 
 
+@register.filter(name="iter")
+def _iter(iterable):
+    return iter(iterable)
+
+
 @register.filter(name="len")
 def _len(s):
     return len(s)
+
+
+@register.filter(name="list")
+def _list(iterable):
+    return list(iterable)
 
 
 @register.filter(name="max")
@@ -184,6 +204,11 @@ def _round(number, ndigits=None):
     return round(number, ndigits)
 
 
+@register.filter(name="set")
+def _set(iterable):
+    return set(iterable)
+
+
 @register.simple_tag(name="setattr")
 def _setattr(obj, name, value):
     setattr(obj, name, value)
@@ -203,6 +228,11 @@ def _str(obj):
 @register.filter(name="sum")
 def _sum(iterable):
     return sum(iterable)
+
+
+@register.filter(name="tuple")
+def _tuple(iterable):
+    return tuple(iterable)
 
 
 @register.filter(name="type")

--- a/docs/template_tags.rst
+++ b/docs/template_tags.rst
@@ -10,8 +10,9 @@ Python built-in functions
 Make Python built-in functions available in DjangoTemplate.
 
 Some non-built-in functions are also provided as filters.
+A live example of the most useful helpers is available in the sample app at the home page.
 
-An example is ``isiterable`` filter.
+The sample page demonstrates helpers such as ``abs``, ``len``, ``iter``, ``next``, ``chunked``, ``literal``, and ``zip`` so the available tags and filters are easy to discover from a running project.
 
 Usage
 ~~~~~~~~~~~~

--- a/example/templates/example/index.html
+++ b/example/templates/example/index.html
@@ -81,8 +81,8 @@
     <div class="panel">
         <div class="panel-header">
             <div>
-                <h2>Template tag output</h2>
-                <p>Examples stay visible so the page doubles as executable documentation.</p>
+                <h2>Template helper playground</h2>
+                <p>These snippets surface the most useful template helpers as runnable examples.</p>
             </div>
         </div>
         {% literal "[1,2,4,5,6,7,8]" as l %}
@@ -94,6 +94,24 @@
                 </li>
             {% endfor %}
         </ul>
+        <div class="result-list">
+            <div class="result-row">
+                <span>abs</span>
+                <code>{{ number|abs }}</code>
+            </div>
+            <div class="result-row">
+                <span>len</span>
+                <code>{{ l|len }}</code>
+            </div>
+            <div class="result-row">
+                <span>next</span>
+                <code>{{ l|iter|next }}</code>
+            </div>
+            <div class="result-row">
+                <span>zip</span>
+                <code>{% for a, b in l|zip:l %}{{ a }}:{{ b }} {% endfor %}</code>
+            </div>
+        </div>
     </div>
     <div class="panel">
         <div class="panel-header">

--- a/tests/tests/example/test_index.py
+++ b/tests/tests/example/test_index.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class TestIndexPage(TestCase):
+
+    def test_renders_template_helper_playground(self):
+        # A misused boost template helper in this page fails only at render
+        # time, which the filters' own unit tests don't exercise.
+        response = self.client.get(reverse('index'))
+        self.assertEqual(response.status_code, 200)

--- a/tests/tests/templatetags/test_boost.py
+++ b/tests/tests/templatetags/test_boost.py
@@ -342,6 +342,16 @@ class TestVars(TestCase):
         self.assertIn("value", _vars(example))
 
 
+class TestIter(TestCase):
+
+    def test_returns_iterator(self):
+        from django_boost.templatetags.boost import _iter
+
+        iterator = _iter([1, 2, 3])
+        self.assertEqual(next(iterator), 1)
+        self.assertEqual(next(iterator), 2)
+
+
 class TestNext(TestCase):
 
     def test_returns_next_item_without_default(self):
@@ -433,3 +443,43 @@ class TestVar(TestCase):
 
         value = object()
         self.assertIs(var(value), value)
+
+
+class TestList(TestCase):
+
+    def test_materializes_iterator(self):
+        from django_boost.templatetags.boost import _list
+
+        self.assertEqual(_list(iter([1, 2, 3])), [1, 2, 3])
+
+
+class TestTuple(TestCase):
+
+    def test_materializes_iterator(self):
+        from django_boost.templatetags.boost import _tuple
+
+        self.assertEqual(_tuple(iter([1, 2, 3])), (1, 2, 3))
+
+
+class TestSet(TestCase):
+
+    def test_deduplicates_iterable(self):
+        from django_boost.templatetags.boost import _set
+
+        self.assertEqual(_set([1, 2, 2, 3]), {1, 2, 3})
+
+
+class TestFrozenset(TestCase):
+
+    def test_deduplicates_iterable(self):
+        from django_boost.templatetags.boost import _frozenset
+
+        self.assertEqual(_frozenset([1, 2, 2, 3]), frozenset({1, 2, 3}))
+
+
+class TestDict(TestCase):
+
+    def test_builds_from_pairs(self):
+        from django_boost.templatetags.boost import _dict
+
+        self.assertEqual(_dict([("a", 1), ("b", 2)]), {"a": 1, "b": 2})


### PR DESCRIPTION
Add a live template-helper playground to the example app's home page and document it in the template tag docs, so the available boost tags and filters are easy to discover from a running project.

Expose the missing Python built-ins iter, list, dict, set, tuple, and frozenset as template filters, completing the built-in coverage. iter turns an iterable into an iterator (for example before next); the container constructors materialize the single-use iterators returned by iter/zip/chain, which Django's built-in make_list cannot do (it stringifies its input first).

The playground demonstrates next via {{ l|iter|next }}, mirroring Python's next(iter(l)). The earlier {{ l|next }} on a list raised "'list' object is not an iterator" and 500'd the page the docs point to, so add a smoke test that GETs the sample index to catch a misused helper in the template.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [x] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [x] Is this a new feature (Requires minor version bump)?  
