### PR TITLE
:bug: Redirect correctly under ASGI in RedirectCorrectHostnameMiddleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ### Fixed
 
+- `RedirectCorrectHostnameMiddleware` no longer raises a `TypeError` on the redirect path under ASGI; it now redirects correctly on both WSGI and ASGI.
 - `AutoOneToOneField` reverse access on an unsaved parent now raises `RelatedObjectDoesNotExist` instead of a `ValueError`.
 - `adminsitelog`'s `--filter`/`--exclude` now split each condition on its leftmost operator, so a value containing `>=` or `<=` is no longer mis-parsed.
 - `looplast` and `loopfirstlast` now accept any iterable (e.g. a generator), matching `loopfirst`, instead of raising `TypeError`.

--- a/django_boost/middleware/__init__.py
+++ b/django_boost/middleware/__init__.py
@@ -53,14 +53,19 @@ class RedirectCorrectHostnameMiddleware(MiddlewareMixin):
     but it is useful when the setting is troublesome or when using services such as heroku.
     """
 
-    def __call__(self, request):
+    def process_request(self, request):
+        # Return the redirect from process_request rather than overriding
+        # __call__, so MiddlewareMixin's own __call__/__acall__ short-circuit
+        # correctly under both WSGI and ASGI. A synchronous __call__ override
+        # would return a bare HttpResponse on the async path, which Django then
+        # awaits -> TypeError.
         enabled = not settings.DEBUG and hasattr(settings, 'CORRECT_HOST')
         if enabled and request.get_host() != settings.CORRECT_HOST:
             return HttpResponsePermanentRedirect(
                 '{scheme}://{host}{path}'.format(scheme=request.scheme,
                                                  host=settings.CORRECT_HOST,
                                                  path=request.get_full_path()))
-        return self.get_response(request)
+        return None
 
 
 class HttpStatusCodeExceptionMiddleware(MiddlewareMixin):

--- a/tests/tests/middleware/test_middleware.py
+++ b/tests/tests/middleware/test_middleware.py
@@ -114,3 +114,30 @@ class RedirectCorrectHostnameMiddlewareTests(SimpleTestCase):
             self.factory.get("/", HTTP_HOST="wrong.example.com"))
 
         self.assertEqual(response.status_code, 200)
+
+    def _async_middleware(self):
+        async def get_response(request):
+            self.downstream.append(request)
+            return HttpResponse()
+        return RedirectCorrectHostnameMiddleware(get_response)
+
+    @override_settings(DEBUG=False, CORRECT_HOST="correct.example.com",
+                       ALLOWED_HOSTS=["*"])
+    async def test_redirects_when_hostname_differs_async(self):
+        """Under ASGI (async get_response) the redirect path must not crash."""
+        response = await self._async_middleware()(
+            self.factory.get("/page?x=1", HTTP_HOST="wrong.example.com"))
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"],
+                         "http://correct.example.com/page?x=1")
+        self.assertEqual(self.downstream, [])  # not forwarded to the view
+
+    @override_settings(DEBUG=False, CORRECT_HOST="correct.example.com",
+                       ALLOWED_HOSTS=["*"])
+    async def test_no_redirect_when_hostname_matches_async(self):
+        response = await self._async_middleware()(
+            self.factory.get("/", HTTP_HOST="correct.example.com"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(self.downstream), 1)


### PR DESCRIPTION
## Summary

`RedirectCorrectHostnameMiddleware` raised `TypeError: object HttpResponsePermanentRedirect can't be used in 'await' expression` on the redirect path under ASGI (async `get_response`), returning a 500 instead of a 301.

The redirect is now returned from a `process_request()` hook instead of overriding `__call__`, so `MiddlewareMixin`'s `__call__`/`__acall__` short-circuit correctly on both WSGI and ASGI.

## Notes

- The synchronous `__call__` override returned a bare `HttpResponsePermanentRedirect` on the async path, which Django then awaited. The pass-through branch worked only incidentally because it returned the awaitable from `get_response`.
- Added sync + async redirect / no-redirect tests.