### PR TITLE
:bug: Coerce non-string input in urlencode/urldecode filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ### Fixed
 
-- `getattr_chain` without a default now propagates the underlying `AttributeError` (preserving its type and message) instead of rewriting it into a generic one.
+- `getattr_chain` without a default now propagates the underlying `AttributeError` instead of rewriting it into a generic one.
+- The `urlencode`/`urldecode` template filters now coerce a non-string value (e.g. an int or `None`) to `str`, instead of raising `TypeError`.
 
 ## [3.2.2] - 2026-07-06
 

--- a/django_boost/templatetags/boost_url.py
+++ b/django_boost/templatetags/boost_url.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from urllib import parse
 
 from django.template import Library
+from django.template.defaultfilters import stringfilter
 
 from django_boost.utils.itertools import chunked
 
@@ -13,11 +14,13 @@ register = Library()
 
 
 @register.filter(name="urlencode", is_safe=True)
+@stringfilter
 def urlencode(value, arg="/"):
     return parse.quote(value, safe=arg)
 
 
 @register.filter(name="urldecode")
+@stringfilter
 def urldecode(value):
     return parse.unquote(value)
 

--- a/tests/tests/templatetags/test_boost_url.py
+++ b/tests/tests/templatetags/test_boost_url.py
@@ -14,6 +14,13 @@ class UrlencodeFilterTests(TestCase):
         for a, e in cases:
             self.assertEqual(urlencode(a), e)
 
+    def test_urlencode_coerces_non_string_input(self):
+        # Like Django's built-in urlencode filter, coerce to str instead of
+        # raising TypeError on a non-string value (e.g. an int or None).
+        from django_boost.templatetags.boost_url import urlencode
+        self.assertEqual(urlencode(123), "123")
+        self.assertEqual(urlencode(None), "None")
+
 
 class UrldecodeFilterTests(TestCase):
 
@@ -26,6 +33,11 @@ class UrldecodeFilterTests(TestCase):
         ]
         for a, e in cases:
             self.assertEqual(urldecode(a), e)
+
+    def test_urldecode_coerces_non_string_input(self):
+        from django_boost.templatetags.boost_url import urldecode
+        self.assertEqual(urldecode(123), "123")
+        self.assertEqual(urldecode(None), "None")
 
     def test_urldecode_output_is_escaped_in_autoescaped_template(self):
         from django.template import Context, Template


### PR DESCRIPTION
## Summary

`{{ value|urlencode }}` (and `urldecode`) raised `TypeError` and broke rendering of the whole template when `value` was not a string (e.g. an int or `None`), because `urllib.parse.quote`/`unquote` require a string. Both filters now apply `@stringfilter`, coercing the value to `str` exactly like Django's built-in `urlencode` filter.