### PR TITLE
Fix utils and shortcuts doc typos

### DIFF
--- a/django_boost/utils/functions/loop.py
+++ b/django_boost/utils/functions/loop.py
@@ -34,7 +34,7 @@ def looplast(iterable: Iterable[_T]) -> Iterator[tuple[bool, _T]]:
 
 def loopfirstlast(iterable: Iterable[_T]) -> Iterator[tuple[bool, _T]]:
     """
-    A function combining `firstloop` and` lastloop`.
+    A function combining `loopfirst` and `looplast`.
 
     Yield True if the first and last element of the iterator object,
     False otherwise.

--- a/docs/shortcut_functions.rst
+++ b/docs/shortcut_functions.rst
@@ -1,7 +1,7 @@
 Shortcut Functions
 ===================
 
-:synopsis: Model mixins in django-boost
+:synopsis: Shortcut functions in django-boost
 
 
 ::

--- a/docs/utility_functions.rst
+++ b/docs/utility_functions.rst
@@ -65,7 +65,7 @@ Yield True when the last element of the given iterator object, False otherwise.
 loopfirstlast
 ~~~~~~~~~~~~~~
 
-A function combining ``firstloop`` and ``lastloop``.
+A function combining ``loopfirst`` and ``looplast``.
 
 Yield True if the first and last element of the iterator object, False otherwise.
 


### PR DESCRIPTION
## Summary

- `docs/shortcut_functions.rst`: `:synopsis:` said "Model mixins in django-boost" (copy-paste); it is shortcut functions.
- `docs/utility_functions.rst` and the `loopfirstlast` docstring: referred to non-existent `firstloop`/`lastloop`; the functions are `loopfirst`/`looplast`.