### PR TITLE
:bug: Fix ColorCodeField crashing on None with upper/lower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `django_boost.forms.UserCreationForm` now preserves Django's `UsernameField` behavior for the active user model identifier field.
 - `django_boost.utils.functions.model_to_json` no longer raises `AttributeError` when given a `QuerySet`.
 - The `urldecode` template filter's output is now auto-escaped instead of being treated as safe HTML.
+- The `upper`/`lower` option of `ColorCodeField` no longer raises `AttributeError` on a `None` value.
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/models/fields/__init__.py
+++ b/django_boost/models/fields/__init__.py
@@ -34,10 +34,10 @@ class ColorCodeField(CharField):
         super().__init__(*args, **kwargs)
 
     def _upper_convert(self, value):
-        return value.upper()
+        return value.upper() if value is not None else value
 
     def _lower_convert(self, value):
-        return value.lower()
+        return value.lower() if value is not None else value
 
     def _no_convert(self, value):
         return value

--- a/tests/tests/models/test_fields.py
+++ b/tests/tests/models/test_fields.py
@@ -12,6 +12,12 @@ class ColorCodeFieldTests(SimpleTestCase):
         with self.assertRaises(AssertionError):
             ColorCodeField(upper=True, lower=True)
 
+    def test_upper_keeps_none(self):
+        self.assertIsNone(ColorCodeField(upper=True).to_python(None))
+
+    def test_lower_keeps_none(self):
+        self.assertIsNone(ColorCodeField(lower=True).to_python(None))
+
 
 class ColorCodeFiledDeprecationTests(SimpleTestCase):
     """`ColorCodeFiled` is the misspelled, deprecated alias of `ColorCodeField`."""


### PR DESCRIPTION
The upper=/lower= converters called value.upper()/value.lower() unconditionally, so a None value (e.g. saving or cleaning a nullable column) raised AttributeError instead of passing through. Guard None in both converters.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
