### PR TITLE
Fix form_mixins docs examples and stale class name

### DIFF
--- a/django_boost/forms/mixins.py
+++ b/django_boost/forms/mixins.py
@@ -27,13 +27,13 @@ class FieldRenameMixin:
 
     ::
 
-      from django import form
+      from django import forms
       from django_boost.forms.mixins import FieldRenameMixin
 
       class MyForm(FieldRenameMixin,forms.Form):
           token_id = forms.CharField()
 
-          rename_field = {"token_id": "token-id"}
+          rename_fields = {"token_id": "token-id"}
 
       MyForm().cleaned_data["token-id"]
     """

--- a/docs/form_mixins.rst
+++ b/docs/form_mixins.rst
@@ -16,10 +16,11 @@ Mixin to add a method to get the queryset and object of the condition that match
   from .models import Customer
 
   class CustomerForm(MatchedObjectGetMixin, forms.ModelForm):
+      field_lookup = {'name': 'name__startswith'}  # filter lookup kwargs
+
       class Meta:
-          models = Customer
+          model = Customer
           fields = ('name', )
-          field_lookup = {'name' : 'name__startswith'} # filter lookup kwargs
 
 
 Set ``field_lookup`` to set detailed search conditions.
@@ -38,7 +39,7 @@ Set ``field_lookup`` to set detailed search conditions.
           object_list = form.get_list()  # get matched models objects queryset
 
 
-``MatchedObjectMixin`` provides ``get_object`` and ``get_list`` methods, each of which returns a ``model object`` or ``queryset`` that matches the form input content.
+``MatchedObjectGetMixin`` provides ``get_object`` and ``get_list`` methods, each of which returns a ``model object`` or ``queryset`` that matches the form input content.
 
 RelatedModelInlineMixin
 ------------------------


### PR DESCRIPTION
## Summary

Corrections to `docs/form_mixins.rst` and the `FieldRenameMixin` docstring (rendered into the page via autoclass):

- **MatchedObjectGetMixin example**: the `class Meta` used `models` (should be `model`), and put `field_lookup` inside `Meta` where it has no effect — it is a form-class attribute read off the form instance.
- **Stale name**: prose referred to `MatchedObjectMixin`; the class is `MatchedObjectGetMixin`.
- **FieldRenameMixin docstring**: `from django import form` → `forms`, and the attribute is `rename_fields` (plural), not `rename_field`.