### PR TITLE
:bug: Build Http405 responses with the correct HttpResponseNotAllowed shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `ModelCRUDViews` create/update now works with a view that defines its own `form_class` or `fields`.
 - `RelatedModelInlineMixin` no longer raises `AttributeError` when a reverse one-to-one related row does not exist yet.
+- `Http405` via `HttpStatusCodeExceptionMiddleware` now returns a valid 405 with an `Allow` header set from its `permitted_methods` argument.
 
 ## [3.1.1] - 2026-07-02
 

--- a/django_boost/http/response.py
+++ b/django_boost/http/response.py
@@ -205,6 +205,10 @@ class Http403(HttpExceptionBase):
 class Http405(HttpExceptionBase):
     response_class = HttpResponseNotAllowed
 
+    def __init__(self, permitted_methods=(), *args):
+        self.permitted_methods = permitted_methods
+        super().__init__(*args)
+
 
 class Http406(HttpExceptionBase):
     response_class = HttpResponseNotAcceptable

--- a/django_boost/middleware/__init__.py
+++ b/django_boost/middleware/__init__.py
@@ -8,6 +8,7 @@ from django.utils.deprecation import MiddlewareMixin
 
 from django_boost.http import STATUS_MESSAGES
 from django_boost.http.response import (
+    Http405,
     HttpExceptionBase,
     HttpRedirectExceptionBase
 )
@@ -104,5 +105,10 @@ class HttpStatusCodeExceptionMiddleware(MiddlewareMixin):
         elif isinstance(e, HttpExceptionBase):
             response_text = self.get_template_from_status_code(
                 e.status_code, request)
+            if isinstance(e, Http405):
+                # HttpResponseNotAllowed takes the allowed methods first, not
+                # the body.
+                return e.response_class(e.permitted_methods,
+                                        content=response_text)
             return e.response_class(response_text)
         return None

--- a/tests/tests/middleware/test_middleware.py
+++ b/tests/tests/middleware/test_middleware.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
 
-from django_boost.http.response import Http301, Http402
+from django_boost.http.response import Http301, Http402, Http405
 from django_boost.middleware import (HttpStatusCodeExceptionMiddleware,
                                       RedirectCorrectHostnameMiddleware)
 
@@ -46,6 +46,33 @@ class HttpStatusCodeExceptionMiddlewareTests(SimpleTestCase):
     def test_unrelated_exception_is_not_handled(self):
         self.assertIsNone(self.middleware.process_exception(
             self.factory.get("/"), ValueError()))
+
+    @override_settings(DEBUG=False)
+    def test_method_not_allowed_sets_allow_and_keeps_body(self):
+        response = self.middleware.process_exception(
+            self.factory.get("/"), Http405(["GET", "POST"]))
+
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response["Allow"], "GET, POST")
+        self.assertEqual(response.content.decode(), "405 Method Not Allowed")
+
+    @override_settings(DEBUG=False)
+    def test_method_not_allowed_without_methods_has_empty_allow(self):
+        response = self.middleware.process_exception(
+            self.factory.get("/"), Http405())
+
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response["Allow"], "")
+        self.assertEqual(response.content.decode(), "405 Method Not Allowed")
+
+    @override_settings(DEBUG=True)
+    def test_method_not_allowed_does_not_crash_in_debug(self):
+        response = self.middleware.process_exception(
+            self.factory.get("/"), Http405(["GET"]))
+
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response["Allow"], "GET")
+        self.assertIn("Method Not Allowed", response.content.decode())
 
 
 class RedirectCorrectHostnameMiddlewareTests(SimpleTestCase):


### PR DESCRIPTION
## Summary

`HttpStatusCodeExceptionMiddleware.process_exception` built every non-redirect response as `response_class(body)`. That is correct for every `HttpResponseXxx` except `Http405.response_class = HttpResponseNotAllowed`, whose Django signature is `__init__(permitted_methods, *args)`. The body string was therefore passed as `permitted_methods` and joined character-by-character into the `Allow` header — raising `BadHeaderError` under `DEBUG=True` (the technical page contains newlines) and, under `DEBUG=False`, producing an empty body with a corrupted `Allow` (e.g. `'4, 0, 5,  , M, e, ...'`).

## Fix

Mirror the existing redirect-exception handling (which carries `self.url`): give `Http405` a `permitted_methods` attribute and special-case it in the middleware, passing the methods first and the body as `content=`. A default `permitted_methods=()` yields an empty `Allow` and no crash; callers can pass the allowed methods for a correct header. `Http405` was never constructed with positional args elsewhere, so the new argument is backward compatible.

## Tests

- `Http405(['GET', 'POST'])` via the middleware returns a 405 with `Allow: GET, POST` and the rendered body.
- `Http405()` returns a 405 with an empty `Allow` and the body.
- `DEBUG=True` no longer raises `BadHeaderError`.
- Full suite green (367 tests) and `flake8` clean, verified on Python 3.12 × Django 5.2 in the devcontainer.
