### PR TITLE
:bug: Keep '=' in values for boost_query filter/exclude template filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Fixed
 
 - The `date` path converter now accepts years below 1000 (e.g. `48/2/29`).
+- The `boost_query` `filter`/`exclude` template filters now accept values containing `=`.
 
 ## [3.1.0] - 2026-07-01
 

--- a/django_boost/templatetags/boost_query.py
+++ b/django_boost/templatetags/boost_query.py
@@ -9,7 +9,7 @@ register = template.Library()
 
 @register.filter
 def filter(queryset, arg):
-    k, v = arg.split("=")
+    k, v = arg.split("=", 1)
     return queryset.filter(**{k: v})
 
 
@@ -20,7 +20,7 @@ def order_by(queryset, arg):
 
 @register.filter
 def exclude(queryset, arg):
-    k, v = arg.split("=")
+    k, v = arg.split("=", 1)
     return queryset.exclude(**{k: v})
 
 

--- a/tests/tests/templatetags/test_boost_query.py
+++ b/tests/tests/templatetags/test_boost_query.py
@@ -35,6 +35,31 @@ class TestBoostQueryTemplateTag(TestCase):
             ["bravo", "charlie"],
         )
 
+    def test_filter_value_containing_equals(self):
+        from tests.models import RelatedItemModel
+        from django_boost.templatetags.boost_query import filter
+
+        item = RelatedItemModel.objects.create(name="a=b=c")
+        queryset = RelatedItemModel.objects.filter(pk__in=self.item_ids + [item.pk])
+
+        result = filter(queryset, "name=a=b=c")
+
+        self.assertEqual(list(result.values_list("name", flat=True)), ["a=b=c"])
+
+    def test_exclude_value_containing_equals(self):
+        from tests.models import RelatedItemModel
+        from django_boost.templatetags.boost_query import exclude
+
+        item = RelatedItemModel.objects.create(name="a=b=c")
+        queryset = RelatedItemModel.objects.filter(pk__in=self.item_ids + [item.pk])
+
+        result = exclude(queryset, "name=a=b=c")
+
+        self.assertEqual(
+            list(result.order_by("name").values_list("name", flat=True)),
+            ["alpha", "bravo", "charlie"],
+        )
+
     def test_order_by(self):
         from django_boost.templatetags.boost_query import order_by
 


### PR DESCRIPTION
## Summary

The `boost_query` `filter` and `exclude` template filters split their argument with `arg.split("=")` and unpacked the result into exactly two names. Any value that itself contains `=` (a query string, redirect target, base64 token, ...) produced more than two parts, so the filter raised `ValueError: too many values to unpack` during rendering — and since template-filter exceptions propagate (unlike variable resolution), this surfaces as a 500.

Example that crashed: `{{ qs|filter:"redirect=/next?a=1" }}`.

## Fix

Split on the first `=` only — `arg.split("=", 1)` — in both `filter` and `exclude`, so the lookup key is taken from the left of the first `=` and the value keeps any later `=`.

## Tests

- `filter`/`exclude` with a value containing `=` (`name=a=b=c`) now return the expected queryset instead of raising.
- Full suite green (354 tests) and `flake8` clean, verified on Python 3.12 × Django 5.2 in the devcontainer.
