### PR TITLE
Ignore all *.sqlite3 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ coverage.xml
 # Django stuff:
 *.log
 local_settings.py
-db.sqlite3
+*.sqlite3
 
 # Flask stuff:
 instance/


### PR DESCRIPTION
## Summary

Broaden the SQLite ignore rule from `db.sqlite3` to `*.sqlite3` so scratch databases such as `example.sqlite3` are no longer tracked.