### PR TITLE
Fix AbstractEmailUser example field

### DIFF
--- a/docs/custom_user.rst
+++ b/docs/custom_user.rst
@@ -41,7 +41,7 @@ example::
   from django_boost.models import AbstractEmailUser
 
   class CustomUser(AbstractEmailUser):
-      is_flozen = models.BoolField(default=False)
+      is_frozen = models.BooleanField(default=False)
       homepage = models.URLField()
 
 


### PR DESCRIPTION
## Summary

Corrections to the `AbstractEmailUser` example in `docs/custom_user.rst`: `models.BoolField` does not exist (use `models.BooleanField`), and `is_flozen` → `is_frozen`.