### PR TITLE
:bug: Fix UnboundLocalError in StaticView with an explicit content_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `ContainAnyValidator` now raises `ValidationError` for invalid input when given multiple elements as a tuple.
 - The `date` path converter now accepts zero-padded dates (e.g. `2020/02/29`).
 - `SpaceLessMiddleware` now compresses streaming HTML responses lazily (async streams included) and works in ASGI middleware chains.
+- `StaticView` with an explicit `content_type` no longer crashes with `UnboundLocalError`.
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/views/base.py
+++ b/django_boost/views/base.py
@@ -98,6 +98,7 @@ class StaticResponseMixin:
         names = self.get_static_names()
         for path in names:
             if os.path.exists(path):
+                encoding = None
                 if self.content_type is None:
                     content_type, encoding = mimetypes.guess_type(path)
                     content_type = content_type or 'application/octet-stream'

--- a/tests/tests/views/tests.py
+++ b/tests/tests/views/tests.py
@@ -3,6 +3,7 @@ import os
 from django.test import override_settings
 from django.urls import reverse
 from django_boost.test import TestCase
+from django_boost.views.base import StaticView
 
 ROOT_PATH = os.path.dirname(__file__)
 
@@ -85,3 +86,29 @@ class DeprecatedViewLayerTests(TestCase):
             generic.JsonView
             generic.StaticView
             generic.ModelCRUDViews
+
+
+class StaticViewContentTypeTests(TestCase):
+    """StaticView with an explicit content_type must serve, not crash."""
+
+    def test_explicit_content_type_does_not_crash(self):
+        class FileView(StaticView):
+            static_name = os.path.abspath(__file__)
+            content_type = 'text/plain'
+
+        response = FileView().create_response()
+        try:
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response['Content-Type'], 'text/plain')
+        finally:
+            response.close()
+
+    def test_guessed_content_type_still_works(self):
+        class FileView(StaticView):
+            static_name = os.path.abspath(__file__)
+
+        response = FileView().create_response()
+        try:
+            self.assertEqual(response.status_code, 200)
+        finally:
+            response.close()


### PR DESCRIPTION
create_response() only bound 'encoding' on the content_type-guessing branch, so a StaticView with content_type set raised UnboundLocalError at 'if encoding:'. Initialize encoding before the branch.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
