### PR TITLE
:bug: Re-export status-code exceptions from django_boost.http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `getattr_chain` without a default now propagates the underlying `AttributeError` instead of rewriting it into a generic one.
 - The `urlencode`/`urldecode` template filters now coerce a non-string value (e.g. an int or `None`) to `str`, instead of raising `TypeError`.
+- The status-code exceptions (`Http400`, `Http500`, and the rest) are now importable from `django_boost.http`, instead of only from `django_boost.http.response`.
 
 ## [3.2.2] - 2026-07-06
 

--- a/django_boost/http/__init__.py
+++ b/django_boost/http/__init__.py
@@ -4,9 +4,28 @@ from __future__ import annotations
 
 from collections import defaultdict
 
-from django_boost.http.response import HttpResponseUnsupportedMediaType
+from django_boost.http.response import (Http301, Http302, Http307, Http308,
+                                        Http400, Http401, Http402, Http403,
+                                        Http405, Http406, Http407, Http408,
+                                        Http409, Http410, Http411, Http412,
+                                        Http413, Http414, Http415, Http416,
+                                        Http417, Http418, Http421, Http422,
+                                        Http423, Http424, Http425, Http426,
+                                        Http428, Http429, Http431, Http451,
+                                        Http500, Http501, Http502, Http503,
+                                        Http504, Http505, Http506, Http507,
+                                        Http508, Http509, Http510, Http511,
+                                        HttpResponseUnsupportedMediaType)
 
-__all__ = ['HttpResponseUnsupportedMediaType']
+__all__ = ['HttpResponseUnsupportedMediaType',
+           'Http301', 'Http302', 'Http307', 'Http308',
+           'Http400', 'Http401', 'Http402', 'Http403', 'Http405', 'Http406',
+           'Http407', 'Http408', 'Http409', 'Http410', 'Http411', 'Http412',
+           'Http413', 'Http414', 'Http415', 'Http416', 'Http417', 'Http418',
+           'Http421', 'Http422', 'Http423', 'Http424', 'Http425', 'Http426',
+           'Http428', 'Http429', 'Http431', 'Http451',
+           'Http500', 'Http501', 'Http502', 'Http503', 'Http504', 'Http505',
+           'Http506', 'Http507', 'Http508', 'Http509', 'Http510', 'Http511']
 
 STATUS_MESSAGES = defaultdict(lambda: '')
 STATUS_MESSAGES.update({

--- a/tests/tests/test_http.py
+++ b/tests/tests/test_http.py
@@ -25,3 +25,35 @@ class TestHttp5xxTailExceptions(TestCase):
             with self.subTest(exc.__name__):
                 self.assertEqual(exc().status_code, code)
                 self.assertEqual(exc.response_class.status_code, code)
+
+
+class TestHttpPackageReExportsExceptions(TestCase):
+    """Every status-code exception is importable from ``django_boost.http``.
+
+    Mirrors Django's own ``Http404``, which is importable from ``django.http``.
+    Derived from the classes in ``response`` so a newly added exception is
+    covered without editing this test.
+    """
+
+    def _status_exception_names(self):
+        from django_boost.http import response
+        bases = (response.HttpExceptionBase,
+                 response.HttpRedirectExceptionBase)
+        return [name for name, obj in vars(response).items()
+                if isinstance(obj, type)
+                and issubclass(obj, response.HttpExceptionBase)
+                and obj not in bases]
+
+    def test_status_exceptions_importable_from_package(self):
+        from django_boost import http
+        from django_boost.http import response
+        for name in self._status_exception_names():
+            with self.subTest(name):
+                self.assertIs(getattr(http, name, None),
+                              getattr(response, name))
+
+    def test_status_exceptions_listed_in_all(self):
+        from django_boost import http
+        for name in self._status_exception_names():
+            with self.subTest(name):
+                self.assertIn(name, http.__all__)


### PR DESCRIPTION
## Summary

The docs and README tell users to `from django_boost.http import Http400` (and the other `HttpNNN` status-code exceptions), but the package only re-exported `HttpResponseUnsupportedMediaType`, so every documented import raised `ImportError`; the exceptions were reachable only via the undocumented `django_boost.http.response`. Re-export all `HttpNNN` exceptions and list them in `__all__`, mirroring how Django exposes `Http404` from `django.http`.

## Notes

- Covers the full documented set: 3xx (301/302/307/308), 4xx (400-451) and 5xx (500-511) — 45 exceptions in total.