### PR TITLE
Guard ReAuthenticationRequiredMixin against a None last_login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `ModelCRUDViews` create/update now works with a view that defines its own `form_class` or `fields`.
 - `RelatedModelInlineMixin` no longer raises `AttributeError` when a reverse one-to-one related row does not exist yet.
 - `Http405` via `HttpStatusCodeExceptionMiddleware` now returns a valid 405 with an `Allow` header set from its `permitted_methods` argument.
+- `ReAuthenticationRequiredMixin` no longer raises `TypeError` for an authenticated user whose `last_login` is `None`.
 
 ## [3.1.1] - 2026-07-02
 

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -200,6 +200,9 @@ class ReAuthenticationRequiredMixin(AccessMixin):
         return timedelta(seconds=self.interval)
 
     def need_reauthentication(self, user, delta):
+        if user.last_login is None:
+            # Never recorded a login (last_login is nullable); require re-auth.
+            return True
         return (user.last_login + delta) < now()
 
     def dispatch(self, request, *args, **kwargs):

--- a/tests/tests/views_mixins/tests.py
+++ b/tests/tests/views_mixins/tests.py
@@ -185,3 +185,33 @@ class JsonRequestMixinBodyTests(TestCase):
 
     def test_valid_utf8_json_is_parsed(self):
         self.assertEqual(self._json_for(b'{"a": 1}'), {"a": 1})
+
+
+class ReAuthenticationRequiredMixinTests(TestCase):
+    """need_reauthentication must handle an authenticated user whose
+    last_login is None (never logged in / no update_last_login)."""
+
+    class _User:
+        def __init__(self, last_login):
+            self.last_login = last_login
+
+    def setUp(self):
+        from django_boost.views.mixins import ReAuthenticationRequiredMixin
+        self.mixin = ReAuthenticationRequiredMixin()
+
+    def test_requires_reauth_when_last_login_is_none(self):
+        from datetime import timedelta
+        self.assertTrue(
+            self.mixin.need_reauthentication(self._User(None), timedelta(hours=1)))
+
+    def test_no_reauth_when_recently_logged_in(self):
+        from datetime import timedelta
+        from django.utils.timezone import now
+        self.assertFalse(
+            self.mixin.need_reauthentication(self._User(now()), timedelta(hours=1)))
+
+    def test_requires_reauth_when_login_is_stale(self):
+        from datetime import timedelta
+        from django.utils.timezone import now
+        self.assertTrue(self.mixin.need_reauthentication(
+            self._User(now() - timedelta(hours=2)), timedelta(hours=1)))


### PR DESCRIPTION
## Summary

`ReAuthenticationRequiredMixin.need_reauthentication` computed `(user.last_login + delta)` without a `None` guard. `AbstractBaseUser.last_login` is nullable, so an authenticated user can reach the mixin with `last_login = None` (e.g. a `createsuperuser` account before its first login, or a backend that skips `update_last_login`), raising `TypeError`. A `None` last_login is now treated as needing re-authentication.