### PR TITLE
:bug: Use bulk log_deletions in the admin hard-delete action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `RelatedModelInlineMixin.save(commit=False)` no longer writes to the database; its inline related objects are now persisted by `save_m2m()`, following Django's `ModelForm` contract.
 - `json_to_model` no longer raises `ValueError` for models with a relation field; it round-trips `model_to_json` output by assigning to the field's `*_id` column.
+- The admin hard-delete action now logs deletions with Django 5.1+'s bulk `log_deletions()` when available, avoiding the `log_deletion()` deprecation warning.
 
 ## [3.2.1] - 2026-07-05
 

--- a/django_boost/admin/actions.py
+++ b/django_boost/admin/actions.py
@@ -24,9 +24,14 @@ def hard_delete_selected(modeladmin, request, queryset):
             raise PermissionDenied
         n = queryset.count()
         if n:
-            for obj in queryset:
-                obj_display = str(obj)
-                modeladmin.log_deletion(request, obj, obj_display)
+            # log_deletions() replaced the per-object log_deletion() in Django
+            # 5.1 (log_deletion() is deprecated); prefer it when available,
+            # falling back on Django 4.2/5.0.
+            if hasattr(modeladmin, 'log_deletions'):
+                modeladmin.log_deletions(request, queryset)
+            else:
+                for obj in queryset:
+                    modeladmin.log_deletion(request, obj, str(obj))
             modeladmin.hard_delete_queryset(request, queryset)
             modeladmin.message_user(request, _("Successfully deleted %(count)d %(items)s.") % {
                 "count": n, "items": model_ngettext(modeladmin.opts, n)

--- a/tests/tests/admin/test_actions.py
+++ b/tests/tests/admin/test_actions.py
@@ -1,0 +1,90 @@
+from django.contrib.admin import AdminSite, ModelAdmin
+from django.test import RequestFactory, TestCase
+
+from django_boost.admin.actions import hard_delete_selected
+from django_boost.admin.mixins import LogicalDeletionModelAdminMixin
+from tests.models import RelatedItemModel
+
+
+class _AllowAllUser:
+    is_active = True
+    is_superuser = True
+    pk = 1
+
+    def has_perm(self, perm, obj=None):
+        return True
+
+
+class _SpyAdmin(LogicalDeletionModelAdminMixin, ModelAdmin):
+    """Records which logging API the action used, without touching LogEntry."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.logged_bulk = False
+        self.logged_single = 0
+
+    def get_deleted_objects(self, queryset, request):
+        return ([], {}, [], [])
+
+    def hard_delete_queryset(self, request, queryset):
+        pass
+
+    def message_user(self, *args, **kwargs):
+        pass
+
+    def log_deletions(self, request, queryset):
+        self.logged_bulk = True
+
+    def log_deletion(self, request, obj, obj_display):
+        self.logged_single += 1
+
+
+class _FallbackAdmin:
+    """A model admin without log_deletions (as on Django 4.2/5.0), providing
+    only what the confirmed hard-delete path touches."""
+
+    def __init__(self, model):
+        self.model = model
+        self.opts = model._meta
+        self.logged_single = 0
+
+    def get_deleted_objects(self, queryset, request):
+        return ([], {}, [], [])
+
+    def hard_delete_queryset(self, request, queryset):
+        pass
+
+    def message_user(self, *args, **kwargs):
+        pass
+
+    def log_deletion(self, request, obj, obj_display):
+        self.logged_single += 1
+
+
+class HardDeleteLoggingTests(TestCase):
+    """The confirmed hard-delete must use the bulk log_deletions() API rather
+    than the per-object log_deletion() deprecated in Django 5.1."""
+
+    def _confirmed_request(self):
+        request = RequestFactory().post("/", {"post": "yes"})
+        request.user = _AllowAllUser()
+        return request
+
+    def test_confirmed_hard_delete_uses_bulk_logging(self):
+        admin = _SpyAdmin(RelatedItemModel, AdminSite())
+        RelatedItemModel.objects.create(name="a")
+
+        hard_delete_selected(
+            admin, self._confirmed_request(), RelatedItemModel.objects.all())
+
+        self.assertTrue(admin.logged_bulk)
+        self.assertEqual(admin.logged_single, 0)
+
+    def test_confirmed_hard_delete_falls_back_to_per_object_logging(self):
+        admin = _FallbackAdmin(RelatedItemModel)
+        RelatedItemModel.objects.create(name="a")
+
+        hard_delete_selected(
+            admin, self._confirmed_request(), RelatedItemModel.objects.all())
+
+        self.assertEqual(admin.logged_single, 1)


### PR DESCRIPTION
## Summary

The admin hard-delete action logged each object with the per-object `ModelAdmin.log_deletion()`, which Django 5.1 deprecated (`RemovedInDjango60Warning`, one per object; an error under warnings-as-errors). It now prefers the bulk `log_deletions(request, queryset)` when available, falling back to the per-object loop on Django 4.2/5.0 where `log_deletions` does not exist.

## Notes

- `log_deletions` was added in Django 5.1, so the fix is guarded with `hasattr` rather than calling it unconditionally.