### PR TITLE
Enable flake8 D401 and rewrite docstrings in imperative mood

### DIFF
--- a/django_boost/utils/__init__.py
+++ b/django_boost/utils/__init__.py
@@ -39,7 +39,7 @@ class Loop(Iterator[tuple["Loop[_T]", _T]]):
 
 
 def loop(iterable: Sequence[_T]) -> Loop[_T]:
-    """Provides features such as Django template like loop."""
+    """Provide features such as Django template like loop."""
     return Loop(iterable)
 
 

--- a/django_boost/utils/functions/loop.py
+++ b/django_boost/utils/functions/loop.py
@@ -34,7 +34,7 @@ def looplast(iterable: Iterable[_T]) -> Iterator[tuple[bool, _T]]:
 
 def loopfirstlast(iterable: Iterable[_T]) -> Iterator[tuple[bool, _T]]:
     """
-    A function combining `loopfirst` and `looplast`.
+    Combine `loopfirst` and `looplast`.
 
     Yield True if the first and last element of the iterator object,
     False otherwise.

--- a/django_boost/validators/uuid.py
+++ b/django_boost/validators/uuid.py
@@ -9,10 +9,11 @@ __all__ = ["validate_uuid4"]
 
 
 def validate_uuid4(value: str) -> None:
-    """Deprecated UUID validator.
+    """Validate that `value` is a UUID4 string.
 
-    Raises a ``DeprecationWarning`` and will be removed in django-boost 4.0;
-    validate UUIDs with Django's ``UUIDField`` or :func:`uuid.UUID` instead.
+    Deprecated: raises a ``DeprecationWarning`` and will be removed in
+    django-boost 4.0; validate UUIDs with Django's ``UUIDField`` or
+    :func:`uuid.UUID` instead.
     """
     warnings.warn(
         "'validate_uuid4' is deprecated and will be removed in django-boost"

--- a/docs/utility_functions.rst
+++ b/docs/utility_functions.rst
@@ -65,7 +65,7 @@ Yield True when the last element of the given iterator object, False otherwise.
 loopfirstlast
 ~~~~~~~~~~~~~~
 
-A function combining ``loopfirst`` and ``looplast``.
+Combine ``loopfirst`` and ``looplast``.
 
 Yield True if the first and last element of the iterator object, False otherwise.
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 commands = flake8 .
 
 [flake8]
-ignore = D100,D101,D102,D103,D104,D105,D106,D107,D205,D400,D401
+ignore = D100,D101,D102,D103,D104,D105,D106,D107,D205,D400
 exclude = 
     .git,
     .tox,


### PR DESCRIPTION
## Summary
Enable flake8's `D401` (imperative mood docstring) check, previously disabled via `tox.ini`'s `ignore` list. Rewrote the three flagged docstrings (`utils.loop`, `utils.functions.loop.loopfirstlast`, `validators.uuid.validate_uuid4`) and updated `docs/utility_functions.rst`, which had duplicated one of the old docstrings verbatim.