### PR TITLE
:wastebasket: Deprecate validate_uuid4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
   `ListView`, `DetailView`, `UpdateView`, `DeleteView`) are deprecated and will
   be removed in django-boost 4.0. Use `django.views.generic.*`, and a
   `dispatch()` override or middleware in place of `after_view_process`.
+- `validate_uuid4` is deprecated and will be removed in django-boost 4.0.
+  Validate UUIDs with Django's `UUIDField` or `uuid.UUID` instead.
 
 ### Fixed
 

--- a/django_boost/validators.py
+++ b/django_boost/validators.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import uuid
+import warnings
 from collections.abc import Iterable
 from json.decoder import JSONDecodeError
 from typing import Any
@@ -68,6 +69,17 @@ def validate_json(value: str) -> None:
 
 
 def validate_uuid4(value: str) -> None:
+    """Deprecated UUID validator.
+
+    Raises a ``DeprecationWarning`` and will be removed in django-boost 4.0;
+    validate UUIDs with Django's ``UUIDField`` or :func:`uuid.UUID` instead.
+    """
+    warnings.warn(
+        "'validate_uuid4' is deprecated and will be removed in django-boost"
+        " 4.0; validate UUIDs with Django's 'UUIDField' or 'uuid.UUID' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     try:
         uuid_value = uuid.UUID(value)
     except ValueError as e:

--- a/tests/tests/test_validatiors.py
+++ b/tests/tests/test_validatiors.py
@@ -22,10 +22,6 @@ TEST_DATA = [
     (validate_json, "{'a':'apple'}", ValidationError),
     (validate_json, 1, TypeError),
 
-    (validate_uuid4, str(uuid4()), None),
-    (validate_uuid4, "59cF05e3-fb29-4be8-af18-da9c94b1964d", ValidationError),
-    (validate_uuid4, "5de21727-8c45-4380-a44d-adc370-e6288", ValidationError),
-
     (ContainAnyValidator("1"), "123", None),
     (ContainAnyValidator("02"), "123", None),
     (ContainAnyValidator("4"), "123", ValidationError),
@@ -57,3 +53,18 @@ class TestValidator(TestCase):
             with self.subTest(name, value=value):
                 with self.assertRaisesMessage(ValidationError, message):
                     validator(value)
+
+
+class ValidateUuid4Deprecation(TestCase):
+    """`validate_uuid4` is deprecated; removal is planned for django-boost 4.0."""
+
+    def test_warns_on_call(self):
+        with self.assertWarns(DeprecationWarning):
+            validate_uuid4(str(uuid4()))
+
+    def test_still_validates_under_warning(self):
+        with self.assertWarns(DeprecationWarning):
+            self.assertIsNone(validate_uuid4(str(uuid4())))
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(ValidationError):
+                validate_uuid4("not-a-uuid")


### PR DESCRIPTION
validate_uuid4 is unused inside the package, never verified version 4 despite its name, and wrongly rejected valid uppercase UUIDs. A UUID check is covered by Django's UUIDField or uuid.UUID, so deprecate it (DeprecationWarning) for removal in django-boost 4.0 rather than fixing behaviour nobody depends on.

Checklist - While not every PR needs it, new features should consider this list:  

- [ ] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
