### PR TITLE
Add TestCase.assertStatusCodeNotIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `NonZeroValidator` and `validate_non_zero`, rejecting a value of `0` — the one integer range Django's built-in `MinValueValidator`/`MaxValueValidator` cannot express as a single validator.
 - `Http505`, `Http506`, `Http508`, `Http509`, `Http510` and `Http511` exceptions, so the 5xx statuses whose response classes django-boost already ships can now be raised through `HttpStatusCodeExceptionMiddleware`, not only returned. A raised or returned `509` now carries the status message `Bandwidth Limit Exceeded` instead of an empty phrase.
 - `AnonymousRequiredMixin`, a view mixin that redirects an already-authenticated user away (e.g. from a login or sign-up page) — the inverse of Django's `LoginRequiredMixin`. The redirect target is `redirect_authenticated_url`, falling back to `settings.LOGIN_REDIRECT_URL`.
+- `django_boost.test.TestCase.assertStatusCodeNotIn`, completing the `assertStatusCode*` family alongside `assertStatusCodeEqual`, `assertStatusCodeNotEqual` and `assertStatusCodeIn`.
 
 ### Deprecated
 

--- a/django_boost/test/testcase.py
+++ b/django_boost/test/testcase.py
@@ -24,3 +24,7 @@ class TestCase(DjangoTestCase):
     def assertStatusCodeIn(self, response: HttpResponseBase,
                            codes: Iterable[int], msg: object = None) -> None:
         self.assertIn(response.status_code, codes, msg)
+
+    def assertStatusCodeNotIn(self, response: HttpResponseBase,
+                              codes: Iterable[int], msg: object = None) -> None:
+        self.assertNotIn(response.status_code, codes, msg)

--- a/tests/tests/test/test_testcase.py
+++ b/tests/tests/test/test_testcase.py
@@ -19,6 +19,17 @@ class AssertStatusCodeTests(TestCase):
                                           msg="custom note")
         self.assertIn("custom note", str(cm.exception))
 
+    def test_not_in_passes_when_code_absent_and_fails_when_present(self):
+        self.assertStatusCodeNotIn(HttpResponse(status=200), [301, 302])
+        with self.assertRaises(AssertionError):
+            self.assertStatusCodeNotIn(HttpResponse(status=302), [301, 302])
+
+    def test_not_in_custom_msg_appears_in_failure(self):
+        with self.assertRaises(AssertionError) as cm:
+            self.assertStatusCodeNotIn(HttpResponse(status=302), [301, 302],
+                                       msg="custom note")
+        self.assertIn("custom note", str(cm.exception))
+
     def test_helper_frame_hidden_from_failure_traceback(self):
         class Inner(TestCase):
             def runTest(inner):


### PR DESCRIPTION
## Summary

Add `assertStatusCodeNotIn` to `django_boost.test.TestCase`, completing the `assertStatusCode*` family (`assertStatusCodeEqual`, `assertStatusCodeNotEqual`, `assertStatusCodeIn`) with its missing negative-membership cell.