### PR TITLE
Fix typos in template tag docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,21 +800,21 @@ Make the query set methods available in the template.
 If you use the LogicalDeletionMixin, you can also use `alive` and `dead`
 
 ```html+django
-{% qureyset|filter:"field=value"%}
+{% queryset|filter:"field=value"%}
 
-{% qureyset|exclude:"field=value"%}
+{% queryset|exclude:"field=value"%}
 
-{% qureyset|order_by:"field"%}
+{% queryset|order_by:"field"%}
 
 {# If it inherits LogicalDeletionMixin. #}
 
-{% qureyset|alive %}
+{% queryset|alive %}
 
-{% qureyset|dead %}
+{% queryset|dead %}
 
 ```
 
-## utilty functions
+## utility functions
 
 ### loop utils
 

--- a/docs/template_tags.rst
+++ b/docs/template_tags.rst
@@ -191,17 +191,17 @@ If you use the LogicalDeletionMixin, you can also use ``alive`` and ``dead``
 
 ::
 
-  {% qureyset|filter:"field=value"%}
+  {% queryset|filter:"field=value"%}
 
-  {% qureyset|exclude:"field=value"%}
+  {% queryset|exclude:"field=value"%}
 
-  {% qureyset|order_by:"field"%}
+  {% queryset|order_by:"field"%}
 
   {# If it inherits LogicalDeletionMixin. #}
 
-  {% qureyset|alive %}
+  {% queryset|alive %}
 
-  {% qureyset|dead %}
+  {% queryset|dead %}
 
 
 MimeType Utility


### PR DESCRIPTION
## Summary
- Fix "qureyset" -> "queryset" in the `queryset` template tag examples (README.md, docs/template_tags.rst).
- Fix "utilty" -> "utility" in a README section heading.