### PR TITLE
:bug: improve auth form compatibility for custom user models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `django_boost.admin.sites.register_all` now registers Django model classes correctly when scanning a models module.
 - The `next` template filter now works for iterators without a supplied default value.
 - `django_boost.forms.UserCreationForm` now preserves Django's `UsernameField` behavior for the active user model identifier field.
+- `django_boost.forms.UserChangeForm` and `django_boost.forms.AuthenticationForm` now expose Django-compatible `UsernameField` behavior for custom user models.
 - `django_boost.utils.functions.model_to_json` no longer raises `AttributeError` when given a `QuerySet`.
 - The `urldecode` template filter's output is now auto-escaped instead of being treated as safe HTML.
 - The `upper`/`lower` option of `ColorCodeField` no longer raises `AttributeError` on a `None` value.

--- a/django_boost/admin/__init__.py
+++ b/django_boost/admin/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 
-from django_boost.forms import UserCreationForm
+from django_boost.forms import UserChangeForm, UserCreationForm
 from django_boost.models import EmailUser
 
 from .mixins import LogicalDeletionModelAdminMixin
@@ -17,6 +17,7 @@ __all__ = ["EmailUserAdmin",
 @admin.register(EmailUser)
 class EmailUserAdmin(UserAdmin):
     add_form = UserCreationForm
+    form = UserChangeForm
     add_fieldsets = (
         (None, {
             'classes': ('wide',),

--- a/django_boost/forms/__init__.py
+++ b/django_boost/forms/__init__.py
@@ -1,17 +1,27 @@
 from __future__ import annotations
 
+from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import (
+    AuthenticationForm as BaseAuthenticationForm,
+    UserChangeForm as BaseUserChangeForm,
     UserCreationForm as BaseUserCreationForm,
     UsernameField,
 )
+from django.utils.translation import gettext_lazy as _
 
 from django_boost.forms.fields import ColorCodeField
 from django_boost.forms.mixins import FormUserKwargsMixin
 from django_boost.forms.widgets import ColorInput
 
-__all__ = ("ColorCodeField", "ColorInput", "FormUserKwargsMixin",
-           "UserCreationForm")
+__all__ = (
+    "AuthenticationForm",
+    "ColorCodeField",
+    "ColorInput",
+    "FormUserKwargsMixin",
+    "UserChangeForm",
+    "UserCreationForm",
+)
 
 
 class UserCreationForm(BaseUserCreationForm):
@@ -26,3 +36,31 @@ class UserCreationForm(BaseUserCreationForm):
         field_classes = {
             model.USERNAME_FIELD: UsernameField,
         }
+
+
+class UserChangeForm(BaseUserChangeForm):
+    """
+    A form for changing an existing user, using the active user model's
+    ``USERNAME_FIELD``.
+    """
+
+    class Meta(BaseUserChangeForm.Meta):
+        model = get_user_model()
+        fields = "__all__"
+        field_classes = {
+            model.USERNAME_FIELD: UsernameField,
+        }
+
+
+class AuthenticationForm(BaseAuthenticationForm):
+    """
+    A form for authenticating a user with the active user model's
+    ``USERNAME_FIELD``.
+    """
+
+    username = UsernameField(widget=forms.TextInput(attrs={"autofocus": True}))
+    password = forms.CharField(
+        label=_("Password"),
+        strip=False,
+        widget=forms.PasswordInput(attrs={"autocomplete": "current-password"}),
+    )

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -8,3 +8,13 @@ UserCreationForm
 -----------------
 
 .. autoclass:: django_boost.forms.UserCreationForm
+
+UserChangeForm
+--------------
+
+.. autoclass:: django_boost.forms.UserChangeForm
+
+AuthenticationForm
+------------------
+
+.. autoclass:: django_boost.forms.AuthenticationForm

--- a/tests/tests/forms/tests.py
+++ b/tests/tests/forms/tests.py
@@ -35,3 +35,31 @@ class FormTest(TestCase):
         self.assertEqual(user.email, 'created@sample.com')
         self.assertTrue(
             get_user_model().objects.filter(email='created@sample.com').exists())
+
+    def test_user_change_form_uses_usernamefield_for_identifier(self):
+        from django.contrib.auth import get_user_model
+        from django.contrib.auth.forms import UsernameField
+        from django_boost.forms import UserChangeForm
+
+        form = UserChangeForm()
+        identifier_field = get_user_model().USERNAME_FIELD
+
+        self.assertIn(identifier_field, form.fields)
+        self.assertIsInstance(form.fields[identifier_field], UsernameField)
+
+    def test_authentication_form_uses_usernamefield_for_identifier(self):
+        from django.contrib.auth.forms import UsernameField
+        from django_boost.forms import AuthenticationForm
+
+        form = AuthenticationForm()
+
+        self.assertIn('username', form.fields)
+        self.assertIsInstance(form.fields['username'], UsernameField)
+        self.assertEqual(
+            form.fields['username'].widget.attrs['autocapitalize'],
+            'none',
+        )
+        self.assertEqual(
+            form.fields['username'].widget.attrs['autocomplete'],
+            'username',
+        )


### PR DESCRIPTION
Expose Django-compatible UserChangeForm and AuthenticationForm wrappers for custom USERNAME_FIELD values and add regression tests.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [x] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
