### PR TITLE
:bookmark: Release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+## [3.2.1] - 2026-07-05
+
 ### Fixed
 
 - `adminsitelog` now reports an unknown `--filter`/`--exclude`/`--order_by` field name as a command error instead of an unhandled `FieldError` traceback.
@@ -453,7 +455,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - First release.
 
-[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.2.0...HEAD
+[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.2.1...HEAD
+[3.2.1]: https://github.com/ChanTsune/django-boost/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/ChanTsune/django-boost/compare/v3.1.2...v3.2.0
 [3.1.2]: https://github.com/ChanTsune/django-boost/compare/v3.1.1...v3.1.2
 [3.1.1]: https://github.com/ChanTsune/django-boost/compare/v3.1.0...v3.1.1

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from django_boost.utils.version import get_version
 
-VERSION = (3, 2, 0, 'final', 0)
+VERSION = (3, 2, 1, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
- Fixed
  - `adminsitelog` now reports an unknown `--filter`/`--exclude`/`--order_by` field name as a command error instead of an unhandled `FieldError` traceback.
  - Comparing two `ContainAnyValidator` instances no longer raises `AttributeError`; `__init__` now initializes the inherited `limit_value`.
  - `ContainAnyValidator` no longer raises `TypeError` when its custom message omits the `%s` placeholder; it raises `ValidationError` with the message verbatim.
  - `JsonResponseMixin.get` now builds the response with the view response_class instead of a hardcoded `JsonResponse`, so a custom response class takes effect.
  - `ColorCodeField` now implements `deconstruct()`, so its `upper`/`lower` option is preserved in migrations instead of being dropped.
