### PR TITLE
:bug: Fix int template filter crashing on numeric input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - The `upper`/`lower` option of `ColorCodeField` no longer raises `AttributeError` on a `None` value.
 - `django_boost.test.TestCase`'s `assertStatusCode*` failures now point at the calling test instead of the assertion helper.
 - `validate_color_code` (and `ColorCodeField`) now require the whole value to be a color code, rejecting strings that merely contain one (e.g. `"x#abcdef"`).
+- The `int` template filter now accepts numeric values (int/float).
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/templatetags/boost.py
+++ b/django_boost/templatetags/boost.py
@@ -130,7 +130,9 @@ def _id(obj):
 
 @register.filter(name="int")
 def _int(value, base=10):
-    return int(value, base)
+    if isinstance(value, (str, bytes, bytearray)):
+        return int(value, base)
+    return int(value)
 
 
 @register.filter(name="iter")

--- a/tests/tests/templatetags/test_boost.py
+++ b/tests/tests/templatetags/test_boost.py
@@ -138,6 +138,17 @@ class TestInt(TestCase):
 
         self.assertEqual(_int("10"), 10)
 
+    def test_converts_numeric_value(self):
+        from django_boost.templatetags.boost import _int
+
+        self.assertEqual(_int(5), 5)
+        self.assertEqual(_int(3.9), 3)
+
+    def test_uses_base_for_string(self):
+        from django_boost.templatetags.boost import _int
+
+        self.assertEqual(_int("ff", 16), 255)
+
 
 class TestLen(TestCase):
 


### PR DESCRIPTION
int(value, base) requires a string, so the filter raised TypeError for non-string input (e.g. {{ 5|int }}, a model IntegerField, a float). Pass base only for str/bytes and convert other values with int(value); the base-conversion feature for strings ({{ "ff"|int:16 }}) is preserved.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
