### PR TITLE
:bug: Avoid raise None in get_object/list_or_exception without exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `RelatedModelInlineMixin.save(commit=False)` no longer writes to the database; its inline related objects are now persisted by `save_m2m()`, following Django's `ModelForm` contract.
 - `json_to_model` no longer raises `ValueError` for models with a relation field; it round-trips `model_to_json` output by assigning to the field's `*_id` column.
 - The admin hard-delete action now logs deletions with Django 5.1+'s bulk `log_deletions()` when available, avoiding the `log_deletion()` deprecation warning.
+- `get_object_or_exception` and `get_list_or_exception` now fall back to the model's `DoesNotExist` when called without an `exception`, instead of raising `TypeError` from `raise None`.
 
 ## [3.2.1] - 2026-07-05
 

--- a/django_boost/shortcuts.py
+++ b/django_boost/shortcuts.py
@@ -63,7 +63,9 @@ def get_object_or_exception(klass, *args, exception=None, **kwargs):
     try:
         return queryset.get(*args, **kwargs)
     except queryset.model.DoesNotExist:
-        raise exception
+        if exception is not None:
+            raise exception
+        raise
 
 
 def get_list_or_default(klass, *args, default=None, **kwargs):
@@ -106,5 +108,9 @@ def get_list_or_exception(klass, *args, exception=None, **kwargs):
         )
     obj_list = list(queryset.filter(*args, **kwargs))
     if not obj_list:
-        raise exception
+        if exception is not None:
+            raise exception
+        raise queryset.model.DoesNotExist(
+            "%s matching query does not exist."
+            % queryset.model._meta.object_name)
     return obj_list

--- a/tests/tests/test_shortcuts.py
+++ b/tests/tests/test_shortcuts.py
@@ -50,6 +50,16 @@ class TestShortCuts(TestCase):
             get_list_or_exception(User, email='no',
                                   exception=MyException)
 
+    def test_get_object_or_exception_without_exception_raises_does_not_exist(self):
+        # Omitting exception must not `raise None` (TypeError); fall back to
+        # the model's DoesNotExist, like QuerySet.get().
+        with self.assertRaises(User.DoesNotExist):
+            get_object_or_exception(User, email='no')
+
+    def test_get_list_or_exception_without_exception_raises_does_not_exist(self):
+        with self.assertRaises(User.DoesNotExist):
+            get_list_or_exception(User, email='no')
+
     def test_bad_first_argument_error_names_the_called_function(self):
         for func in (get_object_or_default, get_object_or_exception,
                      get_list_or_default, get_list_or_exception):


### PR DESCRIPTION
## Summary

`get_object_or_exception` / `get_list_or_exception` default `exception` to `None`, so calling them without an `exception` on a missing/empty result executed `raise None`, producing `TypeError: exceptions must derive from BaseException`. They now fall back to the model's `DoesNotExist` (a bare re-raise for the object helper, a constructed `DoesNotExist` for the list helper). Passing an explicit `exception` is unchanged.