### PR TITLE
🐛 Fix urldecode template filter marking output as safe 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `django_boost.admin.sites.register_all` now registers Django model classes correctly when scanning a models module.
 - The `next` template filter now works for iterators without a supplied default value.
 - `django_boost.forms.UserCreationForm` now preserves Django's `UsernameField` behavior for the active user model identifier field.
-- `django_boost.utils.functions.model_to_json` no longer raises `AttributeError` when given a `QuerySet`; it returns a list of dicts as documented.
+- `django_boost.utils.functions.model_to_json` no longer raises `AttributeError` when given a `QuerySet`.
+- The `urldecode` template filter's output is now auto-escaped instead of being treated as safe HTML.
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/templatetags/boost_url.py
+++ b/django_boost/templatetags/boost_url.py
@@ -17,7 +17,7 @@ def urlencode(value, arg="/"):
     return parse.quote(value, safe=arg)
 
 
-@register.filter(name="urldecode", is_safe=True)
+@register.filter(name="urldecode")
 def urldecode(value):
     return parse.unquote(value)
 

--- a/tests/tests/templatetags/test_boost_url.py
+++ b/tests/tests/templatetags/test_boost_url.py
@@ -24,6 +24,14 @@ class TestBoostUrlTemplateTag(TestCase):
         for a, e in cases:
             self.assertEqual(urldecode(a), e)
 
+    def test_urldecode_output_is_escaped_in_autoescaped_template(self):
+        from django.template import Context, Template
+        from django.utils.safestring import mark_safe
+
+        template = Template("{% load boost_url %}{{ value|urldecode }}")
+        output = template.render(Context({"value": mark_safe("%3Cscript%3E")}))
+        self.assertEqual(output, "&lt;script&gt;")
+
     def test_replace_parameters(self):
         from django_boost.templatetags.boost_url import replace_parameters
 

--- a/tests/tests/templatetags/test_boost_url.py
+++ b/tests/tests/templatetags/test_boost_url.py
@@ -3,7 +3,7 @@ from django.test.client import RequestFactory
 from django_boost.test import TestCase
 
 
-class TestBoostUrlTemplateTag(TestCase):
+class UrlencodeFilterTests(TestCase):
 
     def test_urlencode(self):
         from django_boost.templatetags.boost_url import urlencode
@@ -13,6 +13,9 @@ class TestBoostUrlTemplateTag(TestCase):
         ]
         for a, e in cases:
             self.assertEqual(urlencode(a), e)
+
+
+class UrldecodeFilterTests(TestCase):
 
     def test_urldecode(self):
         from django_boost.templatetags.boost_url import urldecode
@@ -32,6 +35,20 @@ class TestBoostUrlTemplateTag(TestCase):
         output = template.render(Context({"value": mark_safe("%3Cscript%3E")}))
         self.assertEqual(output, "&lt;script&gt;")
 
+    def test_urldecode_output_is_raw_when_autoescape_off(self):
+        from django.template import Context, Template
+        from django.utils.safestring import mark_safe
+
+        template = Template(
+            "{% load boost_url %}"
+            "{% autoescape off %}{{ value|urldecode }}{% endautoescape %}"
+        )
+        output = template.render(Context({"value": mark_safe("%3Cscript%3E")}))
+        self.assertEqual(output, "<script>")
+
+
+class ReplaceParametersTagTests(TestCase):
+
     def test_replace_parameters(self):
         from django_boost.templatetags.boost_url import replace_parameters
 
@@ -50,6 +67,9 @@ class TestBoostUrlTemplateTag(TestCase):
         with self.assertRaisesRegex(LookupError, "must be even"):
             request = factory.request()
             replace_parameters(request, 'q')
+
+
+class GetQuerystringTagTests(TestCase):
 
     def test_get_querystring(self):
         from django_boost.templatetags.boost_url import get_querystring


### PR DESCRIPTION
The urldecode filter was registered with is_safe=True, so a SafeData
input made its percent-decoded result safe too — letting encoded markup
(e.g. %3Cscript%3E) render raw and bypass autoescaping. Drop is_safe so
decoded output is escaped like any other untrusted text.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
