### PR TITLE
:label: Type the utils package helpers (Loop, loop, isiterable, contain_any)

### DIFF
--- a/django_boost/utils/__init__.py
+++ b/django_boost/utils/__init__.py
@@ -1,17 +1,30 @@
 from __future__ import annotations
 
+from collections.abc import Container, Iterable, Iterator, Sequence
+from typing import TypeGuard, TypeVar
 
-class Loop:
+_T = TypeVar("_T")
+
+
+class Loop(Iterator[tuple["Loop[_T]", _T]]):
     """Django template like loop object."""
 
-    def __init__(self, iterable):
+    # Per-iteration state; only valid after the first __next__ call.
+    counter0: int
+    counter: int
+    revcounter: int
+    revcounter0: int
+    first: bool
+    last: bool
+
+    def __init__(self, iterable: Sequence[_T]) -> None:
         self.iterable = enumerate(iterable)
         self.length = len(iterable)
 
-    def __iter__(self):
+    def __iter__(self) -> Loop[_T]:
         return self
 
-    def __next__(self):
+    def __next__(self) -> tuple[Loop[_T], _T]:
         i, item = next(self.iterable)
         # Shortcuts for current loop iteration number.
         self.counter0 = i
@@ -25,26 +38,23 @@ class Loop:
         return self, item
 
 
-def loop(iterable):
+def loop(iterable: Sequence[_T]) -> Loop[_T]:
     """Provides features such as Django template like loop."""
     return Loop(iterable)
 
 
-def isiterable(obj):
+def isiterable(obj: object) -> TypeGuard[Iterable[object]]:
     """Return `True` if `obj` is iterable object, `False` otherwise."""
     try:
-        iter(obj)
+        iter(obj)  # type: ignore[call-overload]  # probe iterability of an arbitrary object
     except TypeError:
         return False
     return True
 
 
-def contain_any(iterable, elements):
+def contain_any(container: Container[object], elements: Iterable[object]) -> bool:
     """
-    Return `True` if any of the `elements` are contained in the `iterable`,
+    Return `True` if any of the `elements` are contained in `container`,
     `False` otherwise.
     """
-    for e in elements:
-        if e in iterable:
-            return True
-    return False
+    return any(e in container for e in elements)

--- a/mypy.ini
+++ b/mypy.ini
@@ -67,6 +67,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.utils]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 # example/ is a development harness, but keep it type-checked so the sample app
 # continues to compile against django-boost's public APIs. Tests and migrations
 # are excluded above.

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -152,6 +152,9 @@ class TestHTMLSpaceLessCompressor(TestCase):
 
 
 class TestContainAny(TestCase):
+    # No generator case: a one-shot iterator would be consumed by the `in`
+    # membership loop and give wrong answers, so contain_any's Container
+    # annotation rejects it at type-check time instead.
 
     def test_contain_any(self):
         from django_boost.utils import contain_any
@@ -161,6 +164,21 @@ class TestContainAny(TestCase):
         self.assertTrue(contain_any(sequence, [0]))
         self.assertFalse(contain_any(sequence, [10]))
         self.assertTrue(contain_any(sequence, [10, 7]))
+
+    def test_contain_any_container_types(self):
+        from django_boost.utils import contain_any
+
+        self.assertTrue(contain_any([1, 2, 3], [3, 9]))
+        self.assertTrue(contain_any({1, 2, 3}, [9, 2]))
+        self.assertTrue(contain_any({"a": 1, "b": 2}, ["b"]))
+        self.assertTrue(contain_any("hello", ["x", "e"]))
+        self.assertFalse(contain_any((1, 2, 3), [4, 5]))
+
+    def test_contain_any_empty(self):
+        from django_boost.utils import contain_any
+
+        self.assertFalse(contain_any([1, 2, 3], []))
+        self.assertFalse(contain_any([], [1, 2]))
 
 
 class TestVersion(TestCase):


### PR DESCRIPTION
Annotate django_boost/utils/__init__.py and register it in mypy.ini's TYPED-MODULE REGISTRY. Loop subclasses Iterator[tuple[Loop[_T], _T]] (so it is generic in _T and mypy enforces the iterator protocol) and declares its per-iteration counter attributes (counter/counter0/revcounter/revcounter0/ first/last); __next__ yields tuple[Loop[_T], _T]; loop returns Loop[_T].

isiterable is a TypeGuard[Iterable[object]], so a true result narrows the argument for callers; it keeps a scoped # type: ignore[call-overload] because it deliberately calls iter() on an arbitrary object to probe iterability.

contain_any takes Container[object] (not Iterable[Any]): the haystack is only used with `in`, so requiring __contains__ both is precise and rejects one-shot iterators -- which the membership loop would consume, yielding wrong answers -- at type-check time. elements stays Iterable[object].

TestContainAny gains Container-contract coverage (list/set/dict/str/tuple and empty cases); TestLoop and isiterable tests stay green. mypy-green; flake8 clean.

Refs: https://github.com/ChanTsune/django-boost/issues/164

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
