### PR TITLE
Let looplast/loopfirstlast accept any iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `AutoOneToOneField` reverse access on an unsaved parent now raises `RelatedObjectDoesNotExist` instead of a `ValueError`.
 - `adminsitelog`'s `--filter`/`--exclude` now split each condition on its leftmost operator, so a value containing `>=` or `<=` is no longer mis-parsed.
+- `looplast` and `loopfirstlast` now accept any iterable (e.g. a generator), matching `loopfirst`, instead of raising `TypeError`.
 
 ## [3.1.2] - 2026-07-03
 

--- a/django_boost/utils/functions/loop.py
+++ b/django_boost/utils/functions/loop.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Collection, Iterable, Iterator
 from typing import TypeVar
 
 _T = TypeVar("_T")
@@ -18,27 +18,29 @@ def loopfirst(iterable: Iterable[_T]) -> Iterator[tuple[bool, _T]]:
         yield i == 0, val
 
 
-def looplast(iterable: Sequence[_T]) -> Iterator[tuple[bool, _T]]:
+def looplast(iterable: Iterable[_T]) -> Iterator[tuple[bool, _T]]:
     """
     Loop util.
 
     Yield True when the last element of the given iterator object,
     False otherwise.
     """
-    it = iterable
-    last_index = len(it) - 1
-    for i, val in enumerate(it):
+    items: Collection[_T] = (
+        iterable if isinstance(iterable, Collection) else list(iterable))
+    last_index = len(items) - 1
+    for i, val in enumerate(items):
         yield i == last_index, val
 
 
-def loopfirstlast(iterable: Sequence[_T]) -> Iterator[tuple[bool, _T]]:
+def loopfirstlast(iterable: Iterable[_T]) -> Iterator[tuple[bool, _T]]:
     """
     A function combining `firstloop` and` lastloop`.
 
     Yield True if the first and last element of the iterator object,
     False otherwise.
     """
-    it = iterable
-    last_index = len(it) - 1
-    for i, val in enumerate(it):
+    items: Collection[_T] = (
+        iterable if isinstance(iterable, Collection) else list(iterable))
+    last_index = len(items) - 1
+    for i, val in enumerate(items):
         yield i == 0 or i == last_index, val

--- a/tests/tests/utils/functions/test_loop.py
+++ b/tests/tests/utils/functions/test_loop.py
@@ -39,3 +39,15 @@ class LoopFunctionTests(TestCase):
             self.assertEqual([True, True][v], is_first_or_last)
         for is_first_or_last, v in loopfirstlast(self.test_list3):
             self.assertEqual([True, False, True][v], is_first_or_last)
+
+    def test_loopfirst_accepts_iterator(self):
+        self.assertEqual(list(loopfirst(x for x in range(3))),
+                         [(True, 0), (False, 1), (False, 2)])
+
+    def test_looplast_accepts_iterator(self):
+        self.assertEqual(list(looplast(x for x in range(3))),
+                         [(False, 0), (False, 1), (True, 2)])
+
+    def test_loopfirstlast_accepts_iterator(self):
+        self.assertEqual(list(loopfirstlast(x for x in range(3))),
+                         [(True, 0), (False, 1), (True, 2)])


### PR DESCRIPTION
## Summary

`looplast` and `loopfirstlast` computed their last index with `len()`, so a true iterator such as a generator raised `TypeError: object of type 'generator' has no len()` — even though their docstrings advertise an "iterator object" and `loopfirst` already accepts one. They now materialize the input only when it lacks `__len__` (mirroring Django's `forloop.last`), so sized inputs such as lists and QuerySets are not needlessly copied, and the type hint is widened from `Sequence` to `Iterable`.