### PR TITLE
:bug: Stop JsonResponseMixin.get_context_data from mutating shared extra_context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ### Fixed
 
+- `JsonResponseMixin.get_context_data` no longer mutates the shared class-level `extra_context`, so request-specific keyword arguments no longer leak into later requests.
 - `RedirectCorrectHostnameMiddleware` no longer raises a `TypeError` on the redirect path under ASGI; it now redirects correctly on both WSGI and ASGI.
 - `AutoOneToOneField` reverse access on an unsaved parent now raises `RelatedObjectDoesNotExist` instead of a `ValueError`.
 - `adminsitelog`'s `--filter`/`--exclude` now split each condition on its leftmost operator, so a value containing `>=` or `<=` is no longer mis-parsed.

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -139,7 +139,9 @@ class JsonResponseMixin:
     extra_context = None
 
     def get_context_data(self, **kwargs):
-        context = self.extra_context or {}
+        # Copy extra_context into a fresh dict; updating it in place would
+        # mutate the shared class attribute and leak kwargs across requests.
+        context = dict(self.extra_context or {})
         context.update(kwargs)
         return context
 

--- a/tests/tests/views_mixins/tests.py
+++ b/tests/tests/views_mixins/tests.py
@@ -215,3 +215,31 @@ class ReAuthenticationRequiredMixinTests(TestCase):
         from django.utils.timezone import now
         self.assertTrue(self.mixin.need_reauthentication(
             self._User(now() - timedelta(hours=2)), timedelta(hours=1)))
+
+
+class JsonResponseMixinContextTests(TestCase):
+    """get_context_data must not mutate or alias the class-level extra_context,
+    otherwise request-specific kwargs leak into later requests."""
+
+    def _view_class(self):
+        from django_boost.views.mixins import JsonResponseMixin
+
+        class V(JsonResponseMixin):
+            extra_context = {'site': 'x'}
+        return V
+
+    def test_does_not_mutate_class_extra_context(self):
+        V = self._view_class()
+        V().get_context_data(pk=1)
+        self.assertEqual(V.extra_context, {'site': 'x'})
+
+    def test_does_not_leak_kwargs_across_instances(self):
+        V = self._view_class()
+        V().get_context_data(pk=1)
+        self.assertEqual(V().get_context_data(), {'site': 'x'})
+
+    def test_returns_a_fresh_dict_not_the_class_attribute(self):
+        V = self._view_class()
+        context = V().get_context_data(pk=1)
+        self.assertEqual(context, {'site': 'x', 'pk': 1})
+        self.assertIsNot(context, V.extra_context)


### PR DESCRIPTION
## Summary

`JsonResponseMixin.get_context_data` did `context = self.extra_context or {}` and then `context.update(kwargs)`, mutating the shared class-level `extra_context` in place and aliasing it out to the caller. Request-specific kwargs (e.g. a URL `pk`) leaked into the shared dict and surfaced in later requests and other instances. It now copies `extra_context` into a fresh dict, matching Django's `ContextMixin`.

## Notes

- The default `JsonView` (no kwargs) was unaffected; the leak triggered when a subclass passed kwargs into `get_context_data`.