### PR TITLE
:wrench: Enable all Read the Docs offline formats

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,9 +15,8 @@ build:
 sphinx:
    configuration: docs/conf.py
 
-# If using Sphinx, optionally build your docs in additional formats such as PDF
-# formats:
-#    - pdf
+# If using Sphinx, optionally build your docs in additional formats
+formats: all
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
Set the Read the Docs formats option to all so PDF, ePub, and zipped HTML artifacts are built alongside the hosted docs.
