### PR TITLE
:bug: Stop LogicalDeletionModelAdminMixin from leaking hard-delete site-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - The `date` path converter now accepts years below 1000 (e.g. `48/2/29`).
 - The `boost_query` `filter`/`exclude` template filters now accept values containing `=`.
+- `LogicalDeletionModelAdmin`'s hard-delete action no longer leaks onto other model admins on the same site.
 
 ## [3.1.0] - 2026-07-01
 

--- a/django_boost/admin/mixins.py
+++ b/django_boost/admin/mixins.py
@@ -10,8 +10,14 @@ class LogicalDeletionModelAdminMixin:
         queryset.delete(hard=True)
 
     def get_actions(self, request):
-        self.admin_site.add_action(hard_delete_selected)
-        return super().get_actions(request)
+        # Add the action to this admin's own action set only; add_action()
+        # would register it on the shared AdminSite and leak it to every
+        # other model admin.
+        actions = super().get_actions(request)
+        if actions and self.has_delete_permission(request):
+            func, name, description = self.get_action(hard_delete_selected)
+            actions[name] = (func, name, description)
+        return actions
 
     def get_list_filter(self, request):
         filters = super().get_list_filter(request)

--- a/tests/tests/admin/test_mixins.py
+++ b/tests/tests/admin/test_mixins.py
@@ -1,0 +1,49 @@
+from django.contrib.admin import AdminSite, ModelAdmin
+from django.contrib.auth.models import Group, User
+from django.test import RequestFactory, SimpleTestCase
+
+from django_boost.admin.mixins import LogicalDeletionModelAdminMixin
+
+
+class _AllowAllUser:
+    is_active = True
+    is_superuser = True
+
+    def has_perm(self, perm, obj=None):
+        return True
+
+
+class LogicalAdmin(LogicalDeletionModelAdminMixin, ModelAdmin):
+    pass
+
+
+class LogicalDeletionAdminActionLeakTests(SimpleTestCase):
+    """The hard-delete action must stay on the logical-deletion admin, not
+    leak onto unrelated model admins sharing the same AdminSite."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _request(self):
+        request = self.factory.get("/")
+        request.user = _AllowAllUser()
+        return request
+
+    def test_hard_delete_action_does_not_leak_to_other_model_admins(self):
+        site = AdminSite()
+        logical_admin = LogicalAdmin(User, site)
+        plain_admin = ModelAdmin(Group, site)
+
+        # Baseline: an unrelated admin has no hard-delete action.
+        self.assertNotIn("hard_delete_selected", plain_admin.get_actions(self._request()))
+
+        # Rendering the logical-deletion admin's actions must not change that.
+        logical_admin.get_actions(self._request())
+
+        self.assertNotIn("hard_delete_selected", plain_admin.get_actions(self._request()))
+
+    def test_hard_delete_action_is_available_on_the_logical_deletion_admin(self):
+        site = AdminSite()
+        logical_admin = LogicalAdmin(User, site)
+
+        self.assertIn("hard_delete_selected", logical_admin.get_actions(self._request()))


### PR DESCRIPTION
## Summary

`LogicalDeletionModelAdminMixin.get_actions()` called `self.admin_site.add_action(hard_delete_selected)`, which registers the action on the **shared `AdminSite`**. Once any logical-deletion admin's change list is rendered, `hard_delete_selected` leaks into `_get_base_actions()` for **every** other `ModelAdmin` on the same site. Selecting it on an unrelated model runs `hard_delete_queryset` → `queryset.delete(hard=True)`, and a plain `QuerySet.delete()` rejects the `hard` keyword, raising `TypeError`.

## Fix

Merge `hard_delete_selected` into this admin's own `get_actions()` return value instead of registering it site-wide. The merge is gated on `self.has_delete_permission(request)` (mirroring the action's `allowed_permissions = ('delete',)`) and only runs when the base method returns actions, so disabled-actions, popup, and permission cases are respected.

## Tests

- The action no longer appears on an unrelated `ModelAdmin` after a logical-deletion admin's `get_actions()` runs.
- The action is still available on the logical-deletion admin itself.
- Full suite green (354 tests) and `flake8` clean, verified on Python 3.12 × Django 5.2 in the devcontainer.
