### PR TITLE
:bug: Decode JsonRequestMixin body by declared charset, tolerate unreadable bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - The `date` path converter now accepts years below 1000 (e.g. `48/2/29`).
 - The `boost_query` `filter`/`exclude` template filters now accept values containing `=`.
 - `LogicalDeletionModelAdmin`'s hard-delete action no longer leaks onto other model admins on the same site.
+- `JsonRequestMixin.json` now honors the request's declared charset and falls back to `{}` for an unreadable body.
 
 ## [3.1.0] - 2026-07-01
 

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -111,13 +111,14 @@ class JsonRequestMixin(AllowContentTypeMixin):
     encoding = 'utf-8'
 
     def get_encoding(self):
-        return self.encoding
+        # Honor a charset declared on the request; fall back to the default.
+        return self.request.content_params.get('charset') or self.encoding
 
     def __json(self):
         try:
-            encoding = self.get_encoding()
-            return json.loads(self.request.body.decode(encoding))
-        except json.JSONDecodeError:
+            return json.loads(self.request.body.decode(self.get_encoding()))
+        except (json.JSONDecodeError, UnicodeDecodeError, LookupError):
+            # Unreadable body (bad charset or bytes) is treated like malformed JSON.
             return {}
 
     @property

--- a/tests/tests/views_mixins/tests.py
+++ b/tests/tests/views_mixins/tests.py
@@ -155,3 +155,33 @@ class TestViewMixins(TestCase):
         url = '/user_kwargs/'
         response = self.client.get(url)
         self.assertStatusCodeEqual(response, 200)
+
+
+class JsonRequestMixinBodyTests(TestCase):
+    """JsonRequestMixin.json honors a declared charset and falls back to {}
+    for an unreadable body, the same as for malformed JSON."""
+
+    def _json_for(self, body, content_type="application/json"):
+        from django.test import RequestFactory
+
+        from tests.tests.views_mixins.views import JsonRequestView
+
+        view = JsonRequestView()
+        view.request = RequestFactory().generic("POST", "/", data=body,
+                                                content_type=content_type)
+        return view.json
+
+    def test_respects_declared_charset(self):
+        body = '{"k": "あ"}'.encode("shift_jis")
+        self.assertEqual(
+            self._json_for(body, "application/json; charset=shift_jis"),
+            {"k": "あ"})
+
+    def test_non_utf8_body_falls_back_to_empty_dict(self):
+        self.assertEqual(self._json_for(b"\xff\xfe"), {})
+
+    def test_malformed_json_falls_back_to_empty_dict(self):
+        self.assertEqual(self._json_for(b"{"), {})
+
+    def test_valid_utf8_json_is_parsed(self):
+        self.assertEqual(self._json_for(b'{"a": 1}'), {"a": 1})


### PR DESCRIPTION

get_encoding() ignored the request's Content-Type charset (always the configured default), and __json() caught only json.JSONDecodeError. A body encoded in a declared non-UTF-8 charset failed to decode, and an undecodable body raised UnicodeDecodeError uncaught -> 500, unlike malformed JSON which fell back to {}. Honor the declared charset and also catch UnicodeDecodeError/LookupError, falling back to {}.

Checklist - While not every PR needs it, new features should consider this list:  

- [x] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
