### PR TITLE
:bug: Initialize limit_value in ContainAnyValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Fixed
 
 - `adminsitelog` now reports an unknown `--filter`/`--exclude`/`--order_by` field name as a command error instead of an unhandled `FieldError` traceback.
+- Comparing two `ContainAnyValidator` instances no longer raises `AttributeError`; `__init__` now initializes the inherited `limit_value`.
 
 ## [3.2.0] - 2026-07-04
 

--- a/django_boost/validators/collection.py
+++ b/django_boost/validators/collection.py
@@ -18,10 +18,9 @@ class ContainAnyValidator(BaseValidator):
     message = _('The input must contain one of "%s"\'s.')
 
     def __init__(self, elements: Iterable[Any], message: Any = None) -> None:
-        self.elements = elements
-        if message:
-            self.message = message
+        # Set limit_value via BaseValidator so its __eq__ can compare validators.
+        super().__init__(elements, message)
 
     def __call__(self, value: Any) -> None:
-        if not contain_any(value, self.elements):
-            raise ValidationError(self.message % (self.elements,))
+        if not contain_any(value, self.limit_value):
+            raise ValidationError(self.message % (self.limit_value,))

--- a/tests/tests/test_validators.py
+++ b/tests/tests/test_validators.py
@@ -63,6 +63,13 @@ class TestValidator(TestCase):
                 with self.assertRaisesMessage(ValidationError, message):
                     validator(value)
 
+    def test_contain_any_validators_are_comparable(self):
+        # Regression: BaseValidator.__eq__ reads limit_value.
+        self.assertEqual(
+            ContainAnyValidator(("a", "b")), ContainAnyValidator(("a", "b")))
+        self.assertNotEqual(
+            ContainAnyValidator(("a",)), ContainAnyValidator(("b",)))
+
 
 class NonZeroValidatorDeconstruct(TestCase):
     """`NonZeroValidator` serializes to its public path for migrations."""


### PR DESCRIPTION
## Summary

`ContainAnyValidator.__init__` overrode `BaseValidator.__init__` without calling `super()`, so `limit_value` was never set and comparing two instances raised `AttributeError: 'ContainAnyValidator' object has no attribute 'limit_value'` (the inherited `__eq__` reads it). `__init__` now calls `super().__init__(elements, message)`.