### PR TITLE
:bug: Propagate LogicalDeletionManager.delete_flag_field to its queryset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `StaticView` with an explicit `content_type` no longer crashes with `UnboundLocalError`.
 - `RedirectCorrectHostnameMiddleware` now reads `DEBUG` and `CORRECT_HOST` per request.
 - `LogicalDeletionMixin.revive()` now honors its `using` and `force_update` arguments.
+- A custom `delete_flag_field` on `LogicalDeletionManager` now applies to its `alive()`/`dead()`/`revive()` queries.
 
 ## [3.0.1] - 2026-06-26
 

--- a/django_boost/models/manager.py
+++ b/django_boost/models/manager.py
@@ -12,7 +12,9 @@ class LogicalDeletionManager(Manager):
         return self.delete_flag_field
 
     def get_queryset(self):
-        return LogicalDeletionQuerySet(self.model, using=self._db, hints=self._hints)
+        qs = LogicalDeletionQuerySet(self.model, using=self._db, hints=self._hints)
+        qs.delete_flag_field = self.get_deleted_flag_field_name()
+        return qs
 
     def delete(self, hard=False, deleted_at=None):
         return self.get_queryset().delete(hard=hard, deleted_at=deleted_at)

--- a/tests/tests/logical_deletion/tests.py
+++ b/tests/tests/logical_deletion/tests.py
@@ -10,6 +10,7 @@ from django.test.utils import isolate_apps
 from django.utils.timezone import now
 
 from django_boost.models.deletion import get_logical_delete_field
+from django_boost.models.manager import LogicalDeletionManager
 from django_boost.models.mixins import LogicalDeletionMixin
 
 
@@ -398,3 +399,24 @@ class GetLogicalDeleteFieldTests(TestCase):
 
             with self.assertRaises(ImproperlyConfigured):
                 get_logical_delete_field(MisconfiguredModel)
+
+
+class LogicalDeletionManagerCustomFieldTests(TestCase):
+    """A custom delete_flag_field on the manager must reach its queryset, so
+    alive()/dead()/revive() filter on the right column."""
+
+    def test_custom_delete_flag_field_propagates_to_queryset(self):
+        with isolate_apps("tests"):
+            class RemovedManager(LogicalDeletionManager):
+                delete_flag_field = "removed_at"
+
+            class CustomFieldModel(models.Model):
+                removed_at = models.DateTimeField(null=True, default=None)
+                objects = RemovedManager()
+
+                class Meta:
+                    app_label = "tests"
+
+            queryset = CustomFieldModel.objects.get_queryset()
+
+        self.assertEqual(queryset.get_delete_flag_field_name(), "removed_at")


### PR DESCRIPTION
The manager's get_queryset() built a LogicalDeletionQuerySet without passing its delete_flag_field, so a custom field on the manager was ignored and alive()/dead()/revive() queried the default 'deleted_at', raising FieldError. Set the queryset's field from the manager.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
