### PR TITLE
:bookmark: Release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-07-01
+
 ### Added
 
 - `iter`, `list`, `dict`, `set`, `tuple` and `frozenset` filters in the
@@ -401,7 +403,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - First release.
 
-[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.0.1...HEAD
+[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/ChanTsune/django-boost/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/ChanTsune/django-boost/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/ChanTsune/django-boost/compare/v2.2.0...v3.0.0
 [2.2.0]: https://github.com/ChanTsune/django-boost/compare/v2.1.2...v2.2.0

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from django_boost.utils.version import get_version
 
-VERSION = (3, 0, 1, 'final', 0)
+VERSION = (3, 1, 0, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
- Added
  - `iter`, `list`, `dict`, `set`, `tuple`, and `frozenset` template filters exposing the corresponding Python built-ins
  - Optional `msg` argument on `TestCase`'s `assertStatusCode*` assertions
- Deprecated
  - The `django_boost.views` base `View` class, `after_view_process`, and its generic-view aliases (removed in 4.0; use Django's generics with a `dispatch()` override or middleware)
  - `validate_uuid4` (removed in 4.0; use Django's `UUIDField` or `uuid.UUID` instead)
- Fixed
  - `admin.sites.register_all`, the `next`/`int`/`urldecode` filters, `ContainAnyValidator`, `ColorCodeField`, `validate_color_code`, and the `date` path converter now handle their respective edge cases correctly
  - `UserCreationForm`, `UserChangeForm`, and `AuthenticationForm` apply Django's `UsernameField` behavior
  - `model_to_json` accepts `QuerySet` input
  - `SpaceLessMiddleware` compresses streaming responses lazily and works in ASGI middleware chains
  - `StaticView`, `RedirectCorrectHostnameMiddleware`, `LogicalDeletionMixin.revive()`, and `LogicalDeletionManager`'s `delete_flag_field` fixes
  - `assertStatusCode*` failures now point at the calling test
