### PR TITLE
Raise RelatedObjectDoesNotExist for AutoOneToOneField reverse access on an unsaved parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `AutoOneToOneField` reverse access on an unsaved parent now raises `RelatedObjectDoesNotExist` instead of a `ValueError`.
+
 ## [3.1.2] - 2026-07-03
 
 ### Fixed

--- a/django_boost/models/fields/related_descriptors.py
+++ b/django_boost/models/fields/related_descriptors.py
@@ -18,6 +18,10 @@ class AutoReverseOneToOneDescriptor(ReverseOneToOneDescriptor):
         try:
             return super().__get__(instance, cls)
         except model.DoesNotExist:
+            if instance.pk is None:
+                # No parent pk to create the related object against; surface the
+                # same RelatedObjectDoesNotExist a plain OneToOneField would.
+                raise
             obj, _ = model.objects.get_or_create(
                 **{self.related.field.name: instance})
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,8 +1,20 @@
 from django.db import models
 
+from django_boost.models.fields import AutoOneToOneField
+
 
 class RelatedItemModel(models.Model):
     name = models.CharField(max_length=128)
+
+
+class AutoOneToOneParentModel(models.Model):
+    name = models.CharField(max_length=128)
+
+
+class AutoOneToOneChildModel(models.Model):
+    parent = AutoOneToOneField(
+        to=AutoOneToOneParentModel, related_name='child',
+        on_delete=models.CASCADE)
 
 
 class ForwardOneToOneModel(models.Model):

--- a/tests/tests/models/fields/test_related_descriptors.py
+++ b/tests/tests/models/fields/test_related_descriptors.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+
+from tests.models import AutoOneToOneChildModel, AutoOneToOneParentModel
+
+
+class AutoReverseOneToOneDescriptorTests(TestCase):
+    """`AutoOneToOneField` auto-creates the related object for a saved parent,
+    but an unsaved parent has no pk to create against, so accessing the reverse
+    relation must raise the same `RelatedObjectDoesNotExist` a plain
+    `OneToOneField` would (not a leaked ORM `ValueError`)."""
+
+    def test_unsaved_parent_raises_related_object_does_not_exist(self):
+        parent = AutoOneToOneParentModel(name='unsaved')
+        with self.assertRaises(AutoOneToOneChildModel.DoesNotExist):
+            parent.child
+
+    def test_saved_parent_auto_creates_child(self):
+        parent = AutoOneToOneParentModel.objects.create(name='saved')
+        child = parent.child
+        self.assertIsInstance(child, AutoOneToOneChildModel)
+        self.assertEqual(child.parent_id, parent.pk)


### PR DESCRIPTION
## Summary

`AutoReverseOneToOneDescriptor.__get__` caught the reverse relation's `DoesNotExist` and unconditionally called `get_or_create(field=instance)`. For an unsaved parent (`pk is None`) that filters on an unsaved instance, so the ORM raised the obscure `ValueError: Model instances passed to related filters must be saved.` instead of the `RelatedObjectDoesNotExist` a plain `OneToOneField` raises. An unsaved parent has no pk to auto-create against, so the `DoesNotExist` is now re-raised.