### PR TITLE
:bug: Delete only top-level migration files in deletemigrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ### Fixed
 
+- `deletemigrations` now deletes only the top-level migration modules, no longer descending into subpackages under `migrations/` and removing unrelated `.py` files.
 - `getattr_chain` without a default now propagates the underlying `AttributeError` instead of rewriting it into a generic one.
 - The `urlencode`/`urldecode` template filters now coerce a non-string value (e.g. an int or `None`) to `str`, instead of raising `TypeError`.
 

--- a/django_boost/management/commands/deletemigrations.py
+++ b/django_boost/management/commands/deletemigrations.py
@@ -17,18 +17,30 @@ class Command(ConfirmOptionMixin, QuitOptionMixin, AppCommand):
         self.add_quit_option(parser)
         self.add_confirm_option(parser)
 
+    @staticmethod
+    def _migration_files(migration_dir):
+        # Only the top-level migration modules; do not descend into nested
+        # packages (e.g. a migrations/helpers/ holding non-migration modules),
+        # which os.walk would sweep in and delete.
+        file_list = []
+        for name in sorted(os.listdir(migration_dir)):
+            path = os.path.join(migration_dir, name)
+            if not os.path.isfile(path):
+                continue
+            if name == '__init__.py' or not name.endswith('.py'):
+                continue
+            file_list.append(path)
+        return file_list
+
     def handle_app_config(self, app_config, **options):
         self.if_needed_make_quit(**options)
         app_path = app_config.path
         migration_dir = os.path.join(app_path, MIGRATIONS_MODULE_NAME)
         file_list = []
         if os.path.exists(migration_dir):
-            for d, dirs, files in os.walk(migration_dir):
-                for file in files:
-                    if file == '__init__.py' or not file.endswith('.py'):
-                        continue
-                    self.stdout.write(file)
-                    file_list.append(os.path.join(d, file))
+            file_list = self._migration_files(migration_dir)
+            for file in file_list:
+                self.stdout.write(os.path.basename(file))
         if not file_list:
             self.stderr.write(
                 'No migration files detected in %s' % app_config.name)

--- a/tests/tests/tests_commands.py
+++ b/tests/tests/tests_commands.py
@@ -1,5 +1,9 @@
+import os
+import tempfile
+
 from django.core.management import call_command
 
+from django_boost.management.commands.deletemigrations import Command
 from django_boost.test import TestCase
 
 
@@ -7,3 +11,17 @@ class TestDeleteMigrations(TestCase):
 
     def test_call_command(self):
        call_command('deletemigrations', 'tests')
+
+    def test_only_top_level_migration_files_are_collected(self):
+        with tempfile.TemporaryDirectory() as migration_dir:
+            open(os.path.join(migration_dir, '__init__.py'), 'w').close()
+            open(os.path.join(migration_dir, '0001_initial.py'), 'w').close()
+            sub = os.path.join(migration_dir, 'helpers')
+            os.mkdir(sub)
+            open(os.path.join(sub, '__init__.py'), 'w').close()
+            open(os.path.join(sub, 'util.py'), 'w').close()
+
+            collected = Command._migration_files(migration_dir)
+
+        names = sorted(os.path.basename(f) for f in collected)
+        self.assertEqual(names, ['0001_initial.py'])


### PR DESCRIPTION
## Summary

`deletemigrations` walked the `migrations/` directory recursively (`os.walk`) and deleted every `.py` except `__init__.py`, so a helper/data subpackage kept under `migrations/` lost its modules. It now scans only the top level (`os.listdir`), matching what Django's migration loader actually treats as migrations.