### PR TITLE
:bookmark: Release 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+## [3.1.1] - 2026-07-02
+
 ### Fixed
 
 - The `date` path converter now accepts years below 1000 (e.g. `48/2/29`).
@@ -409,7 +411,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - First release.
 
-[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.1.0...HEAD
+[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.1.1...HEAD
+[3.1.1]: https://github.com/ChanTsune/django-boost/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/ChanTsune/django-boost/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/ChanTsune/django-boost/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/ChanTsune/django-boost/compare/v2.2.0...v3.0.0

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from django_boost.utils.version import get_version
 
-VERSION = (3, 1, 0, 'final', 0)
+VERSION = (3, 1, 1, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
## Summary

Bump the patch version to 3.1.1, releasing the three bug fixes accumulated in the changelog since 3.1.0.

## Notes

The head commit is `:bookmark: Release 3.1.1`, so merging to `master` triggers the tag, GitHub Release, and PyPI publish via `release.yml`.