### PR TITLE
Enable flake8 D400/D205 and reformat docstring summaries

### DIFF
--- a/django_boost/forms/__init__.py
+++ b/django_boost/forms/__init__.py
@@ -25,10 +25,7 @@ __all__ = (
 
 
 class UserCreationForm(BaseUserCreationForm):
-    """
-    A form that creates a user, with no privileges, from the active user
-    model's ``USERNAME_FIELD`` and password.
-    """
+    """A form that creates a user, with no privileges, from the active user model's ``USERNAME_FIELD`` and password."""
 
     class Meta(BaseUserCreationForm.Meta):
         model = get_user_model()
@@ -39,10 +36,7 @@ class UserCreationForm(BaseUserCreationForm):
 
 
 class UserChangeForm(BaseUserChangeForm):
-    """
-    A form for changing an existing user, using the active user model's
-    ``USERNAME_FIELD``.
-    """
+    """A form for changing an existing user, using the active user model's ``USERNAME_FIELD``."""
 
     class Meta(BaseUserChangeForm.Meta):
         model = get_user_model()
@@ -53,10 +47,7 @@ class UserChangeForm(BaseUserChangeForm):
 
 
 class AuthenticationForm(BaseAuthenticationForm):
-    """
-    A form for authenticating a user with the active user model's
-    ``USERNAME_FIELD``.
-    """
+    """A form for authenticating a user with the active user model's ``USERNAME_FIELD``."""
 
     username = UsernameField(widget=forms.TextInput(attrs={"autofocus": True}))
     password = forms.CharField(

--- a/django_boost/forms/widgets.py
+++ b/django_boost/forms/widgets.py
@@ -42,6 +42,6 @@ class InvertCheckboxInput(CheckboxInput):
 
 
 class Toggleswitch(CheckboxInput):
-    """toggle switch styled input"""
+    """Toggle switch styled input."""
 
     template_name = "boost/forms/widgets/toggleswitch.html"

--- a/django_boost/shortcuts.py
+++ b/django_boost/shortcuts.py
@@ -1,7 +1,8 @@
 """
-This module collects helper functions and classes that "span" multiple levels
-of MVC. In other words, these functions/classes introduce controlled coupling
-for convenience's sake.
+This module collects helper functions and classes that "span" multiple levels of MVC.
+
+In other words, these functions/classes introduce controlled coupling for
+convenience's sake.
 """
 
 from __future__ import annotations
@@ -20,8 +21,7 @@ def _get_queryset(klass):
 
 def get_object_or_default(klass, *args, default=None, **kwargs):
     """
-    Use get() to return an object or return default if the object
-    does not exist.
+    Use get() to return an object or return default if the object does not exist.
 
     klass may be a Model, Manager, or QuerySet object. All other passed
     arguments and keyword arguments are used in the get() query.
@@ -44,8 +44,7 @@ def get_object_or_default(klass, *args, default=None, **kwargs):
 
 def get_object_or_exception(klass, *args, exception=None, **kwargs):
     """
-    Use get() to return an object, or raise exception if the object
-    does not exist.
+    Use get() to return an object, or raise exception if the object does not exist.
 
     klass may be a Model, Manager, or QuerySet object. All other passed
     arguments and keyword arguments are used in the get() query.
@@ -70,8 +69,7 @@ def get_object_or_exception(klass, *args, exception=None, **kwargs):
 
 def get_list_or_default(klass, *args, default=None, **kwargs):
     """
-    Use filter() to return a list of objects, or return default if
-    the list is empty.
+    Use filter() to return a list of objects, or return default if the list is empty.
 
     klass may be a Model, Manager, or QuerySet object. All other passed
     arguments and keyword arguments are used in the filter() query.
@@ -92,8 +90,7 @@ def get_list_or_default(klass, *args, default=None, **kwargs):
 
 def get_list_or_exception(klass, *args, exception=None, **kwargs):
     """
-    Use filter() to return a list of objects, or raise exception if
-    the list is empty.
+    Use filter() to return a list of objects, or raise exception if the list is empty.
 
     klass may be a Model, Manager, or QuerySet object. All other passed
     arguments and keyword arguments are used in the filter() query.

--- a/django_boost/urls/static.py
+++ b/django_boost/urls/static.py
@@ -33,8 +33,7 @@ def load_static_files(path):
 
 def include_static_files(path):
     """
-    Add to routing that static files under the directory
-    specified by the absolute path.
+    Add to routing that static files under the directory specified by the absolute path.
 
     example ::
 

--- a/django_boost/utils/__init__.py
+++ b/django_boost/utils/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Container, Iterable, Iterator, Sequence
 from typing import TypeGuard, TypeVar
 
+__all__ = ["Loop", "contain_any", "isiterable", "loop"]
+
 _T = TypeVar("_T")
 
 

--- a/django_boost/utils/__init__.py
+++ b/django_boost/utils/__init__.py
@@ -53,8 +53,5 @@ def isiterable(obj: object) -> TypeGuard[Iterable[object]]:
 
 
 def contain_any(container: Container[object], elements: Iterable[object]) -> bool:
-    """
-    Return `True` if any of the `elements` are contained in `container`,
-    `False` otherwise.
-    """
+    """Return `True` if any of the `elements` are contained in `container`, `False` otherwise."""
     return any(e in container for e in elements)

--- a/django_boost/utils/functions/json.py
+++ b/django_boost/utils/functions/json.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from django.db import models
 
+__all__ = ["json_to_model", "model_to_json"]
+
 
 def model_to_json(model, fields=(), exclude=()):
     """

--- a/django_boost/utils/functions/loop.py
+++ b/django_boost/utils/functions/loop.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Collection, Iterable, Iterator
 from typing import TypeVar
 
+__all__ = ["loopfirst", "loopfirstlast", "looplast"]
+
 _T = TypeVar("_T")
 
 

--- a/django_boost/utils/itertools.py
+++ b/django_boost/utils/itertools.py
@@ -25,7 +25,7 @@ def take(n: int, iterable: Iterable[_T]) -> list[_T]:
 
 
 def chunked(iterable: Iterable[_T], n: int) -> Iterator[list[_T]]:
-    """Break *iterable* into lists of length *n*:
+    """Break *iterable* into lists of length *n*.
 
     example ::
 

--- a/django_boost/utils/itertools.py
+++ b/django_boost/utils/itertools.py
@@ -5,6 +5,8 @@ from functools import partial
 from itertools import islice
 from typing import TypeVar
 
+__all__ = ["chunked", "take"]
+
 _T = TypeVar("_T")
 
 

--- a/django_boost/utils/version.py
+++ b/django_boost/utils/version.py
@@ -33,8 +33,10 @@ def get_main_version(version: _Version | None = None) -> str:
 
 def get_complete_version(version: _Version | None = None) -> _Version:
     """
-    Return a tuple of the django version. If version argument is non-empty,
-    check for correctness of the tuple provided.
+    Return a tuple of the django version.
+
+    If version argument is non-empty, check for correctness of the tuple
+    provided.
     """
     if version is None:
         from django_boost import VERSION

--- a/django_boost/views/simple.py
+++ b/django_boost/views/simple.py
@@ -23,8 +23,7 @@ class ResponseContentMixin:
 
     def content_to_response(self, content, **response_kwargs):
         """
-        Return a response, using the `response_class` for this view, with
-        the given context.
+        Return a response, using the `response_class` for this view, with the given context.
 
         Pass response_kwargs to the constructor of the response class.
         """

--- a/docs/utility_functions.rst
+++ b/docs/utility_functions.rst
@@ -24,7 +24,8 @@ loop
       forloop.first
       forloop.last
 
-Provides Django Template loops to Python programs.
+Provides Django Template loops to Python programs. ``loop()`` wraps *iterable*
+in a ``Loop`` instance (the ``forloop`` object above).
 
 loopfirst
 ~~~~~~~~~~
@@ -81,3 +82,87 @@ Yield True if the first and last element of the iterator object, False otherwise
   # False 2
   # False 3
   # True 4
+
+
+type utils
+-----------
+
+isiterable
+~~~~~~~~~~~
+
+::
+
+  from django_boost.utils import isiterable
+
+  isiterable([1, 2, 3])  # True
+  isiterable(1)          # False
+
+Return `True` if `obj` is iterable object, `False` otherwise.
+
+contain_any
+~~~~~~~~~~~~
+
+::
+
+  from django_boost.utils import contain_any
+
+  contain_any([1, 2, 3], [3, 4, 5])  # True
+  contain_any([1, 2, 3], [4, 5])     # False
+
+Return `True` if any of the `elements` are contained in `container`, `False`
+otherwise.
+
+
+itertools utils
+-----------------
+
+take
+~~~~~
+
+::
+
+  from django_boost.utils.itertools import take
+
+  take(3, range(10))  # [0, 1, 2]
+
+Return first *n* items of the iterable as a list.
+
+chunked
+~~~~~~~~
+
+::
+
+  from django_boost.utils.itertools import chunked
+
+  list(chunked([1, 2, 3, 4, 5, 6], 3))  # [[1, 2, 3], [4, 5, 6]]
+
+Break *iterable* into lists of length *n*.
+
+
+json utils
+-----------
+
+model_to_json
+~~~~~~~~~~~~~~
+
+::
+
+  from django_boost.utils.functions import model_to_json
+
+  model_to_json(my_model_instance)          # {'id': 1, 'name': 'x', ...}
+  model_to_json(MyModel.objects.filter())   # [{'id': 1, ...}, {'id': 2, ...}]
+
+Take a Model instance or QuerySet and return a dict, or a list of dicts,
+of its field values.
+
+json_to_model
+~~~~~~~~~~~~~~
+
+::
+
+  from django_boost.utils.functions import json_to_model
+
+  json_to_model(MyModel, model_to_json(my_model_instance))
+
+Build an unsaved ``MyModel`` instance from a dict shaped like
+``model_to_json``'s output.

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 commands = flake8 .
 
 [flake8]
-ignore = D100,D101,D102,D103,D104,D105,D106,D107,D205,D400
+ignore = D100,D101,D102,D103,D104,D105,D106,D107
 exclude = 
     .git,
     .tox,


### PR DESCRIPTION
## Summary
Stacked on #403. Enable flake8's `D400` (summary line must end with a period) and `D205` (blank line between summary and description) checks, previously disabled via `tox.ini`'s `ignore` list. These two overlapped almost entirely (11 of 12 D205 hits were the same docstrings as D400), so fixing them together avoided touching the same lines twice.

Reformatted the affected docstrings in `forms/__init__.py`, `forms/widgets.py`, `shortcuts.py`, `urls/static.py`, `utils/__init__.py`, `utils/itertools.py`, `utils/version.py`, and `views/simple.py` so each starts with a single-line, period-terminated summary.