### PR TITLE
🏷️ Type the loop helpers (utils.functions.loop) 

### DIFF
--- a/django_boost/utils/functions/loop.py
+++ b/django_boost/utils/functions/loop.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator, Sequence
+from typing import TypeVar
 
-def loopfirst(iterable):
+_T = TypeVar("_T")
+
+
+def loopfirst(iterable: Iterable[_T]) -> Iterator[tuple[bool, _T]]:
     """
     Loop util.
 
@@ -13,7 +18,7 @@ def loopfirst(iterable):
         yield i == 0, val
 
 
-def looplast(iterable):
+def looplast(iterable: Sequence[_T]) -> Iterator[tuple[bool, _T]]:
     """
     Loop util.
 
@@ -26,7 +31,7 @@ def looplast(iterable):
         yield i == last_index, val
 
 
-def loopfirstlast(iterable):
+def loopfirstlast(iterable: Sequence[_T]) -> Iterator[tuple[bool, _T]]:
     """
     A function combining `firstloop` and` lastloop`.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -61,6 +61,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.utils.functions.loop]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 # example/ is a development harness, but keep it type-checked so the sample app
 # continues to compile against django-boost's public APIs. Tests and migrations
 # are excluded above.

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -2,46 +2,9 @@ from django_boost.test import TestCase
 from django_boost.utils import Loop, isiterable, loop
 from django_boost.utils.attribute import (getattr_chain, getattrs,
                                           hasattr_chain, hasattrs)
-from django_boost.utils.functions import loopfirst, loopfirstlast, looplast
 
 
 class TestUtilFunction(TestCase):
-
-    test_list0 = []
-    test_list1 = [0]
-    test_list2 = [0, 1]
-    test_list3 = [0, 1, 2]
-
-    def test_loopfirst(self):
-        collect = [True, False, False]
-        for is_first, v in loopfirst(self.test_list0):
-            self.assertEqual(collect[v], is_first)
-        for is_first, v in loopfirst(self.test_list1):
-            self.assertEqual(collect[v], is_first)
-        for is_first, v in loopfirst(self.test_list2):
-            self.assertEqual(collect[v], is_first)
-        for is_first, v in loopfirst(self.test_list3):
-            self.assertEqual(collect[v], is_first)
-
-    def test_looplast(self):
-        for is_last, v in looplast(self.test_list0):
-            self.assertEqual([True][v], is_last)
-        for is_last, v in looplast(self.test_list1):
-            self.assertEqual([True][v], is_last)
-        for is_last, v in looplast(self.test_list2):
-            self.assertEqual([False, True][v], is_last)
-        for is_last, v in looplast(self.test_list3):
-            self.assertEqual([False, False, True][v], is_last)
-
-    def test_loopfirstlast(self):
-        for is_first_or_last, v in loopfirstlast(self.test_list0):
-            self.assertEqual([True][v], is_first_or_last)
-        for is_first_or_last, v in loopfirstlast(self.test_list1):
-            self.assertEqual([True][v], is_first_or_last)
-        for is_first_or_last, v in loopfirstlast(self.test_list2):
-            self.assertEqual([True, True][v], is_first_or_last)
-        for is_first_or_last, v in loopfirstlast(self.test_list3):
-            self.assertEqual([True, False, True][v], is_first_or_last)
 
     def test_isiterable(self):
         self.assertTrue(isiterable(range(1)))

--- a/tests/tests/utils/functions/test_loop.py
+++ b/tests/tests/utils/functions/test_loop.py
@@ -1,0 +1,41 @@
+from django_boost.test import TestCase
+from django_boost.utils.functions.loop import loopfirst, loopfirstlast, looplast
+
+
+class LoopFunctionTests(TestCase):
+
+    test_list0 = []
+    test_list1 = [0]
+    test_list2 = [0, 1]
+    test_list3 = [0, 1, 2]
+
+    def test_loopfirst(self):
+        collect = [True, False, False]
+        for is_first, v in loopfirst(self.test_list0):
+            self.assertEqual(collect[v], is_first)
+        for is_first, v in loopfirst(self.test_list1):
+            self.assertEqual(collect[v], is_first)
+        for is_first, v in loopfirst(self.test_list2):
+            self.assertEqual(collect[v], is_first)
+        for is_first, v in loopfirst(self.test_list3):
+            self.assertEqual(collect[v], is_first)
+
+    def test_looplast(self):
+        for is_last, v in looplast(self.test_list0):
+            self.assertEqual([True][v], is_last)
+        for is_last, v in looplast(self.test_list1):
+            self.assertEqual([True][v], is_last)
+        for is_last, v in looplast(self.test_list2):
+            self.assertEqual([False, True][v], is_last)
+        for is_last, v in looplast(self.test_list3):
+            self.assertEqual([False, False, True][v], is_last)
+
+    def test_loopfirstlast(self):
+        for is_first_or_last, v in loopfirstlast(self.test_list0):
+            self.assertEqual([True][v], is_first_or_last)
+        for is_first_or_last, v in loopfirstlast(self.test_list1):
+            self.assertEqual([True][v], is_first_or_last)
+        for is_first_or_last, v in loopfirstlast(self.test_list2):
+            self.assertEqual([True, True][v], is_first_or_last)
+        for is_first_or_last, v in loopfirstlast(self.test_list3):
+            self.assertEqual([True, False, True][v], is_first_or_last)


### PR DESCRIPTION
Annotate loopfirst / looplast / loopfirstlast with a TypeVar: loopfirst takes
Iterable[_T] (it only iterates), while looplast / loopfirstlast take Sequence[_T]
(they call len()); all yield Iterator[tuple[bool, _T]]. Register the module in
mypy.ini's TYPED-MODULE REGISTRY. Driven test-first (no-untyped-def + a failing
assert_type contract red->green); mypy-green with and without the django-stubs
plugin; the moved loop tests stay green.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
