### PR TITLE
:label: Type the database router (db.router)

### DIFF
--- a/django_boost/db/router.py
+++ b/django_boost/db/router.py
@@ -1,29 +1,34 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS
+from django.db.models import Model
 
 
 class DatabaseRouter:
     """Route Django apps to database aliases from DATABASE_APPS_MAPPING."""
 
-    def __init__(self):
-        self.db_map = getattr(settings, "DATABASE_APPS_MAPPING", {})
+    def __init__(self) -> None:
+        self.db_map: dict[str, str] = getattr(
+            settings, "DATABASE_APPS_MAPPING", {})
 
-    def db_for_read(self, model, **hints):
+    def db_for_read(self, model: type[Model], **hints: Any) -> str | None:
         return self.db_map.get(model._meta.app_label, None)
 
-    def db_for_write(self, model, **hints):
+    def db_for_write(self, model: type[Model], **hints: Any) -> str | None:
         return self.db_map.get(model._meta.app_label, None)
 
-    def allow_relation(self, obj1, obj2, **hints):
+    def allow_relation(self, obj1: Model, obj2: Model, **hints: Any) -> bool | None:
         db1 = self.db_map.get(obj1._meta.app_label)
         db2 = self.db_map.get(obj2._meta.app_label)
         if db1 and db2:
             return db1 == db2
         return None
 
-    def allow_migrate(self, db, app_label, model=None, **hints):
+    def allow_migrate(self, db: str, app_label: str, model: Any = None,
+                      **hints: Any) -> bool | None:
         if app_label in self.db_map:
             return self.db_map[app_label] == db
         if db != DEFAULT_DB_ALIAS and db in self.db_map.values():

--- a/mypy.ini
+++ b/mypy.ini
@@ -79,6 +79,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.db.router]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 # example/ is a development harness, but keep it type-checked so the sample app
 # continues to compile against django-boost's public APIs. Tests and migrations
 # are excluded above.


### PR DESCRIPTION
First Tier B (Django-boundary) module. Annotate DatabaseRouter: db_for_read/db_for_write(model: type[Model]) -> str | None, allow_relation(obj1, obj2: Model) -> bool | None, allow_migrate -> bool | None, and pin db_map to dict[str, str] so the Any from settings.DATABASE_APPS_MAPPING doesn't bleed into the return types. Relies on django-stubs (model._meta.app_label is only typed with the plugin), so unlike the pure Tier A modules there is no meaningful plugin-less control; verification is mypy-green with the plugin plus the existing router tests. Driven test-first (no-untyped-def + assert_type contract red->green).

Refs: https://github.com/ChanTsune/django-boost/issues/164

Checklist - While not every PR needs it, new features should consider this list:  

- [ ] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
