### PR TITLE
:bug: Parse 1-3 digit years in the date path converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The `date` path converter now accepts years below 1000 (e.g. `48/2/29`).
+
 ## [3.1.0] - 2026-07-01
 
 ### Added

--- a/django_boost/urls/converters/date.py
+++ b/django_boost/urls/converters/date.py
@@ -42,4 +42,7 @@ class DateConverter:
     def to_python(self, value: datetime | str) -> datetime:
         if isinstance(value, datetime):
             return value
-        return datetime.strptime(value, "%Y/%m/%d")
+        # strptime's %Y needs 4 digits, but the regex accepts 1-4; build the
+        # date directly so every year the pattern matches is parseable.
+        year, month, day = value.split("/")
+        return datetime(int(year), int(month), int(day))

--- a/tests/tests/urls_converters/tests.py
+++ b/tests/tests/urls_converters/tests.py
@@ -64,6 +64,17 @@ class TestConverter(TestCase):
         self.assertEqual(url, '/date/2020/1/5')
         self.assertStatusCodeEqual(self.client.get(url), 200)
 
+    def test_date_accepts_short_year(self):
+        response = self.client.get('/date/48/2/29')
+        self.assertStatusCodeEqual(response, 200)
+
+    def test_date_reverses_short_year_datetime(self):
+        from datetime import datetime
+
+        url = reverse('date', kwargs={'date': datetime(48, 2, 29)})
+        self.assertEqual(url, '/date/48/2/29')
+        self.assertStatusCodeEqual(self.client.get(url), 200)
+
 
 class TestRegex(TestCase):
 


### PR DESCRIPTION
## Summary

The `date` URL path converter accepted 1–3 digit years in its regex but could not parse them: `to_python` used `datetime.strptime(value, "%Y/%m/%d")`, whose `%Y` requires 4 digits. The regex and the parser disagreed on the accepted year width, which caused two problems:

- **Dead route (inbound):** a URL like `/date/48/2/29` matched the pattern but returned **404**, because `to_python` raised `ValueError` and Django treats that as no match.
- **Broken round-trip:** `reverse(..., {'date': datetime(48, 2, 29)})` produces `/date/48/2/29`, so reversing any `datetime` before year 1000 yielded a link that 404s when followed.

## Fix

Parse the components directly with `datetime(int(year), int(month), int(day))` instead of `strptime`, so every year the regex matches is accepted. The regex already validates real dates (leap years, days-per-month), and `int()` handles both zero-padded and non-padded components, so this stays consistent with the existing behavior for 4-digit years.

## Tests

- `/date/48/2/29` (inbound) now returns 200.
- `reverse(...)` of `datetime(48, 2, 29)` round-trips to a URL that returns 200.
- Existing `reverse('date', {'date': '2019/2/29'})` → `NoReverseMatch` (invalid date) still holds.
- Full suite green (352 tests) and `flake8` clean, verified on Python 3.12 × Django 5.2 in the devcontainer.
