### PR TITLE
Fix typo in boost templatetags module docstring

### DIFF
--- a/django_boost/templatetags/boost.py
+++ b/django_boost/templatetags/boost.py
@@ -1,4 +1,4 @@
-"""This module provides python build-in functions for django template."""
+"""This module provides python built-in functions for django template."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- Fix "build-in" -> "built-in" in the `django_boost/templatetags/boost.py` module docstring.