### PR TITLE
:bug: Honor commit=False in RelatedModelInlineMixin.save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `RelatedModelInlineMixin.save(commit=False)` no longer writes to the database; its inline related objects are now persisted by `save_m2m()`, following Django's `ModelForm` contract.
+
 ## [3.2.1] - 2026-07-05
 
 ### Fixed

--- a/django_boost/forms/mixins.py
+++ b/django_boost/forms/mixins.py
@@ -152,39 +152,53 @@ class RelatedModelInlineMixin:
 
     def save(self, commit=True):
         object = super().save(commit=False)
-        for field, related_fields in self.inline_fields.items():
-            related_model = self._related_field_model[field]
-            rel_opts = related_model._meta
-            pk_field_name = rel_opts.pk.attname
-            rel_pk_field_name = '%s_%s' % (field, pk_field_name)
-            if not hasattr(object, rel_pk_field_name):
-                # case of reverse access
-                if hasattr(object, field):
+
+        def save_inline():
+            for field, related_fields in self.inline_fields.items():
+                related_model = self._related_field_model[field]
+                rel_opts = related_model._meta
+                pk_field_name = rel_opts.pk.attname
+                rel_pk_field_name = '%s_%s' % (field, pk_field_name)
+                if not hasattr(object, rel_pk_field_name):
+                    # case of reverse access
+                    if hasattr(object, field):
+                        target_field = getattr(object, field)
+                    else:
+                        name = None
+                        for f in rel_opts.fields:
+                            if f.related_model == type(object):
+                                name = f.name
+                                object.save()
+                        target_field = related_model(**{name: object})
+                elif getattr(object, rel_pk_field_name) is None:
+                    target_field = related_model()
+                else:
                     target_field = getattr(object, field)
-                else:
-                    name = None
-                    for f in rel_opts.fields:
-                        if f.related_model == type(object):
-                            name = f.name
-                            object.save()
-                    target_field = related_model(**{name: object})
-            elif getattr(object, rel_pk_field_name) is None:
-                target_field = related_model()
-            else:
-                target_field = getattr(object, field)
-            for related_field in related_fields:
-                value = self.cleaned_data['%s_%s' % (field, related_field)]
-                if self._is_many_to_many(rel_opts, related_field):
-                    target_field.save()
-                    getattr(target_field, related_field).set(value)
-                else:
-                    setattr(target_field, related_field, value)
-            if commit:
+                for related_field in related_fields:
+                    value = self.cleaned_data['%s_%s' % (field, related_field)]
+                    if self._is_many_to_many(rel_opts, related_field):
+                        target_field.save()
+                        getattr(target_field, related_field).set(value)
+                    else:
+                        setattr(target_field, related_field, value)
                 target_field.save()
-            setattr(object, rel_pk_field_name, target_field.pk)
-            setattr(object, field, target_field)
-        if commit:
+                setattr(object, rel_pk_field_name, target_field.pk)
+                setattr(object, field, target_field)
             object.save()
+
+        if commit:
+            save_inline()
+        else:
+            # Honor Django's ModelForm.save(commit=False) contract: perform no
+            # DB writes now and defer them (plus the base form's own m2m) to
+            # save_m2m(). The m2m branch in particular cannot run before the
+            # target row exists.
+            base_save_m2m = self.save_m2m
+
+            def save_m2m():
+                base_save_m2m()
+                save_inline()
+            self.save_m2m = save_m2m
         return object
 
     def _is_many_to_many(self, rel_opts, field_name):

--- a/tests/tests/forms_mixins/tests.py
+++ b/tests/tests/forms_mixins/tests.py
@@ -117,6 +117,104 @@ class TestRelatedModelInlineMixins(TestCase):
         self.assertTrue(form.is_valid())
         form.save()
 
+    def test_reverse_one_to_one_create_commit_false_writes_nothing(self):
+        from .forms import ReverseOneToOneModelForm
+
+        Reverse = self.ReverseOneToOneModel
+        Forward = self.ForwardOneToOneModel
+        form = ReverseOneToOneModelForm(
+            {'name': 'sample', 'reverse_name': 'reverse_sample'})
+        self.assertTrue(form.is_valid())
+        before = Reverse.objects.count()
+        forward_before = Forward.objects.count()
+
+        obj = form.save(commit=False)
+
+        self.assertEqual(Reverse.objects.count(), before)
+        self.assertEqual(Forward.objects.count(), forward_before)
+        self.assertIsNone(obj.pk)
+
+        obj.save()
+        form.save_m2m()
+
+        self.assertEqual(Reverse.objects.count(), before + 1)
+        self.assertEqual(Forward.objects.count(), forward_before + 1)
+        obj.refresh_from_db()
+        self.assertEqual(obj.name, 'sample')
+        self.assertEqual(obj.reverse.name, 'reverse_sample')
+
+    def test_forward_many_to_many_commit_false_defers_write(self):
+        from .forms import ForwardOneToOneHasManyToManyModelForm
+
+        Parent = self.ForwardOneToOneHasManyToManyModel
+        Related = self.ForwardOneToOneHasManyToManyRelatedModel
+        form = ForwardOneToOneHasManyToManyModelForm(
+            {'name': 'sample', 'forward_items': [self.item1.pk]})
+        self.assertTrue(form.is_valid())
+        parent_before = Parent.objects.count()
+        before = Related.objects.count()
+
+        obj = form.save(commit=False)
+        self.assertEqual(Parent.objects.count(), parent_before)
+        self.assertEqual(Related.objects.count(), before)
+        self.assertIsNone(obj.pk)
+
+        form.save_m2m()
+        self.assertEqual(Parent.objects.count(), parent_before + 1)
+        self.assertEqual(Related.objects.count(), before + 1)
+        obj.refresh_from_db()
+        self.assertEqual(obj.name, 'sample')
+        self.assertEqual(list(obj.forward.items.all()), [self.item1])
+
+    def test_forward_many_to_many_update_commit_false_defers_write(self):
+        from .forms import ForwardOneToOneHasManyToManyModelForm
+
+        r = self.ForwardOneToOneHasManyToManyRelatedModel.objects.create()
+        r.items.set([self.item1])
+        f = self.ForwardOneToOneHasManyToManyModel.objects.create(
+            name='-----', forward=r)
+
+        form = ForwardOneToOneHasManyToManyModelForm(
+            {'name': 'sample', 'forward_items': [self.item2.pk]},
+            instance=f)
+        self.assertTrue(form.is_valid())
+
+        obj = form.save(commit=False)
+        r.refresh_from_db()
+        self.assertEqual(list(r.items.all()), [self.item1])
+
+        form.save_m2m()
+        r.refresh_from_db()
+        self.assertEqual(list(r.items.all()), [self.item2])
+        obj.refresh_from_db()
+        self.assertEqual(obj.name, 'sample')
+
+    def test_reverse_many_to_many_commit_false_defers_write(self):
+        from .forms import ReverseOneToOneHasManyToManyModelForm
+
+        Parent = self.ReverseOneToOneHasManyToManyModel
+        Related = self.ReverseOneToOneHasManyToManyRelatedModel
+        form = ReverseOneToOneHasManyToManyModelForm(
+            {'name': 'sample', 'reverse_items': [self.item2.pk]})
+        self.assertTrue(form.is_valid())
+        parent_before = Parent.objects.count()
+        before = Related.objects.count()
+
+        obj = form.save(commit=False)
+        self.assertEqual(Parent.objects.count(), parent_before)
+        self.assertEqual(Related.objects.count(), before)
+        self.assertIsNone(obj.pk)
+
+        obj.save()
+        self.assertEqual(Related.objects.count(), before)
+
+        form.save_m2m()
+        self.assertEqual(Parent.objects.count(), parent_before + 1)
+        self.assertEqual(Related.objects.count(), before + 1)
+        obj.refresh_from_db()
+        self.assertEqual(obj.name, 'sample')
+        self.assertEqual(list(obj.reverse.items.all()), [self.item2])
+
     @classmethod
     def tearDownClass(cls):
         pass


### PR DESCRIPTION
## Summary

`RelatedModelInlineMixin.save(commit=False)` inserted rows into the database: the reverse-relation parent (`object.save()`) and any many-to-many target (`target_field.save()`) were saved unconditionally. It now defers all inline writes to `save_m2m()`, so `save(commit=False)` performs no database writes, matching Django's `ModelForm` contract.

## Notes

- Because a forward-relation `object` depends on its inline target's pk, `save_m2m()` performs the full inline persistence (including `object.save()`); it also chains the base `ModelForm`'s own `save_m2m`.