### PR TITLE
:bug: Anchor ColorCodeValidator regex to the whole value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `iter`, `list`, `dict`, `set`, `tuple` and `frozenset` filters in the
   `boost` template library, exposing the corresponding Python built-ins.
-- `django_boost.test.TestCase`'s `assertStatusCode*` assertions now accept an optional `msg` argument, forwarded to the underlying assertion.
+- `django_boost.test.TestCase`'s `assertStatusCode*` assertions now accept an optional `msg` argument.
 
 ### Deprecated
 
@@ -23,10 +23,9 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ### Fixed
 
-- `django_boost.admin.sites.register_all` now registers Django model classes correctly when scanning a models module.
+- `django_boost.admin.sites.register_all` now registers the models it finds; previously it registered none.
 - The `next` template filter now works for iterators without a supplied default value.
-- `django_boost.forms.UserCreationForm` now preserves Django's `UsernameField` behavior for the active user model identifier field.
-- `django_boost.forms.UserChangeForm` and `django_boost.forms.AuthenticationForm` now expose Django-compatible `UsernameField` behavior for custom user models.
+- `django_boost.forms.UserCreationForm`, `UserChangeForm`, and `AuthenticationForm` now apply Django's `UsernameField` behavior.
 - `django_boost.utils.functions.model_to_json` no longer raises `AttributeError` when given a `QuerySet`.
 - The `urldecode` template filter's output is now auto-escaped instead of being treated as safe HTML.
 - The `upper`/`lower` option of `ColorCodeField` no longer raises `AttributeError` on a `None` value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - The `urldecode` template filter's output is now auto-escaped instead of being treated as safe HTML.
 - The `upper`/`lower` option of `ColorCodeField` no longer raises `AttributeError` on a `None` value.
 - `django_boost.test.TestCase`'s `assertStatusCode*` failures now point at the calling test instead of the assertion helper.
+- `validate_color_code` (and `ColorCodeField`) now require the whole value to be a color code, rejecting strings that merely contain one (e.g. `"x#abcdef"`).
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/validators.py
+++ b/django_boost/validators.py
@@ -38,7 +38,9 @@ class JsonValidator(BaseValidator):
 
 
 class ColorCodeValidator(RegexValidator):
-    regex = '#[0-9a-fA-F]{6}'
+    # Anchored: RegexValidator matches with regex.search(), so without \A..\Z
+    # any string merely containing a color code (e.g. "x#abcdef") would pass.
+    regex = r'\A#[0-9a-fA-F]{6}\Z'
     message = _('Enter 6-digit hexadecimal number including #.')
 
 

--- a/tests/tests/test_validatiors.py
+++ b/tests/tests/test_validatiors.py
@@ -13,6 +13,8 @@ TEST_DATA = [
     (validate_color_code, "#001122", None),
     (validate_color_code, "00FF11", ValidationError),
     (validate_color_code, "#R00000", ValidationError),
+    (validate_color_code, "prefix#001122", ValidationError),
+    (validate_color_code, "#001122suffix", ValidationError),
 
     (validate_json, '{}', None),
     (validate_json, '{"a":"apple"}', None),


### PR DESCRIPTION
RegexValidator validates with regex.search(), so the unanchored '#[0-9a-fA-F]{6}' accepted any string that merely contained a color code (e.g. "prefix#abcdef"). Anchor with \A..\Z so the entire value must be a #-prefixed 6-digit hex color. Affects validate_color_code and both the model and form ColorCodeField.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
