### PR TITLE
Fix stale names in model docs

### DIFF
--- a/django_boost/models/fields/__init__.py
+++ b/django_boost/models/fields/__init__.py
@@ -77,9 +77,9 @@ class SplitDateTimeField(models.DateTimeField):
     """
     A little convenient DateTimeField.
 
-    form_class in django.models.db.DateTimeField is replaced with
+    form_class in django.db.models.DateTimeField is replaced with
     django.forms.SplitDateTimeField.
-    The effect on DB is the same as django.models.db.DateTimeField.
+    The effect on DB is the same as django.db.models.DateTimeField.
     """
 
     def formfield(self, **kwargs):

--- a/django_boost/models/mixins.py
+++ b/django_boost/models/mixins.py
@@ -37,7 +37,7 @@ class UUIDModelMixin(models.Model):
 
 
 class TimeStampModelMixin(models.Model):
-    """The fields `posted_at` and `updated_at` are added."""
+    """The fields `created_at` and `updated_at` are added."""
 
     class Meta:
         abstract = True

--- a/docs/model_fields.rst
+++ b/docs/model_fields.rst
@@ -58,6 +58,6 @@ SplitDateTimeField
 
 A little convenient DateTimeField.
 
-``SplitDateTimeField`` is the form_class of ``django.models.db.DateTimeField`` replaced with ``django.forms.SplitDateTimeField``.
+``SplitDateTimeField`` is the form_class of ``django.db.models.DateTimeField`` replaced with ``django.forms.SplitDateTimeField``.
 
-Internal DB field is the same as ``django.models.db.DateTimeField``.
+Internal DB field is the same as ``django.db.models.DateTimeField``.

--- a/docs/model_mixins.rst
+++ b/docs/model_mixins.rst
@@ -12,7 +12,7 @@ Mixins that replace ``id`` from ``AutoField`` to ``UUIDField``
 ::
 
   from django.db import models
-  from django_boost.models import UUIDModelMixin
+  from django_boost.models.mixins import UUIDModelMixin
 
   class Stock(UUIDModelMixin):
       name = models.CharField(max_length=128)
@@ -31,13 +31,13 @@ TimeStampModelMixin
       name = models.CharField(max_length=128)
       count = models.IntegerField()
 
-The fields ``posted_at`` and ``updated_at`` are added.
+The fields ``created_at`` and ``updated_at`` are added.
 
 The following fields are automatically added to the above model.
 
 ::
 
-  posted_at = models.DateTimeField(auto_now_add=True)
+  created_at = models.DateTimeField(auto_now_add=True)
   updated_at = models.DateTimeField(auto_now=True)
 
 


### PR DESCRIPTION
## Summary

Corrections to `docs/model_mixins.rst`, `docs/model_fields.rst`, and the matching source docstrings:

- **TimeStampModelMixin**: docs said it adds `posted_at`; the field is `created_at`. Fixed the prose, the example, and the stale mixin docstring.
- **UUIDModelMixin**: the example imported from `django_boost.models` (ImportError); the mixin is in `django_boost.models.mixins`.
- **SplitDateTimeField**: transposed path `django.models.db.DateTimeField` → `django.db.models.DateTimeField`, in both the docs and the field docstring.