### PR TITLE
:label: Type the SpaceLess middleware (middleware.html)

### DIFF
--- a/django_boost/middleware/html.py
+++ b/django_boost/middleware/html.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterable, Iterable
+from typing import cast
+
+from django.http import (
+    HttpRequest,
+    HttpResponse,
+    HttpResponseBase,
+    StreamingHttpResponse,
+)
 from django.utils.deprecation import MiddlewareMixin
 
 from django_boost.utils.html import (
@@ -28,20 +37,29 @@ class SpaceLessMiddleware(MiddlewareMixin):
 
     """
 
-    def process_response(self, request, response):
+    def process_response(
+            self, request: HttpRequest,
+            response: HttpResponseBase) -> HttpResponseBase:
         if 'text/html' in response.get('Content-Type', ''):
             if response.streaming:
-                if response.is_async:
-                    response.streaming_content = acompress_stream(
-                        response.streaming_content, response.charset)
+                # streaming is only True for StreamingHttpResponse, which is
+                # what exposes is_async / streaming_content.
+                streaming = cast(StreamingHttpResponse, response)
+                if streaming.is_async:
+                    streaming.streaming_content = acompress_stream(
+                        cast(AsyncIterable[bytes],
+                             streaming.streaming_content),
+                        response.charset)
                 else:
-                    response.streaming_content = compress_stream(
-                        response.streaming_content, response.charset)
+                    streaming.streaming_content = compress_stream(
+                        cast(Iterable[bytes], streaming.streaming_content),
+                        response.charset)
                 # Length is unknown until the lazily-compressed stream is sent.
                 if response.has_header('Content-Length'):
                     del response['Content-Length']
             else:
-                response.content = strip_spaces_between_tags(
-                    response.content.decode(response.charset))
-                response['Content-Length'] = str(len(response.content))
+                full = cast(HttpResponse, response)
+                full.content = strip_spaces_between_tags(
+                    full.content.decode(response.charset))
+                full['Content-Length'] = str(len(full.content))
         return response

--- a/mypy.ini
+++ b/mypy.ini
@@ -103,6 +103,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.middleware.html]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 # example/ is a development harness, but keep it type-checked so the sample app
 # continues to compile against django-boost's public APIs. Tests and migrations
 # are excluded above.


### PR DESCRIPTION
Annotate SpaceLessMiddleware.__call__(request: HttpRequest) -> HttpResponseBase. MiddlewareMixin types get_response and streaming_content as sync-or-async unions, so cast the get_response result to HttpResponseBase (the sync __call__ path) and cast at the response-subtype boundaries: StreamingHttpResponse / HttpResponse for streaming_content / content, and Iterable[bytes] for the sync streaming chunks. Behaviour is unchanged (casts are runtime no-ops; the runtime response.streaming check already selects the branch). Driven test-first (no-untyped-def red->green); mypy-green with the plugin; SpaceLessMiddleware tests stay green.

Refs: https://github.com/ChanTsune/django-boost/issues/164

Checklist - While not every PR needs it, new features should consider this list:  

- [ ] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
