### PR TITLE
Deprecate EmailUser and add the migrate_emailuser adoption command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - Signed-integer path converters `signed_int`, `positive_int`, `negative_int`, `non_negative_int`, `non_positive_int` and `non_zero_int` (registered by `register_boost_converters`), covering integer ranges Django's built-in `int` converter cannot express.
 
+### Deprecated
+
+- `django_boost.EmailUser` / `AbstractEmailUser` are deprecated and will be removed in 4.0. A system check (`django_boost.W050`) now warns when `AUTH_USER_MODEL` is `'django_boost.EmailUser'`. Copy the model into one of your own apps (keeping `db_table = 'django_boost_emailuser'`) and run the new `migrate_emailuser` command to adopt the existing table and its permissions. See the Custom User docs.
+
 ### Fixed
 
 - `RedirectCorrectHostnameMiddleware` no longer raises a `TypeError` on the redirect path under ASGI; it now redirects correctly on both WSGI and ASGI.

--- a/README.md
+++ b/README.md
@@ -60,31 +60,6 @@ INSTALLED_APPS = [
 
 ## Brief introduction
 
-### EmailUser
-
-`settings.py`
-
-```py
-AUTH_USER_MODEL = 'django_boost.EmailUser'
-```
-
-Replace Django default user model
-Use email address instead of username when logging in
-
-### AbstractEmailUser
-
-```py
-from django.db import models
-from django_boost.models import AbstractEmailUser
-
-class CustomUser(AbstractEmailUser):
-    is_flozen = models.BoolField(default=False)
-    homepage = models.URLField()
-
-```
-
-Available when you want to add a field to EmailUser
-
 ### UUIDModelMixin
 
 ```py

--- a/django_boost/checks.py
+++ b/django_boost/checks.py
@@ -17,6 +17,7 @@ USER_AGENTS_PACKAGE = "user_agents"
 ADMIN_TOOLS_APP = "django_boost.contrib.admin_tools"
 LEGACY_ADMIN_TOOLS_APP = "django_boost.admin_tools"
 DJANGO_ADMIN_APP = "django.contrib.admin"
+EMAILUSER_MODEL = "django_boost.EmailUser"
 
 
 def _matches_dotted_path(value, dotted_path):
@@ -270,10 +271,27 @@ def check_admin_tools_requires_admin(app_configs, **kwargs):
     ]
 
 
+def check_emailuser_deprecated(app_configs, **kwargs):
+    if getattr(settings, "AUTH_USER_MODEL", None) != EMAILUSER_MODEL:
+        return []
+
+    return [
+        Warning(
+            "AUTH_USER_MODEL uses the deprecated built-in %s." % EMAILUSER_MODEL,
+            hint="%s is deprecated and will be removed in django-boost 4.0. Copy the model "
+                 "into one of your own apps (keep db_table='django_boost_emailuser') and run "
+                 "`manage.py migrate_emailuser`. See the Custom User docs." % EMAILUSER_MODEL,
+            obj=EMAILUSER_MODEL,
+            id="django_boost.W050",
+        )
+    ]
+
+
 CHECKS = (
     check_database_router,
     check_redirect_correct_hostname_middleware,
     check_user_agent_extra,
     check_logical_deletion_models,
     check_admin_tools_requires_admin,
+    check_emailuser_deprecated,
 )

--- a/django_boost/management/commands/migrate_emailuser.py
+++ b/django_boost/management/commands/migrate_emailuser.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from django.apps import apps
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.migrations.recorder import MigrationRecorder
+
+from django_boost.core.management import BaseCommand
+
+LEGACY_TABLE = "django_boost_emailuser"
+LEGACY_APP_LABEL = "django_boost"
+LEGACY_MODEL = "emailuser"
+LEGACY_USER_MODEL = "django_boost.EmailUser"
+
+
+def adopt_content_type(using, from_label, from_model, to_label, to_model) -> int:
+    """Rename the legacy ContentType in place so its permissions carry over.
+
+    Returns the number of rows updated (0 if nothing to adopt).
+    """
+    if not apps.is_installed("django.contrib.contenttypes"):
+        return 0
+    from django.contrib.contenttypes.models import ContentType
+    content_types = ContentType.objects.using(using)
+    if content_types.filter(app_label=to_label, model=to_model).exists():
+        return 0
+    return content_types.filter(app_label=from_label, model=from_model).update(
+        app_label=to_label, model=to_model)
+
+
+def record_migration_applied(using, app_label, name) -> bool:
+    """Record a migration as applied without running it. Idempotent.
+
+    Returns True if a new record was written, False if it was already present.
+    """
+    recorder = MigrationRecorder(connections[using])
+    recorder.ensure_schema()
+    if (app_label, name) in recorder.applied_migrations():
+        return False
+    recorder.record_applied(app_label, name)
+    return True
+
+
+class Command(BaseCommand):
+    help = ("Adopt the legacy django_boost_emailuser table and content type into your own "
+            "AUTH_USER_MODEL app, then finish migrating.")
+
+    def add_arguments(self, parser):
+        parser.add_argument("--database", default=DEFAULT_DB_ALIAS)
+        parser.add_argument(
+            "--target-migration", default="0001_initial",
+            help="Migration in the target app that creates the user model "
+                 "(default: 0001_initial).")
+
+    def handle(self, *args, **options):
+        using = options["database"]
+        target = getattr(settings, "AUTH_USER_MODEL", "") or ""
+        if target == LEGACY_USER_MODEL or "." not in target:
+            raise CommandError(
+                "Set AUTH_USER_MODEL to your own model (e.g. 'accounts.User') before running "
+                "migrate_emailuser; it must not be '%s'." % LEGACY_USER_MODEL)
+
+        target_app, target_model = target.split(".", 1)
+        model_name = target_model.lower()
+
+        adopted = adopt_content_type(
+            using, LEGACY_APP_LABEL, LEGACY_MODEL, target_app, model_name)
+        if adopted:
+            self.stdout.write(
+                "Adopted content type %s.%s -> %s.%s (permissions preserved)."
+                % (LEGACY_APP_LABEL, LEGACY_MODEL, target_app, model_name))
+
+        if LEGACY_TABLE in connections[using].introspection.table_names():
+            migration = options["target_migration"]
+            if record_migration_applied(using, target_app, migration):
+                self.stdout.write(
+                    "Recorded %s.%s as applied (existing %s adopted)."
+                    % (target_app, migration, LEGACY_TABLE))
+
+        call_command("migrate", database=using)
+        self.stdout.write(self.style.SUCCESS("migrate_emailuser complete."))

--- a/docs/custom_user.rst
+++ b/docs/custom_user.rst
@@ -7,6 +7,12 @@ Custom User
 EmailUser
 ----------
 
+.. deprecated:: 3.2
+   ``EmailUser`` and ``AbstractEmailUser`` are deprecated and will be removed in
+   django-boost 4.0. Copy the model into one of your own apps and drop the
+   django_boost dependency. See `Migrating off EmailUser`_.
+
+
 Configuration
 ^^^^^^^^^^^^^
 
@@ -37,3 +43,60 @@ example::
   class CustomUser(AbstractEmailUser):
       is_flozen = models.BoolField(default=False)
       homepage = models.URLField()
+
+
+Migrating off EmailUser
+-----------------------
+
+``EmailUser`` is a swappable ``AUTH_USER_MODEL``. The underlying table is
+``django_boost_emailuser``; keep that table name and you move **no data**.
+
+1. Add an equivalent model to one of *your own* apps (a fresh app is simplest).
+   Keep ``db_table`` so the existing table matches:
+
+   ::
+
+     # accounts/models.py
+     from django.contrib.auth.models import AbstractUser
+     from django.contrib.auth.validators import UnicodeUsernameValidator
+     from django.db import models
+
+     class User(AbstractUser):
+         username = models.CharField(
+             'username', max_length=150,
+             validators=[UnicodeUsernameValidator()])   # non-unique: matches the existing table
+         email = models.EmailField('email address', unique=True)
+         USERNAME_FIELD = 'email'
+         REQUIRED_FIELDS = ['username']
+
+         class Meta(AbstractUser.Meta):
+             db_table = 'django_boost_emailuser'
+
+   ``EmailUser`` overrides ``username`` without ``unique=True``, so the existing
+   table has no unique index on it; declaring it unique here would make your
+   (faked) migration state claim a constraint the table lacks.
+
+2. In *accounts/apps.py*, set ``AppConfig.default_auto_field =
+   'django.db.models.AutoField'``. The existing table's ``id`` column is a
+   32-bit ``AutoField``; Django's default (``BigAutoField``) would make your
+   (faked) migration state claim a ``BIGINT`` column where the table has
+   ``INT`` — the same class of drift as the username issue.
+
+3. ``python manage.py makemigrations accounts`` (creates ``0001_initial``).
+
+4. In *settings.py*: ``AUTH_USER_MODEL = 'accounts.User'``.
+
+5. ``python manage.py migrate_emailuser``
+
+   The command adopts the existing content type (so assigned permissions carry
+   over), records your app's initial migration as applied (the table already
+   exists), then runs ``migrate``.
+
+.. note::
+
+   Do not use ``migrate accounts 0001 --fake`` by hand. ``migrate`` runs its
+   consistency check before reading ``--fake``; once ``AUTH_USER_MODEL`` points
+   at the new app, ``django.contrib.admin``'s applied migration depends on your
+   (unapplied) initial migration and Django raises
+   ``InconsistentMigrationHistory``. ``migrate_emailuser`` records the migration
+   directly, which is why it is needed.

--- a/tests/tests/checks/tests.py
+++ b/tests/tests/checks/tests.py
@@ -8,6 +8,7 @@ from django.test.utils import isolate_apps
 
 from django_boost.checks import (
     DATABASE_ROUTER,
+    EMAILUSER_MODEL,
     REDIRECT_CORRECT_HOSTNAME_MIDDLEWARE,
     USER_AGENT_CONTEXT_PROCESSOR,
     _app_labels,
@@ -16,6 +17,7 @@ from django_boost.checks import (
     _correct_host_is_allowed,
     check_admin_tools_requires_admin,
     check_database_router,
+    check_emailuser_deprecated,
     check_logical_deletion_models,
     check_redirect_correct_hostname_middleware,
     check_user_agent_extra,
@@ -326,3 +328,17 @@ class AdminToolsCheckTests(TestCase):
     def test_no_warning_when_admin_tools_absent(self):
         with patch("django_boost.checks.apps.is_installed", return_value=False):
             self.assertEqual(check_admin_tools_requires_admin(None), [])
+
+
+class EmailUserDeprecationCheckTests(TestCase):
+
+    def test_warns_when_emailuser_is_active(self):
+        fake_settings = SimpleNamespace(AUTH_USER_MODEL=EMAILUSER_MODEL)
+        with patch("django_boost.checks.settings", fake_settings):
+            messages = check_emailuser_deprecated(None)
+        self.assertEqual(check_ids(messages), ["django_boost.W050"])
+
+    def test_silent_for_other_user_model(self):
+        fake_settings = SimpleNamespace(AUTH_USER_MODEL="auth.User")
+        with patch("django_boost.checks.settings", fake_settings):
+            self.assertEqual(check_emailuser_deprecated(None), [])

--- a/tests/tests/management/commands/test_migrate_emailuser.py
+++ b/tests/tests/management/commands/test_migrate_emailuser.py
@@ -1,0 +1,87 @@
+from io import StringIO
+from unittest.mock import Mock, patch
+
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.migrations.recorder import MigrationRecorder
+from django.test import override_settings
+
+from django_boost.management.commands.migrate_emailuser import (
+    adopt_content_type,
+    record_migration_applied,
+)
+from django_boost.test import TestCase
+
+
+class AdoptContentTypeTests(TestCase):
+
+    def test_moves_content_type_and_preserves_permissions(self):
+        ct = ContentType.objects.create(app_label="django_boost", model="faketarget")
+        perm = Permission.objects.create(
+            content_type=ct, codename="add_faketarget", name="Can add faketarget")
+        group = Group.objects.create(name="staff")
+        group.permissions.add(perm)
+
+        moved = adopt_content_type(
+            DEFAULT_DB_ALIAS, "django_boost", "faketarget", "accounts", "faketarget")
+
+        self.assertEqual(moved, 1)
+        ct.refresh_from_db()
+        self.assertEqual((ct.app_label, ct.model), ("accounts", "faketarget"))
+        perm.refresh_from_db()
+        self.assertEqual(perm.content_type_id, ct.id)
+        self.assertIn(perm, group.permissions.all())
+
+    def test_noop_when_target_already_exists(self):
+        ContentType.objects.create(app_label="accounts", model="faketarget")
+        ContentType.objects.create(app_label="django_boost", model="faketarget")
+        moved = adopt_content_type(
+            DEFAULT_DB_ALIAS, "django_boost", "faketarget", "accounts", "faketarget")
+        self.assertEqual(moved, 0)
+
+
+class RecordMigrationAppliedTests(TestCase):
+
+    def test_is_idempotent(self):
+        first = record_migration_applied(DEFAULT_DB_ALIAS, "accounts", "0001_initial")
+        second = record_migration_applied(DEFAULT_DB_ALIAS, "accounts", "0001_initial")
+        self.assertTrue(first)
+        self.assertFalse(second)
+        recorder = MigrationRecorder(connections[DEFAULT_DB_ALIAS])
+        self.assertIn(("accounts", "0001_initial"), recorder.applied_migrations())
+
+
+class MigrateEmailUserCommandTests(TestCase):
+
+    @override_settings(AUTH_USER_MODEL="django_boost.EmailUser")
+    def test_refuses_when_target_not_set(self):
+        with self.assertRaisesRegex(CommandError, "AUTH_USER_MODEL"):
+            call_command("migrate_emailuser", stdout=StringIO())
+
+    @override_settings(AUTH_USER_MODEL="nouserdot")
+    def test_refuses_when_target_has_no_dot(self):
+        with self.assertRaisesRegex(CommandError, "AUTH_USER_MODEL"):
+            call_command("migrate_emailuser", stdout=StringIO())
+
+    @override_settings(AUTH_USER_MODEL="accounts.User")
+    def test_adopts_and_records_before_migrate(self):
+        module = "django_boost.management.commands.migrate_emailuser"
+        manager = Mock()
+        with patch(module + ".adopt_content_type", return_value=1) as adopt, \
+                patch(module + ".record_migration_applied", return_value=True) as record, \
+                patch(module + ".call_command") as migrate:
+            manager.attach_mock(adopt, "adopt")
+            manager.attach_mock(record, "record")
+            manager.attach_mock(migrate, "migrate")
+            call_command("migrate_emailuser", stdout=StringIO())
+
+        adopt.assert_called_once_with(
+            DEFAULT_DB_ALIAS, "django_boost", "emailuser", "accounts", "user")
+        record.assert_called_once_with(DEFAULT_DB_ALIAS, "accounts", "0001_initial")
+        migrate.assert_called_once_with("migrate", database=DEFAULT_DB_ALIAS)
+        names = [c[0] for c in manager.mock_calls]
+        self.assertLess(names.index("adopt"), names.index("migrate"))
+        self.assertLess(names.index("record"), names.index("migrate"))


### PR DESCRIPTION
## Summary

Deprecate `django_boost.EmailUser` / `AbstractEmailUser` (removal planned for 4.0) and give existing adopters a supported, data-preserving path to move the model into their own app.

## Notes

- New system check `django_boost.W050` warns only when `AUTH_USER_MODEL == 'django_boost.EmailUser'` — projects that don't use it see nothing.
- New `migrate_emailuser` command relocates the model to a project's own app without moving data: it renames the existing `django_boost_emailuser` content type in place (preserving assigned permissions) and records the target app's initial migration as applied, then runs `migrate`. `migrate --fake` cannot be used here — `migrate` runs its consistency check before honoring `--fake`, so re-pointing `AUTH_USER_MODEL` at an unapplied initial migration raises `InconsistentMigrationHistory`.
- `EmailUser` is otherwise unchanged and still ships in 3.x; actual removal is deferred to 4.0.

## Verification

Full test suite (400 tests) and flake8 pass. The command's units are covered by tests (permission-preserving content-type rename on real rows, idempotency, before-`migrate` ordering, preconditions); a full `AUTH_USER_MODEL`-swap end-to-end is exercised via the documented recipe rather than the automated suite.
