### PR TITLE
:label: Type the attribute helpers (utils/attribute)

### DIFF
--- a/django_boost/utils/attribute.py
+++ b/django_boost/utils/attribute.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django_boost.core import EMPTY, is_empty
 
 
-def getattrs(obj, *names, default=EMPTY):
+def getattrs(obj: object, *names: str, default: Any = EMPTY) -> tuple[Any, ...]:
     """Get multiple attributes."""
     if is_empty(default):
         return tuple(getattr(obj, name) for name in names)
     return tuple(getattr(obj, name, default) for name in names)
 
 
-def getattr_chain(obj, name, default=EMPTY):
+def getattr_chain(obj: object, name: str, default: Any = EMPTY) -> Any:
     """
     Get attribute.
 
@@ -29,7 +31,7 @@ def getattr_chain(obj, name, default=EMPTY):
         return default
 
 
-def hasattrs(obj, *names):
+def hasattrs(obj: object, *names: str) -> bool:
     """Check if obj has all attribute names given in the argument."""
     try:
         getattrs(obj, *names)
@@ -38,7 +40,7 @@ def hasattrs(obj, *names):
         return False
 
 
-def hasattr_chain(obj, name):
+def hasattr_chain(obj: object, name: str) -> bool:
     """
     Check if obj have an attribute named.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -97,6 +97,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.utils.attribute]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 # example/ is a development harness, but keep it type-checked so the sample app
 # continues to compile against django-boost's public APIs. Tests and migrations
 # are excluded above.


### PR DESCRIPTION
Annotate getattrs / getattr_chain / hasattrs / hasattr_chain (obj: object, str names, getattr-based results kept as Any) and register the module in mypy.ini's TYPED-MODULE REGISTRY. Driven test-first: no-untyped-def + a failing assert_type contract drove it red->green; mypy-green with and without the django-stubs plugin (no Django dependency); TestAttribute stays green.

Refs: https://github.com/ChanTsune/django-boost/issues/164

Checklist - While not every PR needs it, new features should consider this list:  

- [ ] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
