### PR TITLE
:bug: Round-trip relation fields in json_to_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Fixed
 
 - `RelatedModelInlineMixin.save(commit=False)` no longer writes to the database; its inline related objects are now persisted by `save_m2m()`, following Django's `ModelForm` contract.
+- `json_to_model` no longer raises `ValueError` for models with a relation field; it round-trips `model_to_json` output by assigning to the field's `*_id` column.
 
 ## [3.2.1] - 2026-07-05
 

--- a/django_boost/utils/functions/json.py
+++ b/django_boost/utils/functions/json.py
@@ -35,5 +35,8 @@ def json_to_model(model_class, dic, fields=(), exclude=()):
             continue
         if exclude and f.name in exclude:
             continue
-        setattr(model, f.name, dic[f.name])
+        # Assign via attname so relation fields receive the stored pk on their
+        # *_id column; for plain fields name == attname. model_to_json keys the
+        # value by f.name but stores value_from_object (the attname value).
+        setattr(model, f.attname, dic[f.name])
     return model

--- a/tests/tests/utils/functions/test_json.py
+++ b/tests/tests/utils/functions/test_json.py
@@ -1,6 +1,7 @@
 from django_boost.test import TestCase
-from django_boost.utils.functions import model_to_json
-from tests.models import RelatedItemModel
+from django_boost.utils.functions import json_to_model, model_to_json
+from tests.models import (ForwardOneToOneModel, RelatedItemModel,
+                          ReverseOneToOneModel)
 
 
 class ModelToJsonTests(TestCase):
@@ -19,3 +20,15 @@ class ModelToJsonTests(TestCase):
         result = model_to_json(queryset)
         self.assertIsInstance(result, list)
         self.assertEqual([d["name"] for d in result], ["a", "b"])
+
+
+class JsonToModelTests(TestCase):
+
+    def test_round_trip_with_relation_field(self):
+        r = ReverseOneToOneModel.objects.create(name="r")
+        f = ForwardOneToOneModel.objects.create(name="f", forward=r)
+
+        rebuilt = json_to_model(ForwardOneToOneModel, model_to_json(f))
+
+        self.assertEqual(rebuilt.name, "f")
+        self.assertEqual(rebuilt.forward_id, r.pk)


### PR DESCRIPTION
## Summary

`json_to_model` did `setattr(model, f.name, dic[f.name])`, so a model with a foreign key / one-to-one field raised `ValueError: Cannot assign "1": ... must be a "..." instance` when fed `model_to_json` output (which stores the pk under the field name). It now assigns via `f.attname` (the `*_id` column), so the two functions round-trip. Plain fields are unaffected since `name == attname`.