### PR TITLE
✨ Forward msg and hide helper frames in assertStatusCode* 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `iter`, `list`, `dict`, `set`, `tuple` and `frozenset` filters in the
   `boost` template library, exposing the corresponding Python built-ins.
+- `django_boost.test.TestCase`'s `assertStatusCode*` assertions now accept an optional `msg` argument, forwarded to the underlying assertion.
 
 ### Deprecated
 
@@ -28,6 +29,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `django_boost.utils.functions.model_to_json` no longer raises `AttributeError` when given a `QuerySet`.
 - The `urldecode` template filter's output is now auto-escaped instead of being treated as safe HTML.
 - The `upper`/`lower` option of `ColorCodeField` no longer raises `AttributeError` on a `None` value.
+- `django_boost.test.TestCase`'s `assertStatusCode*` failures now point at the calling test instead of the assertion helper.
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/test/testcase.py
+++ b/django_boost/test/testcase.py
@@ -5,14 +5,22 @@ from collections.abc import Iterable
 from django.http.response import HttpResponseBase
 from django.test import TestCase as DjangoTestCase
 
+# Hide this module's frames from assertion tracebacks (the convention unittest
+# itself uses in unittest/case.py) so a failed assertStatusCode* points at the
+# calling test rather than at these helpers.
+__unittest = True
+
 
 class TestCase(DjangoTestCase):
 
-    def assertStatusCodeEqual(self, response: HttpResponseBase, code: int) -> None:
-        self.assertEqual(response.status_code, code)
+    def assertStatusCodeEqual(self, response: HttpResponseBase, code: int,
+                              msg: object = None) -> None:
+        self.assertEqual(response.status_code, code, msg)
 
-    def assertStatusCodeNotEqual(self, response: HttpResponseBase, code: int) -> None:
-        self.assertNotEqual(response.status_code, code)
+    def assertStatusCodeNotEqual(self, response: HttpResponseBase, code: int,
+                                 msg: object = None) -> None:
+        self.assertNotEqual(response.status_code, code, msg)
 
-    def assertStatusCodeIn(self, response: HttpResponseBase, codes: Iterable[int]) -> None:
-        self.assertIn(response.status_code, codes)
+    def assertStatusCodeIn(self, response: HttpResponseBase,
+                           codes: Iterable[int], msg: object = None) -> None:
+        self.assertIn(response.status_code, codes, msg)

--- a/django_boost/test/testcase.py
+++ b/django_boost/test/testcase.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+
+from django.http.response import HttpResponseBase
 from django.test import TestCase as DjangoTestCase
 
 
 class TestCase(DjangoTestCase):
 
-    def assertStatusCodeEqual(self, response, code):
+    def assertStatusCodeEqual(self, response: HttpResponseBase, code: int) -> None:
         self.assertEqual(response.status_code, code)
 
-    def assertStatusCodeNotEqual(self, response, code):
+    def assertStatusCodeNotEqual(self, response: HttpResponseBase, code: int) -> None:
         self.assertNotEqual(response.status_code, code)
 
-    def assertStatusCodeIn(self, response, codes):
+    def assertStatusCodeIn(self, response: HttpResponseBase, codes: Iterable[int]) -> None:
         self.assertIn(response.status_code, codes)

--- a/mypy.ini
+++ b/mypy.ini
@@ -91,6 +91,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.test.testcase]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 # example/ is a development harness, but keep it type-checked so the sample app
 # continues to compile against django-boost's public APIs. Tests and migrations
 # are excluded above.

--- a/tests/tests/test/test_testcase.py
+++ b/tests/tests/test/test_testcase.py
@@ -1,0 +1,31 @@
+import unittest
+
+from django.http import HttpResponse
+
+from django_boost.test import TestCase
+
+
+class AssertStatusCodeTests(TestCase):
+
+    def test_custom_msg_appears_in_failure(self):
+        with self.assertRaises(AssertionError) as cm:
+            self.assertStatusCodeEqual(HttpResponse(status=404), 200,
+                                       msg="custom note")
+        self.assertIn("custom note", str(cm.exception))
+
+    def test_not_equal_custom_msg_appears_in_failure(self):
+        with self.assertRaises(AssertionError) as cm:
+            self.assertStatusCodeNotEqual(HttpResponse(status=200), 200,
+                                          msg="custom note")
+        self.assertIn("custom note", str(cm.exception))
+
+    def test_helper_frame_hidden_from_failure_traceback(self):
+        class Inner(TestCase):
+            def runTest(inner):
+                inner.assertStatusCodeEqual(HttpResponse(status=404), 200)
+
+        result = unittest.TestResult()
+        Inner().run(result)
+        self.assertEqual(len(result.failures), 1)
+        formatted = result.failures[0][1]
+        self.assertNotIn("in assertStatusCodeEqual", formatted)


### PR DESCRIPTION
Make django_boost.test.TestCase's assertStatusCode* helpers behave like
first-class unittest assertions:
- accept an optional msg, forwarded to the underlying assertEqual /
  assertNotEqual / assertIn (so a custom message is appended via unittest's
  longMessage), and
- set module-level __unittest = True so a failed assertion's traceback points
  at the calling test instead of these helpers (the frame-hiding convention
  unittest uses in unittest/case.py).

Driven test-first: a custom msg now appears in the failure text, and the helper
frame no longer leaks into the formatted failure traceback.
Checklist - While not every PR needs it, new features should consider this list:  

- [ ] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
