### PR TITLE
:bug: Evaluate RedirectCorrectHostnameMiddleware settings per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - The `date` path converter now accepts zero-padded dates (e.g. `2020/02/29`).
 - `SpaceLessMiddleware` now compresses streaming HTML responses lazily (async streams included) and works in ASGI middleware chains.
 - `StaticView` with an explicit `content_type` no longer crashes with `UnboundLocalError`.
+- `RedirectCorrectHostnameMiddleware` now reads `DEBUG` and `CORRECT_HOST` per request.
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/middleware/__init__.py
+++ b/django_boost/middleware/__init__.py
@@ -52,18 +52,14 @@ class RedirectCorrectHostnameMiddleware(MiddlewareMixin):
     but it is useful when the setting is troublesome or when using services such as heroku.
     """
 
-    conditions = not settings.DEBUG and hasattr(settings, 'CORRECT_HOST')
-
     def __call__(self, request):
-
-        if self.conditions and request.get_host() != settings.CORRECT_HOST:
+        enabled = not settings.DEBUG and hasattr(settings, 'CORRECT_HOST')
+        if enabled and request.get_host() != settings.CORRECT_HOST:
             return HttpResponsePermanentRedirect(
                 '{scheme}://{host}{path}'.format(scheme=request.scheme,
                                                  host=settings.CORRECT_HOST,
                                                  path=request.get_full_path()))
-
-        response = self.get_response(request)
-        return response
+        return self.get_response(request)
 
 
 class HttpStatusCodeExceptionMiddleware(MiddlewareMixin):

--- a/tests/tests/middleware/test_middleware.py
+++ b/tests/tests/middleware/test_middleware.py
@@ -52,27 +52,38 @@ class RedirectCorrectHostnameMiddlewareTests(SimpleTestCase):
 
     def setUp(self):
         self.factory = RequestFactory()
+        self.downstream = []
 
-    @override_settings(CORRECT_HOST="correct.example.com", ALLOWED_HOSTS=["*"])
+    def _middleware(self):
+        def get_response(request):
+            self.downstream.append(request)
+            return HttpResponse()
+        return RedirectCorrectHostnameMiddleware(get_response)
+
+    @override_settings(DEBUG=False, CORRECT_HOST="correct.example.com",
+                       ALLOWED_HOSTS=["*"])
     def test_redirects_when_hostname_differs(self):
-        downstream = []
-        middleware = RedirectCorrectHostnameMiddleware(
-            get_response=lambda request: downstream.append(request))
-        # `conditions` is frozen at class-definition time (DEBUG was on then);
-        # simulate a deployment where the redirect is active.
-        middleware.conditions = True
-
-        response = middleware(self.factory.get("/page?x=1"))
+        response = self._middleware()(
+            self.factory.get("/page?x=1", HTTP_HOST="wrong.example.com"))
 
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response["Location"],
                          "http://correct.example.com/page?x=1")
-        self.assertEqual(downstream, [])  # not forwarded to the view
+        self.assertEqual(self.downstream, [])  # not forwarded to the view
 
-    def test_passes_through_when_disabled(self):
-        sentinel = HttpResponse()
-        middleware = RedirectCorrectHostnameMiddleware(
-            get_response=lambda request: sentinel)
-        # Default `conditions` is False under the test settings (DEBUG on), so
-        # the request flows through untouched.
-        self.assertIs(middleware(self.factory.get("/")), sentinel)
+    @override_settings(DEBUG=False, CORRECT_HOST="correct.example.com",
+                       ALLOWED_HOSTS=["*"])
+    def test_no_redirect_when_hostname_matches(self):
+        response = self._middleware()(
+            self.factory.get("/", HTTP_HOST="correct.example.com"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(self.downstream), 1)
+
+    @override_settings(DEBUG=True, CORRECT_HOST="correct.example.com",
+                       ALLOWED_HOSTS=["*"])
+    def test_no_redirect_when_debug(self):
+        response = self._middleware()(
+            self.factory.get("/", HTTP_HOST="wrong.example.com"))
+
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
The redirect condition was a class attribute computed at import, freezing DEBUG and CORRECT_HOST at module-load time so runtime changes (and test override_settings) had no effect. Evaluate it inside __call__ instead.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
