### PR TITLE
:bug: Preserve the original AttributeError from getattr_chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `getattr_chain` without a default now propagates the underlying `AttributeError` (preserving its type and message) instead of rewriting it into a generic one.
+
 ## [3.2.2] - 2026-07-06
 
 ### Fixed

--- a/django_boost/utils/attribute.py
+++ b/django_boost/utils/attribute.py
@@ -20,14 +20,19 @@ def getattr_chain(obj: object, name: str, default: Any = EMPTY) -> Any:
 
     getattr_chain(obj, '__class__.__name__')
     getattr_chain(obj, '__class__.__name__', default_value)
+
+    Without a default, the underlying ``AttributeError`` propagates unchanged,
+    so a descriptor that raises an ``AttributeError`` subclass (e.g. a reverse
+    one-to-one accessor) keeps its type and message. With a default, any
+    ``AttributeError`` yields the default, like the builtin ``getattr``.
     """
     try:
         for n in name.split('.'):
             obj = getattr(obj, n)
         return obj
-    except AttributeError as e:
+    except AttributeError:
         if is_empty(default):
-            raise AttributeError('%s has no Attribute %s' % (obj, name)) from e
+            raise
         return default
 
 
@@ -47,6 +52,10 @@ def hasattr_chain(obj: object, name: str) -> bool:
     example ::
 
     hasattr_chain(obj, '__class__.__name__')
+
+    Like the builtin ``hasattr``, this returns ``False`` when accessing any
+    segment raises ``AttributeError`` (including subclasses raised inside a
+    descriptor), so it cannot tell a missing attribute from a raising one.
     """
     try:
         for n in name.split('.'):

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -67,6 +67,30 @@ class TestAttribute(TestCase):
         with self.assertRaises(AttributeError):
             getattr_chain(i, '__class__.name')
 
+    def test_getattr_chain_preserves_descriptor_exception(self):
+        class Boom(AttributeError):
+            pass
+
+        class Obj:
+            @property
+            def rel(self):
+                raise Boom('descriptor raised')
+
+        # The attribute exists; its getter raised. The original exception must
+        # propagate, not be rewritten into a generic AttributeError.
+        with self.assertRaises(Boom):
+            getattr_chain(Obj(), 'rel.name')
+
+    def test_getattr_chain_with_default_swallows_descriptor_exception(self):
+        class Boom(AttributeError):
+            pass
+
+        class Obj:
+            @property
+            def rel(self):
+                raise Boom('descriptor raised')
+
+        self.assertIsNone(getattr_chain(Obj(), 'rel.name', default=None))
 
     def test_hasattrs(self):
         i = 1


### PR DESCRIPTION
## Summary

`getattr_chain` without a default now re-raises the underlying `AttributeError` as-is instead of rewriting it into a generic one, so descriptor-raised subclasses (e.g. `RelatedObjectDoesNotExist`) keep their type and message, and the message no longer points at an intermediate object with the full path. The default-taking path and `hasattr_chain` are unchanged (builtin-consistent, now documented).