### PR TITLE
:bug: Report unknown adminsitelog fields as a command error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `adminsitelog` now reports an unknown `--filter`/`--exclude`/`--order_by` field name as a command error instead of an unhandled `FieldError` traceback.
+
 ## [3.2.0] - 2026-07-04
 
 ### Added

--- a/django_boost/contrib/admin_tools/management/commands/adminsitelog.py
+++ b/django_boost/contrib/admin_tools/management/commands/adminsitelog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from django.core.exceptions import FieldError
 from django.core.management.base import CommandError
 from django.db.models.sql.query import get_field_names_from_opts
 from django.utils.translation import gettext_lazy as _
@@ -145,10 +146,12 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
         LogEntry = self.get_log_entry_model()
         queryset = LogEntry.objects.all()
 
-        queryset = queryset.filter(**self.parse_filter(options['filter']))
-        queryset = queryset.exclude(**self.parse_filter(options['exclude']))
-
-        queryset = queryset.order_by(*options['order_by'])
+        try:
+            queryset = queryset.filter(**self.parse_filter(options['filter']))
+            queryset = queryset.exclude(**self.parse_filter(options['exclude']))
+            queryset = queryset.order_by(*options['order_by'])
+        except FieldError as e:
+            raise CommandError(str(e))
 
         if queryset.count() == 0:
             self.stderr.write('No logs')

--- a/tests/tests/contrib/admin_tools/management/commands/test_adminsitelog.py
+++ b/tests/tests/contrib/admin_tools/management/commands/test_adminsitelog.py
@@ -149,6 +149,16 @@ class TestAdminSiteLog(TestCase):
             call_command(
                 'adminsitelog', '--filter', 'nooperatorhere', stdout=StringIO())
 
+    def test_invalid_filter_field_raises_command_error(self):
+        with self.assertRaises(CommandError):
+            call_command(
+                'adminsitelog', '--filter', 'badfield=1', stdout=StringIO())
+
+    def test_invalid_order_by_field_raises_command_error(self):
+        with self.assertRaises(CommandError):
+            call_command(
+                'adminsitelog', '--order_by', 'badfield', stdout=StringIO())
+
     def test_text_format_styles_changed_and_deleted_actions(self):
         LogEntry.objects.create(
             user=self.user, content_type=self.content_type, object_id='2',


### PR DESCRIPTION
## Summary

Passing an unknown field name to `adminsitelog --filter`/`--exclude`/`--order_by` surfaced a raw `FieldError` traceback, because `FieldError` is not a `CommandError` subclass and the command runner does not format it. The query building is now wrapped so an unknown field is reported as a `CommandError`, matching the existing handling of an invalid operator.