### PR TITLE
Name the actual function in shortcuts bad-first-argument errors

### DIFF
--- a/django_boost/shortcuts.py
+++ b/django_boost/shortcuts.py
@@ -57,7 +57,7 @@ def get_object_or_exception(klass, *args, exception=None, **kwargs):
         klass__name = klass.__name__ if isinstance(
             klass, type) else klass.__class__.__name__
         raise ValueError(
-            "First argument to get_object_or_default() must be a Model, "
+            "First argument to get_object_or_exception() must be a Model, "
             "Manager, or QuerySet, not '%s'." % klass__name
         )
     try:
@@ -79,7 +79,7 @@ def get_list_or_default(klass, *args, default=None, **kwargs):
         klass__name = klass.__name__ if isinstance(
             klass, type) else klass.__class__.__name__
         raise ValueError(
-            "First argument to get_object_or_default() must be a Model, "
+            "First argument to get_list_or_default() must be a Model, "
             "Manager, or QuerySet, not '%s'." % klass__name
         )
     obj_list = list(queryset.filter(*args, **kwargs))
@@ -101,7 +101,7 @@ def get_list_or_exception(klass, *args, exception=None, **kwargs):
         klass__name = klass.__name__ if isinstance(
             klass, type) else klass.__class__.__name__
         raise ValueError(
-            "First argument to get_object_or_default() must be a Model, "
+            "First argument to get_list_or_exception() must be a Model, "
             "Manager, or QuerySet, not '%s'." % klass__name
         )
     obj_list = list(queryset.filter(*args, **kwargs))

--- a/tests/tests/test_shortcuts.py
+++ b/tests/tests/test_shortcuts.py
@@ -49,3 +49,12 @@ class TestShortCuts(TestCase):
         with self.assertRaises(MyException):
             get_list_or_exception(User, email='no',
                                   exception=MyException)
+
+    def test_bad_first_argument_error_names_the_called_function(self):
+        for func in (get_object_or_default, get_object_or_exception,
+                     get_list_or_default, get_list_or_exception):
+            with self.subTest(func=func.__name__):
+                with self.assertRaisesMessage(
+                        ValueError,
+                        'First argument to %s()' % func.__name__):
+                    func(42)


### PR DESCRIPTION
## Summary

`get_object_or_exception`, `get_list_or_default`, and `get_list_or_exception` each raised a `ValueError` hardcoding `get_object_or_default()` (copied from that function) when the first argument is not a Model/Manager/QuerySet, misnaming the function actually called. Each now names itself.