### PR TITLE
Document validators and TestCase status-code assertions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,6 +64,7 @@ User-agent detection requires the optional ``useragent`` extra:
    form
    form_mixins
    form_fields
+   validators
    path_converters
    shortcut_functions
    routing_utilities
@@ -73,6 +74,7 @@ User-agent detection requires the optional ``useragent`` extra:
    template_context
    template_tags
    commands
+   test
 
 
 Indices and tables

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -1,0 +1,59 @@
+Test
+====
+
+:synopsis: Test utilities in django-boost
+
+``django_boost.test.TestCase`` extends Django's ``TestCase`` with assertions
+for a response's status code.
+
+::
+
+  from django_boost.test import TestCase
+
+  class MyViewTests(TestCase):
+      def test_ok(self):
+          response = self.client.get("/")
+          self.assertStatusCodeEqual(response, 200)
+
+Each assertion takes the response first and an optional ``msg`` shown on
+failure. A failure points at the calling test, not at the assertion helper.
+
+
+assertStatusCodeEqual
+---------------------
+
+Assert the response status code equals ``code``.
+
+::
+
+  self.assertStatusCodeEqual(response, 200)
+
+
+assertStatusCodeNotEqual
+------------------------
+
+Assert the response status code does not equal ``code``.
+
+::
+
+  self.assertStatusCodeNotEqual(response, 500)
+
+
+assertStatusCodeIn
+------------------
+
+Assert the response status code is one of ``codes``.
+
+::
+
+  self.assertStatusCodeIn(response, [301, 302])
+
+
+assertStatusCodeNotIn
+---------------------
+
+Assert the response status code is none of ``codes``.
+
+::
+
+  self.assertStatusCodeNotIn(response, [401, 403])

--- a/docs/validators.rst
+++ b/docs/validators.rst
@@ -1,0 +1,82 @@
+Validators
+==========
+
+:synopsis: Validator classes and functions in django-boost
+
+Validators for form and model fields. Use them like Django's built-in
+validators, by passing them in a field's ``validators`` argument.
+
+
+ContainAnyValidator
+-------------------
+
+Validate that the input contains at least one of the given elements.
+
+::
+
+  from django import forms
+  from django_boost.validators import ContainAnyValidator
+
+  class SignUpForm(forms.Form):
+      password = forms.CharField(
+          validators=[ContainAnyValidator("0123456789")])
+
+The elements may be any iterable; a value passes when it shares at least one
+element with it.
+
+
+ColorCodeValidator / validate_color_code
+----------------------------------------
+
+Validate that the whole value is a 6-digit hexadecimal color code prefixed
+with ``#`` (e.g. ``#00ff88``).
+
+::
+
+  from django.db import models
+  from django_boost.validators import validate_color_code
+
+  class Theme(models.Model):
+      accent = models.CharField(max_length=7, validators=[validate_color_code])
+
+``validate_color_code`` is a ready-made instance; use the ``ColorCodeValidator``
+class when you want a custom message.
+
+
+JsonValidator / validate_json
+-----------------------------
+
+Validate that the value is a JSON-parseable string.
+
+::
+
+  from django_boost.validators import validate_json
+
+  validate_json('{"a": 1}')   # ok
+  validate_json('{a: 1}')     # raises ValidationError
+
+
+NonZeroValidator / validate_non_zero
+------------------------------------
+
+Validate that an integer is not ``0``. Django's ``MinValueValidator`` /
+``MaxValueValidator`` cover the other integer ranges; excluding only zero is
+the one range they cannot express as a single validator.
+
+::
+
+  from django.db import models
+  from django_boost.validators import validate_non_zero
+
+  class Transfer(models.Model):
+      amount = models.IntegerField(validators=[validate_non_zero])
+
+Use the ``NonZeroValidator`` class to supply a custom message.
+
+
+validate_uuid4
+--------------
+
+.. deprecated:: 3.1.0
+   ``validate_uuid4`` will be removed in django-boost 4.0. Validate UUIDs with
+   Django's ``UUIDField`` or ``uuid.UUID`` instead.


### PR DESCRIPTION
## Summary

Add docs pages for two public families that had none:

- `validators` — `ContainAnyValidator`, `ColorCodeValidator`/`validate_color_code`, `JsonValidator`/`validate_json`, `NonZeroValidator`/`validate_non_zero`, and the deprecated `validate_uuid4`.
- `test` — the `django_boost.test.TestCase` `assertStatusCode*` assertions (`Equal`/`NotEqual`/`In`/`NotIn`).

Both are wired into the toctree.