### PR TITLE
:bug: Accept zero-padded dates in the date path converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `validate_color_code` (and `ColorCodeField`) now require the whole value to be a color code, rejecting strings that merely contain one (e.g. `"x#abcdef"`).
 - The `int` template filter now accepts numeric values (int/float).
 - `ContainAnyValidator` now raises `ValidationError` for invalid input when given multiple elements as a tuple.
+- The `date` path converter now accepts zero-padded dates (e.g. `2020/02/29`).
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/urls/converters/date.py
+++ b/django_boost/urls/converters/date.py
@@ -6,17 +6,17 @@ from typing import ClassVar
 REGEX_LEAP_YEAR = r"(([48](00)?)|(([2468][048]|[13579][26])(00)?)|([1-9][0-9]?(0[48]|[2468][048]|[13579][26])))"
 NON_ZERO_YEAR = r"[1-9]([0-9]){,3}"
 
-REGEX_MONTH_31 = r"([13578]|10|12)"
-REGEX_DAY_31 = r"([1-9]|[12][0-9]|3[01])"
+REGEX_MONTH_31 = r"(0?[13578]|10|12)"
+REGEX_DAY_31 = r"(0?[1-9]|[12][0-9]|3[01])"
 REGEX_DATE_31 = REGEX_MONTH_31 + "/" + REGEX_DAY_31
 
-REGEX_MONTH_30 = r"([469]|11)"
-REGEX_DAY_30 = r"([1-9]|[12][0-9]|30)"
+REGEX_MONTH_30 = r"(0?[469]|11)"
+REGEX_DAY_30 = r"(0?[1-9]|[12][0-9]|30)"
 REGEX_DATE_30 = REGEX_MONTH_30 + "/" + REGEX_DAY_30
 
-REGEX_MONTH_29 = REGEX_MONTH_28 = '2'
-REGEX_DAY_29 = r"([1-9]|[12][0-9])"
-REGEX_DAY_28 = r"([1-9]|1[0-9]|2[0-8])"
+REGEX_MONTH_29 = REGEX_MONTH_28 = r"0?2"
+REGEX_DAY_29 = r"(0?[1-9]|[12][0-9])"
+REGEX_DAY_28 = r"(0?[1-9]|1[0-9]|2[0-8])"
 
 REGEX_DATE_29 = REGEX_MONTH_29 + "/" + REGEX_DAY_29
 REGEX_DATE_28 = REGEX_MONTH_28 + "/" + REGEX_DAY_28
@@ -36,7 +36,7 @@ class DateConverter:
 
     def to_url(self, value: datetime | str) -> str:
         if isinstance(value, datetime):
-            return datetime.strftime(value, "%Y/%m/%d")
+            return f"{value.year}/{value.month}/{value.day}"
         return str(value)
 
     def to_python(self, value: datetime | str) -> datetime:

--- a/tests/tests/urls_converters/tests.py
+++ b/tests/tests/urls_converters/tests.py
@@ -53,6 +53,17 @@ class TestConverter(TestCase):
         with self.assertRaises(NoReverseMatch):
             reverse('date', kwargs={'date': '2019/2/29'})
 
+    def test_date_accepts_zero_padded(self):
+        response = self.client.get('/date/2020/02/29')
+        self.assertStatusCodeEqual(response, 200)
+
+    def test_date_reverses_datetime(self):
+        from datetime import datetime
+
+        url = reverse('date', kwargs={'date': datetime(2020, 1, 5)})
+        self.assertEqual(url, '/date/2020/1/5')
+        self.assertStatusCodeEqual(self.client.get(url), 200)
+
 
 class TestRegex(TestCase):
 


### PR DESCRIPTION
The date converter regex only matched non-zero-padded components, so a valid URL like /2020/02/29 returned 404, and reverse() with a datetime raised NoReverseMatch whenever strftime zero-padded a single-digit month or day. Allow an optional leading zero on month/day (validity checks for leap years and days-per-month are unchanged) and build the reverse URL from integer components so it stays non-padded and platform-independent.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
