### PR TITLE
:memo: Note Django's built-in urlencode as the preferred filter

### DIFF
--- a/docs/template_tags.rst
+++ b/docs/template_tags.rst
@@ -131,6 +131,13 @@ You can specify non-conversion characters in the argument.
 
   {{ url | urlencode:'abc' }}
 
+.. note::
+
+   Django ships an equivalent built-in ``urlencode`` filter (its argument is
+   named ``safe``), so prefer the built-in when you only need URL encoding.
+   This filter is kept mainly to pair with ``urldecode`` below, for which
+   Django has no built-in.
+
 
 urldecode
 ~~~~~~~~~~


### PR DESCRIPTION
## Summary

`django_boost`'s `urlencode` template filter is behavior-equivalent to Django's built-in `urlencode` (both `@stringfilter` + `quote(value, safe=...)`). Add a docs note pointing readers at the built-in and explaining this filter is kept mainly to pair with `urldecode`, for which Django has no built-in.