### PR TITLE
:memo: Document hex/oct/bin path converters as non-negative only

### DIFF
--- a/django_boost/urls/converters/__init__.py
+++ b/django_boost/urls/converters/__init__.py
@@ -6,6 +6,12 @@ from django_boost.urls.converters.date import DateConverter
 
 
 class HexConverter:
+    """Hexadecimal URL converter for non-negative integers.
+
+    Negative values are not supported: ``reverse()`` with one raises
+    ``NoReverseMatch``.
+    """
+
     regex = '[0-9a-fA-F]+'
 
     def to_url(self, value):
@@ -15,6 +21,12 @@ class HexConverter:
 
 
 class OctConverter:
+    """Octal URL converter for non-negative integers.
+
+    Negative values are not supported: ``reverse()`` with one raises
+    ``NoReverseMatch``.
+    """
+
     regex = '[0-7]+'
 
     def to_url(self, value):
@@ -24,6 +36,12 @@ class OctConverter:
 
 
 class BinConverter:
+    """Binary URL converter for non-negative integers.
+
+    Negative values are not supported: ``reverse()`` with one raises
+    ``NoReverseMatch``.
+    """
+
     regex = '[01]+'
 
     def to_url(self, value):


### PR DESCRIPTION
## Summary

The `hex`/`oct`/`bin` path converters encode integers with `hex()`/`oct()`/`bin()` sliced at `[2:]` and match digit-only regexes (`[0-9a-fA-F]+`, `[0-7]+`, `[01]+`). A negative integer therefore cannot round-trip: its encoding keeps no usable sign and does not match the regex, so `reverse()` raises `NoReverseMatch` (and an inbound `-...` URL 404s). Negative values are out of scope for these converters.

This documents that non-negative contract on the base converters. No behavior change — negatives already fail loudly (never a silently wrong URL).

## Tests

- `flake8` clean; the existing `urls_converters` tests still pass (docstring-only change, no CHANGELOG entry needed).
