### PR TITLE
:label: Type the core package helpers (get_version, is_empty)

### DIFF
--- a/django_boost/core/__init__.py
+++ b/django_boost/core/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from django_boost import __version__ as VERSION
 
 
-def get_version():
+def get_version() -> str:
     return VERSION
 
 
@@ -14,5 +14,5 @@ class Empty:
 EMPTY = Empty()
 
 
-def is_empty(obj):
+def is_empty(obj: object) -> bool:
     return isinstance(obj, Empty)

--- a/mypy.ini
+++ b/mypy.ini
@@ -73,6 +73,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.core]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 # example/ is a development harness, but keep it type-checked so the sample app
 # continues to compile against django-boost's public APIs. Tests and migrations
 # are excluded above.


### PR DESCRIPTION
Annotate django_boost/core/__init__.py (get_version -> str; is_empty(obj: object) -> bool) and register it in mypy.ini's TYPED-MODULE REGISTRY. The Empty sentinel class has no methods to annotate. Driven test-first (no-untyped-def + assert_type contract red->green); mypy-green with and without the django-stubs plugin; is_empty stays covered by TestAttribute's default-sentinel paths.

Refs: https://github.com/ChanTsune/django-boost/issues/164

Checklist - While not every PR needs it, new features should consider this list:  

- [ ] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
