### PR TITLE
:bug: Preserve custom delete_flag_field across queryset clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `JsonResponseMixin.get_context_data` no longer mutates the shared class-level `extra_context`, so request-specific keyword arguments no longer leak into later requests.
 - `RedirectCorrectHostnameMiddleware` no longer raises a `TypeError` on the redirect path under ASGI; it now redirects correctly on both WSGI and ASGI.
+- A custom `delete_flag_field` on `LogicalDeletionManager` now survives queryset cloning, so a chained `filter(...).alive()`/`dead()`/`revive()` no longer raises `FieldError`.
 - `AutoOneToOneField` reverse access on an unsaved parent now raises `RelatedObjectDoesNotExist` instead of a `ValueError`.
 - `adminsitelog`'s `--filter`/`--exclude` now split each condition on its leftmost operator, so a value containing `>=` or `<=` is no longer mis-parsed.
 - `looplast` and `loopfirstlast` now accept any iterable (e.g. a generator), matching `loopfirst`, instead of raising `TypeError`.

--- a/django_boost/models/query.py
+++ b/django_boost/models/query.py
@@ -12,6 +12,15 @@ class LogicalDeletionQuerySet(QuerySet):
     def get_delete_flag_field_name(self):
         return self.delete_flag_field
 
+    def _clone(self):
+        # delete_flag_field is set as an instance attribute by the manager, but
+        # QuerySet._clone() only copies a fixed set of attributes, so carry it
+        # forward or a chained alive()/dead()/revive() would fall back to the
+        # class default and query the wrong column.
+        clone = super()._clone()
+        clone.delete_flag_field = self.delete_flag_field
+        return clone
+
     def delete(self, hard=False, deleted_at=None):
         if hard:
             return super().delete()

--- a/tests/tests/logical_deletion/tests.py
+++ b/tests/tests/logical_deletion/tests.py
@@ -420,3 +420,22 @@ class LogicalDeletionManagerCustomFieldTests(TestCase):
             queryset = CustomFieldModel.objects.get_queryset()
 
         self.assertEqual(queryset.get_delete_flag_field_name(), "removed_at")
+
+    def test_custom_delete_flag_field_survives_clone(self):
+        with isolate_apps("tests"):
+            class RemovedManager(LogicalDeletionManager):
+                delete_flag_field = "removed_at"
+
+            class CustomFieldModel(models.Model):
+                removed_at = models.DateTimeField(null=True, default=None)
+                objects = RemovedManager()
+
+                class Meta:
+                    app_label = "tests"
+
+            # A cloning method (filter/all/order_by) must not drop the custom
+            # field; alive() on the clone must filter on removed_at, not the
+            # class-default deleted_at (which would raise FieldError).
+            queryset = CustomFieldModel.objects.filter(pk__gt=0).alive()
+
+        self.assertEqual(queryset.get_delete_flag_field_name(), "removed_at")


### PR DESCRIPTION
## Summary

A custom `delete_flag_field` on a `LogicalDeletionManager` subclass was lost after any cloning queryset method, so a chained `filter(...).alive()` / `dead()` / `revive()` fell back to the class-default `deleted_at` column and raised `FieldError`. `LogicalDeletionQuerySet._clone()` now carries `delete_flag_field` forward.

## Notes

- The manager sets `delete_flag_field` as a queryset instance attribute, but `QuerySet._clone()` copies only a fixed set of attributes, so the un-chained `objects.alive()` worked while the chained form did not.