### PR TITLE
Add Http5xx tail exceptions (505, 506, 508-511)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - Signed-integer path converters `signed_int`, `positive_int`, `negative_int`, `non_negative_int`, `non_positive_int` and `non_zero_int` (registered by `register_boost_converters`), covering integer ranges Django's built-in `int` converter cannot express.
 - `NonZeroValidator` and `validate_non_zero`, rejecting a value of `0` — the one integer range Django's built-in `MinValueValidator`/`MaxValueValidator` cannot express as a single validator.
+- `Http505`, `Http506`, `Http508`, `Http509`, `Http510` and `Http511` exceptions, so the 5xx statuses whose response classes django-boost already ships can now be raised through `HttpStatusCodeExceptionMiddleware`, not only returned. A raised or returned `509` now carries the status message `Bandwidth Limit Exceeded` instead of an empty phrase.
 
 ### Deprecated
 

--- a/django_boost/http/__init__.py
+++ b/django_boost/http/__init__.py
@@ -67,5 +67,6 @@ STATUS_MESSAGES.update({
     506: 'Variant Also Negotiates',
     507: 'Insufficient Storage',
     508: 'Loop Detected',
+    509: 'Bandwidth Limit Exceeded',
     510: 'Not Extended',
     511: 'Network Authentication Required'})

--- a/django_boost/http/response.py
+++ b/django_boost/http/response.py
@@ -322,5 +322,29 @@ class Http504(HttpExceptionBase):
     response_class = HttpResponseGatewayTimeout
 
 
+class Http505(HttpExceptionBase):
+    response_class = HttpResponseHTTPVersionNotSupported
+
+
+class Http506(HttpExceptionBase):
+    response_class = HttpResponseVariantAlsoNegotiates
+
+
 class Http507(HttpExceptionBase):
     response_class = HttpResponseInsufficientStorage
+
+
+class Http508(HttpExceptionBase):
+    response_class = HttpResponseLoopDetected
+
+
+class Http509(HttpExceptionBase):
+    response_class = HttpResponseBandwidthLimitExceeded
+
+
+class Http510(HttpExceptionBase):
+    response_class = HttpResponseNotExtended
+
+
+class Http511(HttpExceptionBase):
+    response_class = HttpResponseNetworkAuthenticationRequired

--- a/docs/http_status_code_exceptions.rst
+++ b/docs/http_status_code_exceptions.rst
@@ -61,4 +61,5 @@ Support ``Http400``, ``Http401``, ``Http402``, ``Http403``, ``Http405``, ``Http4
   ...
     raise Http500(message...)
 
-Support ``Http500``, ``Http501``, ``Http502``, ``Http503``, ``Http504`` and ``Http507``.
+Support ``Http500``, ``Http501``, ``Http502``, ``Http503``, ``Http504``, ``Http505``, ``Http506``,
+``Http507``, ``Http508``, ``Http509``, ``Http510`` and ``Http511``.

--- a/tests/tests/middleware/test_middleware.py
+++ b/tests/tests/middleware/test_middleware.py
@@ -1,7 +1,9 @@
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
 
-from django_boost.http.response import Http301, Http402, Http405
+from django_boost.http.response import (Http301, Http402, Http405, Http505,
+                                         Http506, Http508, Http509, Http510,
+                                         Http511)
 from django_boost.middleware import (HttpStatusCodeExceptionMiddleware,
                                       RedirectCorrectHostnameMiddleware)
 
@@ -35,6 +37,23 @@ class HttpStatusCodeExceptionMiddlewareTests(SimpleTestCase):
 
         self.assertEqual(response.status_code, 402)
         self.assertEqual(response.content.decode(), "402 Payment Required")
+
+    @override_settings(DEBUG=False)
+    def test_tail_5xx_exceptions_map_to_their_response(self):
+        cases = [
+            (Http505(), 505, "505 HTTP Version Not Supported"),
+            (Http506(), 506, "506 Variant Also Negotiates"),
+            (Http508(), 508, "508 Loop Detected"),
+            (Http509(), 509, "509 Bandwidth Limit Exceeded"),
+            (Http510(), 510, "510 Not Extended"),
+            (Http511(), 511, "511 Network Authentication Required"),
+        ]
+        for exc, code, body in cases:
+            with self.subTest(code=code):
+                response = self.middleware.process_exception(
+                    self.factory.get("/"), exc)
+                self.assertEqual(response.status_code, code)
+                self.assertEqual(response.content.decode(), body)
 
     def test_redirect_exception_becomes_a_redirect_response(self):
         response = self.middleware.process_exception(

--- a/tests/tests/test_http.py
+++ b/tests/tests/test_http.py
@@ -1,12 +1,27 @@
 from django_boost.http import STATUS_MESSAGES
+from django_boost.http.response import (Http505, Http506, Http508, Http509,
+                                        Http510, Http511)
 from django_boost.test import TestCase
 
 
 class TestStatusMessages(TestCase):
 
-    def test_http_510_and_511_messages(self):
+    def test_http_509_510_511_messages(self):
+        self.assertEqual(STATUS_MESSAGES[509], 'Bandwidth Limit Exceeded')
         self.assertEqual(STATUS_MESSAGES[510], 'Not Extended')
         self.assertEqual(STATUS_MESSAGES[511], 'Network Authentication Required')
 
     def test_unknown_status_message_falls_back_to_empty_string(self):
-        self.assertEqual(STATUS_MESSAGES[509], '')
+        self.assertEqual(STATUS_MESSAGES[512], '')
+
+
+class TestHttp5xxTailExceptions(TestCase):
+    """The 5xx exceptions whose response classes already exist can be raised."""
+
+    def test_tail_exceptions_expose_their_status_code(self):
+        cases = [(Http505, 505), (Http506, 506), (Http508, 508),
+                 (Http509, 509), (Http510, 510), (Http511, 511)]
+        for exc, code in cases:
+            with self.subTest(exc.__name__):
+                self.assertEqual(exc().status_code, code)
+                self.assertEqual(exc.response_class.status_code, code)


### PR DESCRIPTION
## Summary

Add `Http505`, `Http506`, `Http508`, `Http509`, `Http510` and `Http511`. The 5xx response classes for these codes already shipped but had no paired `Http*` exception, so they could be returned but never raised through `HttpStatusCodeExceptionMiddleware`.

## Notes

- The middleware dispatches on `HttpExceptionBase` + `response_class`, so it needs no change.
- Fills the one missing `STATUS_MESSAGES` entry (`509 Bandwidth Limit Exceeded`); a `509` previously degraded to an empty status phrase.