### PR TITLE
Fix path_converters example and hex regex

### DIFF
--- a/docs/path_converters.rst
+++ b/docs/path_converters.rst
@@ -24,8 +24,8 @@ Example
 
   urlpatterns = [
       path('bin/<bin:id>', ~~),
-      path('oct/<bin:id>', ~~),
-      path('hex/<bin:id>', ~~),
+      path('oct/<oct:id>', ~~),
+      path('hex/<hex:id>', ~~),
       path('float/<float:id>', ~~),
   ]
 
@@ -49,7 +49,7 @@ This is passed as `int` type to the python program.
 hex
 ~~~~
 
-``hex`` match ``[0-9a-fA-F]``
+``hex`` match ``[0-9a-fA-F]+``
 
 This is passed as `int` type to the python program.
 


### PR DESCRIPTION
## Summary

Corrections to `docs/path_converters.rst`:

- The `oct/` and `hex/` example routes used the `bin` converter; they now use `oct` and `hex`.
- The documented `hex` regex was `[0-9a-fA-F]`; the actual converter regex is `[0-9a-fA-F]+`.