### PR TITLE
:bug: Preserve ColorCodeField upper/lower in deconstruct()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - Comparing two `ContainAnyValidator` instances no longer raises `AttributeError`; `__init__` now initializes the inherited `limit_value`.
 - `ContainAnyValidator` no longer raises `TypeError` when its custom message omits the `%s` placeholder; it raises `ValidationError` with the message verbatim.
 - `JsonResponseMixin.get` now builds the response with the view's `response_class` instead of a hardcoded `JsonResponse`, so a custom response class takes effect.
+- `ColorCodeField` now implements `deconstruct()`, so its `upper`/`lower` option is preserved in migrations instead of being dropped.
 
 ## [3.2.0] - 2026-07-04
 

--- a/django_boost/models/fields/__init__.py
+++ b/django_boost/models/fields/__init__.py
@@ -33,6 +33,14 @@ class ColorCodeField(CharField):
             self.normalize = self._no_convert
         super().__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        if self.upper:
+            kwargs["upper"] = True
+        if self.lower:
+            kwargs["lower"] = True
+        return name, path, args, kwargs
+
     def _upper_convert(self, value):
         return value.upper() if value is not None else value
 

--- a/tests/tests/models/test_fields.py
+++ b/tests/tests/models/test_fields.py
@@ -18,6 +18,23 @@ class ColorCodeFieldTests(SimpleTestCase):
     def test_lower_keeps_none(self):
         self.assertIsNone(ColorCodeField(lower=True).to_python(None))
 
+    def test_deconstruct_preserves_upper(self):
+        name, path, args, kwargs = ColorCodeField(upper=True).deconstruct()
+        self.assertTrue(kwargs.get("upper"))
+        rebuilt = ColorCodeField(*args, **kwargs)
+        self.assertEqual(rebuilt.to_python("#abcdef"), "#ABCDEF")
+
+    def test_deconstruct_preserves_lower(self):
+        name, path, args, kwargs = ColorCodeField(lower=True).deconstruct()
+        self.assertTrue(kwargs.get("lower"))
+        rebuilt = ColorCodeField(*args, **kwargs)
+        self.assertEqual(rebuilt.to_python("#ABCDEF"), "#abcdef")
+
+    def test_deconstruct_omits_flags_by_default(self):
+        name, path, args, kwargs = ColorCodeField().deconstruct()
+        self.assertNotIn("upper", kwargs)
+        self.assertNotIn("lower", kwargs)
+
 
 class ColorCodeFiledDeprecationTests(SimpleTestCase):
     """`ColorCodeFiled` is the misspelled, deprecated alias of `ColorCodeField`."""


### PR DESCRIPTION
## Summary

`ColorCodeField` added custom `upper`/`lower` kwargs but did not override `deconstruct()`, so `ColorCodeField(upper=True)` deconstructed to `ColorCodeField(max_length=7)`. Migrations and other reconstructed fields lost the flag and stopped normalizing case, and `makemigrations` could not tell `upper=True` from `lower=True`. `deconstruct()` now re-emits the non-default flags.