### PR TITLE
Split adminsitelog filters on the leftmost operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Fixed
 
 - `AutoOneToOneField` reverse access on an unsaved parent now raises `RelatedObjectDoesNotExist` instead of a `ValueError`.
+- `adminsitelog`'s `--filter`/`--exclude` now split each condition on its leftmost operator, so a value containing `>=` or `<=` is no longer mis-parsed.
 
 ## [3.1.2] - 2026-07-03
 

--- a/django_boost/contrib/admin_tools/management/commands/adminsitelog.py
+++ b/django_boost/contrib/admin_tools/management/commands/adminsitelog.py
@@ -39,15 +39,24 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
         return ", ".join(self.get_sortable_fields(self.get_log_entry_model()))
 
     def _parse_filter(self, condition):
-        for op in self.COMPARISON_OPERATION.keys():
-            field, op, value = condition.partition(op)
-            op = self.COMPARISON_OPERATION.get(op, None)
-            if op is not None:
-                return {"%s__%s" % (field, op): value}
-        raise CommandError(
-            "Unsupported filter operation in '%s'; "
-            "--filter and --exclude support: %s"
-            % (condition, ", ".join(self.COMPARISON_OPERATION)))
+        # Split on the operator that appears leftmost in the condition (so a
+        # comparison operator inside the value is not mistaken for the
+        # field/value boundary); at the same position prefer the longer
+        # operator so '>=' wins over '>'.
+        best = None
+        for op in self.COMPARISON_OPERATION:
+            index = condition.find(op)
+            if index != -1 and (best is None or (index, -len(op)) < best[0]):
+                best = ((index, -len(op)), op)
+        if best is None:
+            raise CommandError(
+                "Unsupported filter operation in '%s'; "
+                "--filter and --exclude support: %s"
+                % (condition, ", ".join(self.COMPARISON_OPERATION)))
+        index, op = best[0][0], best[1]
+        lookup = self.COMPARISON_OPERATION[op]
+        return {"%s__%s" % (condition[:index], lookup):
+                condition[index + len(op):]}
 
     def parse_filter(self, conditions):
         parsed = {}

--- a/tests/tests/contrib/admin_tools/management/commands/test_adminsitelog.py
+++ b/tests/tests/contrib/admin_tools/management/commands/test_adminsitelog.py
@@ -238,6 +238,21 @@ class TestAdminSiteLog(TestCase):
         self.assertEqual(
             self._ids_with_filter('action_flag<=1'), [str(self.log.id)])
 
+    def test_parse_filter_splits_on_leftmost_operator(self):
+        # A '>=' inside the value must not be picked over the leading '='; the
+        # leftmost operator is the field/value boundary.
+        self.assertEqual(
+            Command()._parse_filter('object_repr=val>=x'),
+            {'object_repr__exact': 'val>=x'})
+
+    def test_parse_filter_comparison_operators(self):
+        command = Command()
+        self.assertEqual(command._parse_filter('n>=5'), {'n__gte': '5'})
+        self.assertEqual(command._parse_filter('n<=5'), {'n__lte': '5'})
+        self.assertEqual(command._parse_filter('n>5'), {'n__gt': '5'})
+        self.assertEqual(command._parse_filter('n<5'), {'n__lt': '5'})
+        self.assertEqual(command._parse_filter('n=5'), {'n__exact': '5'})
+
     def test_order_by_orders_output(self):
         second = LogEntry.objects.create(
             user=self.user, content_type=self.content_type, object_id='2',


### PR DESCRIPTION
## Summary

`_parse_filter` chose the comparison operator by `COMPARISON_OPERATION` insertion order, so a value containing `>=` or `<=` was picked over a leading `=`, splitting the field/value boundary wrong and building a bogus lookup key (`--filter 'object_repr=val>=x'` became `{'object_repr=val__gte': 'x'}`, which raises `FieldError`). It now selects the operator that appears leftmost in the condition, preferring the longer operator at the same position.