### PR TITLE
:bug: Honor response_class in JsonResponseMixin.get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `adminsitelog` now reports an unknown `--filter`/`--exclude`/`--order_by` field name as a command error instead of an unhandled `FieldError` traceback.
 - Comparing two `ContainAnyValidator` instances no longer raises `AttributeError`; `__init__` now initializes the inherited `limit_value`.
 - `ContainAnyValidator` no longer raises `TypeError` when its custom message omits the `%s` placeholder; it raises `ValidationError` with the message verbatim.
+- `JsonResponseMixin.get` now builds the response with the view's `response_class` instead of a hardcoded `JsonResponse`, so a custom response class takes effect.
 
 ## [3.2.0] - 2026-07-04
 

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -148,7 +148,7 @@ class JsonResponseMixin:
         return context
 
     def get(self, request, *args, **kwargs):
-        return JsonResponse(self.get_context_data())
+        return self.response_class(self.get_context_data())
 
     post = get
     put = post

--- a/tests/tests/views_mixins/tests.py
+++ b/tests/tests/views_mixins/tests.py
@@ -267,3 +267,23 @@ class JsonResponseMixinContextTests(TestCase):
         context = V().get_context_data(pk=1)
         self.assertEqual(context, {'site': 'x', 'pk': 1})
         self.assertIsNot(context, V.extra_context)
+
+
+class JsonResponseMixinResponseClassTests(TestCase):
+    """JsonResponseMixin.get must build the response with the configured
+    response_class, not a hardcoded JsonResponse."""
+
+    def test_get_uses_configured_response_class(self):
+        from django.http import JsonResponse
+        from django.test import RequestFactory
+
+        from django_boost.views.mixins import JsonResponseMixin
+
+        class MyJsonResponse(JsonResponse):
+            pass
+
+        class V(JsonResponseMixin):
+            response_class = MyJsonResponse
+
+        response = V().get(RequestFactory().get("/"))
+        self.assertIsInstance(response, MyJsonResponse)


### PR DESCRIPTION
## Summary

`JsonResponseMixin` declared `response_class = JsonResponse` as an overridable extension point, but `get` hardcoded `JsonResponse(...)`, so a subclass that set `response_class` (e.g. a custom encoder/headers) was ignored. `get` now uses `self.response_class(...)`, matching the sibling `ResponseContentMixin`.