### PR TITLE
:bug: Tolerate a missing reverse one-to-one in RelatedModelInlineMixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Fixed
 
 - `ModelCRUDViews` create/update now works with a view that defines its own `form_class` or `fields`.
+- `RelatedModelInlineMixin` no longer raises `AttributeError` when a reverse one-to-one related row does not exist yet.
 
 ## [3.1.1] - 2026-07-02
 

--- a/django_boost/forms/mixins.py
+++ b/django_boost/forms/mixins.py
@@ -144,8 +144,10 @@ class RelatedModelInlineMixin:
 
             for field_name, field_object in related_model_fields.items():
                 if self.instance and self.instance.pk:
+                    # default=None: a reverse relation may not exist yet.
                     setattr(field_object, 'initial', getattr_chain(
-                        self.instance, '%s.%s' % (field, field_name)))
+                        self.instance, '%s.%s' % (field, field_name),
+                        default=None))
                 self.fields['%s_%s' % (field, field_name)] = field_object
 
     def save(self, commit=True):

--- a/tests/tests/forms_mixins/tests.py
+++ b/tests/tests/forms_mixins/tests.py
@@ -59,6 +59,19 @@ class TestRelatedModelInlineMixins(TestCase):
         self.assertTrue(form.is_valid())
         form.save()
 
+    def test_reverse_one_to_one_update_without_related_row(self):
+        from .forms import ReverseOneToOneModelForm
+
+        # A parent with a pk but no related row yet: the reverse accessor
+        # raises RelatedObjectDoesNotExist, which must not break __init__.
+        r = self.ReverseOneToOneModel.objects.create(name='orphan')
+
+        form = ReverseOneToOneModelForm(
+            {'name': 'sample', 'reverse_name': 'x'}, instance=r)
+
+        self.assertTrue(form.is_valid())
+        self.assertIsNone(form.fields['reverse_name'].initial)
+
     def test_forward_many_to_many_create(self):
         from .forms import ForwardOneToOneHasManyToManyModelForm
 


### PR DESCRIPTION
## Summary

`RelatedModelInlineMixin.__init__` prefilled each inline field's `initial` via `getattr_chain(self.instance, '<field>.<name>')` with no default, guarded only by `self.instance.pk`. For a reverse one-to-one relation whose related row does not exist yet, the accessor raises `RelatedObjectDoesNotExist` (an `AttributeError` subclass); `getattr_chain` re-raised it as a new `AttributeError`, so the form could not even be constructed. Forward FKs (row present) worked, and the existing tests only covered that.

## Fix

Pass `default=None` to `getattr_chain`, so a not-yet-created reverse relation yields no initial value instead of raising. `field`/`field_name` are already validated before this call, so the default only absorbs the "no related row" case.

## Tests

- Constructing the reverse-one-to-one inline form on a parent with a pk but no related row now succeeds (`is_valid()`), with the reverse field's `initial` left as `None`.
- Full suite green (361 tests) and `flake8` clean, verified on Python 3.12 × Django 5.2 in the devcontainer.
