### PR TITLE
:bug: Tolerate a placeholder-less custom message in ContainAnyValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `adminsitelog` now reports an unknown `--filter`/`--exclude`/`--order_by` field name as a command error instead of an unhandled `FieldError` traceback.
 - Comparing two `ContainAnyValidator` instances no longer raises `AttributeError`; `__init__` now initializes the inherited `limit_value`.
+- `ContainAnyValidator` no longer raises `TypeError` when its custom message omits the `%s` placeholder; it raises `ValidationError` with the message verbatim.
 
 ## [3.2.0] - 2026-07-04
 

--- a/django_boost/validators/collection.py
+++ b/django_boost/validators/collection.py
@@ -23,4 +23,10 @@ class ContainAnyValidator(BaseValidator):
 
     def __call__(self, value: Any) -> None:
         if not contain_any(value, self.limit_value):
-            raise ValidationError(self.message % (self.limit_value,))
+            message: Any = self.message
+            try:
+                message = message % (self.limit_value,)
+            except TypeError:
+                # A custom message may omit the %-placeholder; use it verbatim.
+                pass
+            raise ValidationError(message)

--- a/tests/tests/test_validators.py
+++ b/tests/tests/test_validators.py
@@ -70,6 +70,13 @@ class TestValidator(TestCase):
         self.assertNotEqual(
             ContainAnyValidator(("a",)), ContainAnyValidator(("b",)))
 
+    def test_contain_any_custom_message_without_placeholder(self):
+        # A custom message with no %-placeholder must still raise
+        # ValidationError, not a string-formatting TypeError.
+        validator = ContainAnyValidator(("a", "b"), "Supply a valid token")
+        with self.assertRaisesMessage(ValidationError, "Supply a valid token"):
+            validator("xyz")
+
 
 class NonZeroValidatorDeconstruct(TestCase):
     """`NonZeroValidator` serializes to its public path for migrations."""


### PR DESCRIPTION
## Summary

`ContainAnyValidator` interpolated its message with `self.message % (self.elements,)` unconditionally, so a custom message without a `%s` placeholder raised `TypeError: not all arguments converted during string formatting` on the failure path instead of `ValidationError`. The interpolation is now guarded; a placeholder-less message is used verbatim, while messages containing `%s` still interpolate.