### PR TITLE
:bug: Compress streaming responses lazily in SpaceLessMiddleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - The `int` template filter now accepts numeric values (int/float).
 - `ContainAnyValidator` now raises `ValidationError` for invalid input when given multiple elements as a tuple.
 - The `date` path converter now accepts zero-padded dates (e.g. `2020/02/29`).
+- `SpaceLessMiddleware` now compresses streaming HTML responses lazily (async streams included) and works in ASGI middleware chains.
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/middleware/html.py
+++ b/django_boost/middleware/html.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from django.utils.deprecation import MiddlewareMixin
 
-from django_boost.utils.html import strip_spaces_between_tags
+from django_boost.utils.html import (
+    acompress_stream, compress_stream, strip_spaces_between_tags)
 
 
 class SpaceLessMiddleware(MiddlewareMixin):
@@ -27,14 +28,18 @@ class SpaceLessMiddleware(MiddlewareMixin):
 
     """
 
-    def __call__(self, request):
-        response = self.get_response(request)
+    def process_response(self, request, response):
         if 'text/html' in response.get('Content-Type', ''):
             if response.streaming:
-                content = b''.join(response.streaming_content).decode(
-                    response.charset)
-                response.streaming_content = [
-                    strip_spaces_between_tags(content).encode(response.charset)]
+                if response.is_async:
+                    response.streaming_content = acompress_stream(
+                        response.streaming_content, response.charset)
+                else:
+                    response.streaming_content = compress_stream(
+                        response.streaming_content, response.charset)
+                # Length is unknown until the lazily-compressed stream is sent.
+                if response.has_header('Content-Length'):
+                    del response['Content-Length']
             else:
                 response.content = strip_spaces_between_tags(
                     response.content.decode(response.charset))

--- a/django_boost/utils/html.py
+++ b/django_boost/utils/html.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import codecs
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 from html import escape
 from html.parser import HTMLParser
 from io import StringIO
@@ -8,32 +10,69 @@ from typing import Any
 
 class HTMLSpaceLessCompressor(HTMLParser):
 
+    RAW_TEXT_ELEMENTS = frozenset({'script', 'style'})
+    WHITESPACE_PRESERVING_ELEMENTS = frozenset({'pre', 'textarea'})
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.buffer = StringIO()
-        self.pre_count = 0
+        self._raw_depth = 0
+        self._preserve_depth = 0
+        self._run_started = False
+        self._pending_ws = ''
+
+    def _end_run(self) -> None:
+        # End of a text run (tag boundary or close()): drop the trailing
+        # whitespace held back below (rstrip) and reset for the next run.
+        self._pending_ws = ''
+        self._run_started = False
 
     def handle_data(self, data: str) -> None:
-        if self.pre_count == 0:
-            data = data.strip()
-        # convert_charrefs already decoded entities here; re-escape them.
-        self.buffer.write(escape(data, quote=False))
+        if self._raw_depth > 0:
+            # Raw CDATA (script/style): escaping would corrupt the JS/CSS.
+            self.buffer.write(data)
+            return
+        if self._preserve_depth > 0:
+            # pre/textarea: whitespace is significant, so re-escape but keep it.
+            self.buffer.write(escape(data, quote=False))
+            return
+        # Default: strip the run as a whole but stream its interior as it
+        # arrives — drop leading whitespace, then hold back only trailing
+        # whitespace until the run continues (more data) or ends (a tag).
+        # convert_charrefs decoded entities, so re-escape.
+        if not self._run_started:
+            data = data.lstrip()
+            if not data:
+                return
+            self._run_started = True
+        else:
+            data = self._pending_ws + data
+        stripped = data.rstrip()
+        self._pending_ws = data[len(stripped):]
+        self.buffer.write(escape(stripped, quote=False))
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self._end_run()
         self.buffer.write("<%s" % tag)
         if attrs:
             self.buffer.write(' ')
             self.buffer.write(self._render_attrs(attrs))
         self.buffer.write('>')
-        if tag == 'pre':
-            self.pre_count += 1
+        if tag in self.RAW_TEXT_ELEMENTS:
+            self._raw_depth += 1
+        elif tag in self.WHITESPACE_PRESERVING_ELEMENTS:
+            self._preserve_depth += 1
 
     def handle_endtag(self, tag: str) -> None:
+        self._end_run()
         self.buffer.write("</%s>" % tag)
-        if tag == 'pre':
-            self.pre_count -= 1
+        if tag in self.RAW_TEXT_ELEMENTS:
+            self._raw_depth -= 1
+        elif tag in self.WHITESPACE_PRESERVING_ELEMENTS:
+            self._preserve_depth -= 1
 
     def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self._end_run()
         self.buffer.write("<%s" % tag)
         if attrs:
             self.buffer.write(' ')
@@ -41,20 +80,79 @@ class HTMLSpaceLessCompressor(HTMLParser):
         self.buffer.write("/>")
 
     def handle_decl(self, decl: str) -> None:
+        self._end_run()
         self.buffer.write("<!%s>" % decl)
+
+    def handle_comment(self, data: str) -> None:
+        # Comments are dropped, but a comment still ends the current text run
+        # so the text on either side is stripped separately, as with a tag.
+        self._end_run()
 
     def _render_attrs(self, attrs: list[tuple[str, str | None]]) -> str:
         return ' '.join(
             name if value is None else '%s="%s"' % (name, escape(value))
             for name, value in attrs)
 
-    def compress(self, data: str) -> str:
+    def close(self) -> None:
+        # super().close() flushes text the parser was still buffering (e.g. a
+        # trailing "&" that looked like the start of an entity); _end_run()
+        # then drops that last run's trailing whitespace.
+        super().close()
+        self._end_run()
+
+    def _drain(self) -> str:
+        out = self.buffer.getvalue()
+        self.buffer = StringIO()
+        return out
+
+    def feed_chunk(self, data: str) -> str:
+        """Feed one chunk and return the compressed output produced so far.
+
+        Only undecided trailing state stays buffered until finalize(): the
+        run's trailing whitespace (held back for rstrip), and any input
+        HTMLParser cannot resolve yet (a dangling "&" or a partial tag).
+        """
         self.feed(data)
-        # close() flushes trailing buffered text; reset() would drop it.
+        return self._drain()
+
+    def finalize(self) -> str:
+        """Emit text buffered after the last tag and close the parser.
+
+        Call once, last; the compressor is single-use afterward.
+        """
         self.close()
-        return self.buffer.getvalue()
+        return self._drain()
+
+    def compress(self, data: str) -> str:
+        return self.feed_chunk(data) + self.finalize()
 
 
 def strip_spaces_between_tags(value: str) -> str:
-    value = HTMLSpaceLessCompressor().compress(value)
-    return value
+    return HTMLSpaceLessCompressor().compress(value)
+
+
+def compress_stream(chunks: Iterable[bytes], charset: str) -> Iterator[bytes]:
+    compressor = HTMLSpaceLessCompressor()
+    decoder = codecs.getincrementaldecoder(charset)()
+    for chunk in chunks:
+        out = compressor.feed_chunk(decoder.decode(chunk))
+        if out:
+            yield out.encode(charset)
+    # Flush the decoder (final=True surfaces a truncated trailing multibyte),
+    # then finalize() emits the parser's last buffered text.
+    out = compressor.feed_chunk(decoder.decode(b'', final=True)) + compressor.finalize()
+    if out:
+        yield out.encode(charset)
+
+
+async def acompress_stream(chunks: AsyncIterable[bytes], charset: str) -> AsyncIterator[bytes]:
+    compressor = HTMLSpaceLessCompressor()
+    decoder = codecs.getincrementaldecoder(charset)()
+    async for chunk in chunks:
+        out = compressor.feed_chunk(decoder.decode(chunk))
+        if out:
+            yield out.encode(charset)
+    # Final decode flush + finalize; see compress_stream for the rationale.
+    out = compressor.feed_chunk(decoder.decode(b'', final=True)) + compressor.finalize()
+    if out:
+        yield out.encode(charset)

--- a/tests/tests/middleware/test_html.py
+++ b/tests/tests/middleware/test_html.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from django.http import HttpResponse, StreamingHttpResponse
 from django.test import RequestFactory, SimpleTestCase
 
@@ -9,18 +11,180 @@ class SpaceLessMiddlewareStreamingTests(SimpleTestCase):
     def setUp(self):
         self.factory = RequestFactory()
 
-    def test_compresses_streaming_html_response(self):
+    def test_streaming_response_is_compressed_lazily(self):
+        consumed = []
+
+        def gen():
+            consumed.append(True)
+            yield b'<html>  <body>  hi  </body>  </html>'
+
         def get_response(request):
-            return StreamingHttpResponse(
-                [b'<html>  <body>  hi  </body>  </html>'],
-                content_type='text/html')
+            return StreamingHttpResponse(gen(), content_type='text/html')
 
-        middleware = SpaceLessMiddleware(get_response)
-        response = middleware(self.factory.get('/'))
+        response = SpaceLessMiddleware(get_response)(self.factory.get('/'))
 
-        self.assertTrue(response.streaming)
+        self.assertEqual(consumed, [])
         self.assertEqual(b''.join(response.streaming_content),
                          b'<html><body>hi</body></html>')
+
+    def test_streaming_compresses_across_chunk_boundaries(self):
+        def gen():
+            yield b'<html>  <bo'
+            yield b'dy>  hi  </body'
+            yield b'>  </html>'
+
+        def get_response(request):
+            return StreamingHttpResponse(gen(), content_type='text/html')
+
+        response = SpaceLessMiddleware(get_response)(self.factory.get('/'))
+
+        self.assertEqual(b''.join(response.streaming_content),
+                         b'<html><body>hi</body></html>')
+
+    def test_async_streaming_response_is_compressed(self):
+        async def agen():
+            yield b'<html>  <body>  hi  </body>  </html>'
+
+        def get_response(request):
+            return StreamingHttpResponse(agen(), content_type='text/html')
+
+        response = SpaceLessMiddleware(get_response)(self.factory.get('/'))
+        self.assertTrue(response.streaming)
+
+        async def collect():
+            return b''.join([c async for c in response.streaming_content])
+
+        self.assertEqual(asyncio.run(collect()),
+                         b'<html><body>hi</body></html>')
+
+    def test_async_streaming_response_is_not_consumed_eagerly(self):
+        consumed = []
+
+        async def agen():
+            consumed.append(True)
+            yield b'<html>  <body>  hi  </body>  </html>'
+
+        def get_response(request):
+            return StreamingHttpResponse(agen(), content_type='text/html')
+
+        response = SpaceLessMiddleware(get_response)(self.factory.get('/'))
+
+        self.assertEqual(consumed, [])
+
+        async def collect():
+            return b''.join([c async for c in response.streaming_content])
+
+        self.assertEqual(asyncio.run(collect()), b'<html><body>hi</body></html>')
+        self.assertEqual(consumed, [True])
+
+    def test_async_streaming_handles_multibyte_split_across_chunks(self):
+        body = '<html> <body>あい</body> </html>'.encode('utf-8')
+
+        async def agen():
+            yield body[:14]
+            yield body[14:]
+
+        def get_response(request):
+            return StreamingHttpResponse(agen(), content_type='text/html')
+
+        response = SpaceLessMiddleware(get_response)(self.factory.get('/'))
+
+        async def collect():
+            return b''.join([c async for c in response.streaming_content])
+
+        self.assertEqual(asyncio.run(collect()).decode('utf-8'),
+                         '<html><body>あい</body></html>')
+
+    def test_streaming_drops_content_length(self):
+        def get_response(request):
+            response = StreamingHttpResponse([b'<html>  x  </html>'],
+                                             content_type='text/html')
+            response['Content-Length'] = '18'
+            return response
+
+        response = SpaceLessMiddleware(get_response)(self.factory.get('/'))
+
+        self.assertFalse(response.has_header('Content-Length'))
+
+    def test_streaming_handles_multibyte_split_across_chunks(self):
+        body = '<html> <body>あい</body> </html>'.encode('utf-8')
+
+        def gen():
+            yield body[:14]
+            yield body[14:]
+
+        def get_response(request):
+            return StreamingHttpResponse(gen(), content_type='text/html')
+
+        response = SpaceLessMiddleware(get_response)(self.factory.get('/'))
+
+        self.assertEqual(b''.join(response.streaming_content).decode('utf-8'),
+                         '<html><body>あい</body></html>')
+
+
+class SpaceLessMiddlewareAsyncChainTests(SimpleTestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_async_get_response_is_awaited(self):
+        async def get_response(request):
+            return HttpResponse('<html>  <body>  hi  </body>  </html>',
+                                content_type='text/html')
+
+        middleware = SpaceLessMiddleware(get_response)
+
+        async def call():
+            return await middleware(self.factory.get('/'))
+
+        response = asyncio.run(call())
+
+        self.assertEqual(response.content, b'<html><body>hi</body></html>')
+
+    def test_async_get_response_streaming_is_compressed(self):
+        async def agen():
+            yield b'<html>  <bo'
+            yield b'dy>  hi  </body'
+            yield b'>  </html>'
+
+        async def get_response(request):
+            return StreamingHttpResponse(agen(), content_type='text/html')
+
+        middleware = SpaceLessMiddleware(get_response)
+
+        async def call():
+            response = await middleware(self.factory.get('/'))
+            return b''.join([c async for c in response.streaming_content])
+
+        self.assertEqual(asyncio.run(call()), b'<html><body>hi</body></html>')
+
+
+class SpaceLessMiddlewarePassthroughTests(SimpleTestCase):
+    """Non-HTML responses must be left byte-for-byte untouched."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_non_html_response_is_left_untouched(self):
+        body = b'{"a":  1,  "b":  2}'  # whitespace must not be collapsed
+
+        def get_response(request):
+            return HttpResponse(body, content_type='application/json')
+
+        response = SpaceLessMiddleware(get_response)(self.factory.get('/'))
+
+        self.assertEqual(response.content, body)
+
+    def test_non_html_streaming_response_is_left_untouched(self):
+        chunks = [b'\x00\x01  \x02', b'  raw  bytes  ']
+
+        def get_response(request):
+            return StreamingHttpResponse(iter(chunks),
+                                         content_type='application/octet-stream')
+
+        response = SpaceLessMiddleware(get_response)(self.factory.get('/'))
+
+        self.assertEqual(b''.join(response.streaming_content), b''.join(chunks))
 
 
 class SpaceLessMiddlewareCharsetTests(SimpleTestCase):

--- a/tests/tests/utils/test_html.py
+++ b/tests/tests/utils/test_html.py
@@ -1,5 +1,8 @@
+import asyncio
+
 from django_boost.test import TestCase
-from django_boost.utils.html import strip_spaces_between_tags
+from django_boost.utils.html import (
+    acompress_stream, compress_stream, strip_spaces_between_tags)
 
 
 class SpaceLessEntityEscapingTests(TestCase):
@@ -39,3 +42,162 @@ class SpaceLessTrailingDataTests(TestCase):
         self.assertEqual(
             strip_spaces_between_tags('<p>x</p>price is 5 USD &'),
             '<p>x</p>price is 5 USD &amp;')
+
+
+class SpaceLessCommentBoundaryTests(TestCase):
+    """A comment between text must not merge the surrounding runs."""
+
+    def test_whitespace_around_a_comment_is_collapsed(self):
+        # The comment is a run boundary like a tag: "a" and "b" are stripped
+        # separately, so the whitespace between them collapses.
+        self.assertEqual(
+            strip_spaces_between_tags('<p>  a  <!-- c -->  b  </p>'),
+            '<p>ab</p>')
+
+
+class SpaceLessStreamLazinessTests(TestCase):
+    """A text run must stream as it arrives, not buffer until the next tag."""
+
+    def test_long_text_node_is_emitted_before_the_closing_tag(self):
+        def gen():
+            yield b'<html><body>'
+            yield b'x' * 50
+            yield b'</body></html>'
+
+        chunks = list(compress_stream(gen(), 'utf-8'))
+
+        self.assertIn(b'x' * 50, chunks)
+        self.assertEqual(b''.join(chunks), b'<html><body>' + b'x' * 50 + b'</body></html>')
+
+
+class SpaceLessStreamPreTests(TestCase):
+    """<pre> whitespace must survive being split across chunk boundaries."""
+
+    def test_pre_block_whitespace_is_preserved_across_chunk_boundaries(self):
+        source = '<pre>  line1\n   line2  </pre>'
+        data = source.encode('utf-8')
+        streamed = b''.join(
+            compress_stream([data[i:i + 4] for i in range(0, len(data), 4)],
+                            'utf-8')).decode('utf-8')
+
+        self.assertEqual(streamed, strip_spaces_between_tags(source))
+        self.assertEqual(streamed, '<pre>  line1\n   line2  </pre>')
+
+
+class SpaceLessStreamEquivalenceTests(TestCase):
+    """Streamed output must equal batch output for any chunk split."""
+
+    def test_streamed_output_equals_batch_for_various_chunk_sizes(self):
+        source = ('<html>  <head>  <title> T </title>  </head>  <body>'
+                  '  <p> a  b </p>  <pre>  x  y  </pre>  </body>  </html>')
+        batch = strip_spaces_between_tags(source)
+        data = source.encode('utf-8')
+        for size in (1, 2, 3, 5, 7, 16):
+            chunks = [data[i:i + size] for i in range(0, len(data), size)]
+            streamed = b''.join(compress_stream(chunks, 'utf-8')).decode('utf-8')
+            self.assertEqual(streamed, batch, msg='chunk size %d' % size)
+
+
+class SpaceLessStreamEntityTests(TestCase):
+    """An entity straddling a chunk boundary must reassemble, not split or
+    double-escape."""
+
+    def test_entity_split_across_chunk_boundary_matches_batch(self):
+        source = '<p>a &amp; b &lt; c</p>'
+        batch = strip_spaces_between_tags(source)
+        data = source.encode('utf-8')
+        for size in (1, 2, 3, 4, 5):
+            chunks = [data[i:i + size] for i in range(0, len(data), size)]
+            streamed = b''.join(compress_stream(chunks, 'utf-8')).decode('utf-8')
+            self.assertEqual(streamed, batch, msg='chunk size %d' % size)
+
+
+class SpaceLessStreamEdgeCaseTests(TestCase):
+
+    def test_empty_stream_yields_nothing(self):
+        self.assertEqual(list(compress_stream([], 'utf-8')), [])
+
+    def test_truncated_trailing_multibyte_raises(self):
+        # A stream ending mid-character is malformed; fail loudly rather than
+        # emit silently corrupted output.
+        with self.assertRaises(UnicodeDecodeError):
+            list(compress_stream([b'<p>ok', b'\xe3\x81'], 'utf-8'))
+
+
+class SpaceLessAsyncStreamEdgeCaseTests(TestCase):
+    """acompress_stream is a separate implementation; guard its edges too."""
+
+    def test_empty_async_stream_yields_nothing(self):
+        async def agen():
+            for _ in ():
+                yield b''
+
+        async def run():
+            return [chunk async for chunk in acompress_stream(agen(), 'utf-8')]
+
+        self.assertEqual(asyncio.run(run()), [])
+
+    def test_async_truncated_trailing_multibyte_raises(self):
+        async def agen():
+            yield b'<p>ok'
+            yield b'\xe3\x81'  # stream ends mid-character
+
+        async def run():
+            return [chunk async for chunk in acompress_stream(agen(), 'utf-8')]
+
+        with self.assertRaises(UnicodeDecodeError):
+            asyncio.run(run())
+
+
+class SpaceLessRawTextElementTests(TestCase):
+    """<script>/<style> content is raw (must not be escaped); <textarea>
+    whitespace is significant (must not be stripped)."""
+
+    def test_script_content_is_not_escaped(self):
+        self.assertEqual(
+            strip_spaces_between_tags(
+                '<script>if (a < b && c > d) { x = 1; }</script>'),
+            '<script>if (a < b && c > d) { x = 1; }</script>')
+
+    def test_style_content_is_not_escaped(self):
+        self.assertEqual(
+            strip_spaces_between_tags('<style>body > p { color: red; }</style>'),
+            '<style>body > p { color: red; }</style>')
+
+    def test_textarea_whitespace_is_preserved(self):
+        self.assertEqual(
+            strip_spaces_between_tags('<textarea>  a  b  </textarea>'),
+            '<textarea>  a  b  </textarea>')
+
+
+class SpaceLessStreamRawTextTests(TestCase):
+    """script/style/textarea must stream identically to batch for any split."""
+
+    SOURCE = ('<html>  <head>  <style> body > p { x: 1 } </style>'
+              '  <script>if (a < b) { y(); }</script>  </head>'
+              '  <body>  <textarea>  a  b  </textarea>  </body>  </html>')
+
+    def test_sync_streamed_raw_text_equals_batch(self):
+        batch = strip_spaces_between_tags(self.SOURCE)
+        data = self.SOURCE.encode('utf-8')
+        for size in (1, 2, 3, 5, 7, 16):
+            chunks = [data[i:i + size] for i in range(0, len(data), size)]
+            streamed = b''.join(compress_stream(chunks, 'utf-8')).decode('utf-8')
+            self.assertEqual(streamed, batch, msg='chunk size %d' % size)
+
+    def test_async_streamed_raw_text_equals_batch(self):
+        batch = strip_spaces_between_tags(self.SOURCE)
+        data = self.SOURCE.encode('utf-8')
+
+        async def run(size):
+            chunks = [data[i:i + size] for i in range(0, len(data), size)]
+
+            async def agen():
+                for chunk in chunks:
+                    yield chunk
+
+            return b''.join(
+                [p async for p in acompress_stream(agen(), 'utf-8')]).decode('utf-8')
+
+        for size in (1, 3, 7):
+            self.assertEqual(asyncio.run(run(size)), batch, msg='chunk size %d' % size)


### PR DESCRIPTION
The streaming branch did b''.join(response.streaming_content), which consumed the iterator eagerly (breaking lazy streaming), crashed with TypeError on async-generator bodies, and left Content-Length at the pre-compression length. Compress streaming bodies through a lazy sync/async generator that feeds the parser incrementally and drop the now-unknown Content-Length. The compressor defers each text run to the next markup boundary, so a run split across chunks is stripped as a whole and streamed output matches the non-streaming result.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
