### PR TITLE
:bug: Forward using/force_update from LogicalDeletionMixin.revive() to save()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `SpaceLessMiddleware` now compresses streaming HTML responses lazily (async streams included) and works in ASGI middleware chains.
 - `StaticView` with an explicit `content_type` no longer crashes with `UnboundLocalError`.
 - `RedirectCorrectHostnameMiddleware` now reads `DEBUG` and `CORRECT_HOST` per request.
+- `LogicalDeletionMixin.revive()` now honors its `using` and `force_update` arguments.
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/models/mixins.py
+++ b/django_boost/models/mixins.py
@@ -76,7 +76,7 @@ class LogicalDeletionMixin(models.Model):
     def revive(self, force_update=False, using=None):
         """Revive logical deleted item."""
         self.deleted_at = None
-        return self.save()
+        return self.save(force_update=force_update, using=using)
 
     def is_dead(self):
         """Return True if the item is dead."""

--- a/tests/tests/logical_deletion/tests.py
+++ b/tests/tests/logical_deletion/tests.py
@@ -82,6 +82,17 @@ class TestLogicalDeletionMixin(TestCase):
         self.assertEqual(len(self.model.objects.dead()), 0)
         self.assertEqual(len(self.model.objects.alive()), 10)
 
+    def test_revive_forwards_save_arguments(self):
+        from unittest import mock
+
+        self._register_items("0")
+        item = self.model.objects.get(name="0")
+        item.delete()
+        with mock.patch.object(item, "save") as save:
+            item.revive(force_update=True, using="other")
+        save.assert_called_once_with(force_update=True, using="other")
+        self.assertIsNone(item.deleted_at)
+
     def test_is_dead(self):
         self._register_items(*[str(i) for i in range(10)])
         item = self.model.objects.get(name="0")


### PR DESCRIPTION
revive() accepted force_update and using but called self.save() with no arguments, so a revive on a non-default database wrote to the default one and force_update was dropped. Forward both to save().

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
