### PR TITLE
:bug: Fix ContainAnyValidator crashing when given a multi-element tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `django_boost.test.TestCase`'s `assertStatusCode*` failures now point at the calling test instead of the assertion helper.
 - `validate_color_code` (and `ColorCodeField`) now require the whole value to be a color code, rejecting strings that merely contain one (e.g. `"x#abcdef"`).
 - The `int` template filter now accepts numeric values (int/float).
+- `ContainAnyValidator` now raises `ValidationError` for invalid input when given multiple elements as a tuple.
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/validators.py
+++ b/django_boost/validators.py
@@ -56,7 +56,7 @@ class ContainAnyValidator(BaseValidator):
 
     def __call__(self, value: Any) -> None:
         if not contain_any(value, self.elements):
-            raise ValidationError(self.message % self.elements)
+            raise ValidationError(self.message % (self.elements,))
 
 
 json_validator = JsonValidator()

--- a/tests/tests/test_validatiors.py
+++ b/tests/tests/test_validatiors.py
@@ -29,6 +29,7 @@ TEST_DATA = [
     (ContainAnyValidator("1"), "123", None),
     (ContainAnyValidator("02"), "123", None),
     (ContainAnyValidator("4"), "123", ValidationError),
+    (ContainAnyValidator(("4", "5")), "123", ValidationError),
 ]
 
 


### PR DESCRIPTION
ContainAnyValidator(elements) formatted its error message with `self.message % self.elements`. A multi-element tuple is unpacked by %-formatting against the single %s, so validation failure raised TypeError instead of ValidationError. Wrap the operand in a 1-tuple.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
