### PR TITLE
Enable flake8 D104 and add package docstrings

### DIFF
--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -1,3 +1,5 @@
+"""Reusable Django extensions: drop-in replacements and add-ons for Django's built-in classes."""
+
 from __future__ import annotations
 
 from django_boost.utils.version import get_version

--- a/django_boost/admin/__init__.py
+++ b/django_boost/admin/__init__.py
@@ -1,3 +1,5 @@
+"""Admin site extensions for Django's ``django.contrib.admin``."""
+
 from __future__ import annotations
 
 from django.contrib import admin

--- a/django_boost/admin_tools/__init__.py
+++ b/django_boost/admin_tools/__init__.py
@@ -1,0 +1,1 @@
+"""Deprecated alias for ``django_boost.contrib.admin_tools``; will be removed in django-boost 4.0."""

--- a/django_boost/admin_tools/management/__init__.py
+++ b/django_boost/admin_tools/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management command package for the deprecated ``django_boost.admin_tools`` app."""

--- a/django_boost/admin_tools/management/commands/__init__.py
+++ b/django_boost/admin_tools/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for the deprecated ``django_boost.admin_tools`` app."""

--- a/django_boost/contrib/__init__.py
+++ b/django_boost/contrib/__init__.py
@@ -1,0 +1,1 @@
+"""Namespace package for django-boost's optional, separately-installed apps."""

--- a/django_boost/contrib/admin_tools/__init__.py
+++ b/django_boost/contrib/admin_tools/__init__.py
@@ -1,0 +1,1 @@
+"""The current location for admin-tooling; see ``django_boost.admin_tools`` for its deprecated predecessor."""

--- a/django_boost/contrib/admin_tools/management/__init__.py
+++ b/django_boost/contrib/admin_tools/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management command package for the ``django_boost.contrib.admin_tools`` app."""

--- a/django_boost/contrib/admin_tools/management/commands/__init__.py
+++ b/django_boost/contrib/admin_tools/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for the ``django_boost.contrib.admin_tools`` app."""

--- a/django_boost/core/__init__.py
+++ b/django_boost/core/__init__.py
@@ -1,3 +1,5 @@
+"""Internal helpers used across django_boost; not part of the public API."""
+
 from __future__ import annotations
 
 from django_boost import __version__ as VERSION

--- a/django_boost/db/__init__.py
+++ b/django_boost/db/__init__.py
@@ -1,0 +1,1 @@
+"""Extensions for Django's ``django.db``."""

--- a/django_boost/forms/__init__.py
+++ b/django_boost/forms/__init__.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.forms``."""
+
 from __future__ import annotations
 
 from django import forms

--- a/django_boost/http/__init__.py
+++ b/django_boost/http/__init__.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.http``."""
+
 from __future__ import annotations
 
 from collections import defaultdict

--- a/django_boost/management/__init__.py
+++ b/django_boost/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management-command support code, mirroring Django's ``management`` app-subpackage convention."""

--- a/django_boost/management/commands/__init__.py
+++ b/django_boost/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""django_boost's ``manage.py`` command implementations."""

--- a/django_boost/middleware/__init__.py
+++ b/django_boost/middleware/__init__.py
@@ -1,3 +1,5 @@
+"""Middleware extensions for Django's request/response cycle."""
+
 from __future__ import annotations
 
 from django.conf import settings

--- a/django_boost/migrations/__init__.py
+++ b/django_boost/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Database migrations for django_boost's own models."""

--- a/django_boost/models/__init__.py
+++ b/django_boost/models/__init__.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.db.models``."""
+
 from __future__ import annotations
 
 from django.contrib.auth.models import AbstractUser, UnicodeUsernameValidator

--- a/django_boost/models/fields/__init__.py
+++ b/django_boost/models/fields/__init__.py
@@ -1,3 +1,5 @@
+"""Custom model fields for Django's ``django.db.models``."""
+
 from __future__ import annotations
 
 import warnings

--- a/django_boost/template/__init__.py
+++ b/django_boost/template/__init__.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.template``."""
+
 from __future__ import annotations
 
 from django_boost.template.base import StrictInvalidTemplateVariable

--- a/django_boost/templatetags/__init__.py
+++ b/django_boost/templatetags/__init__.py
@@ -1,0 +1,1 @@
+"""Template tag and filter library; load with ``{% load boost %}``."""

--- a/django_boost/test/__init__.py
+++ b/django_boost/test/__init__.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.test``."""
+
 from __future__ import annotations
 
 from django_boost.test.testcase import TestCase

--- a/django_boost/urls/__init__.py
+++ b/django_boost/urls/__init__.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.urls``."""
+
 from __future__ import annotations
 
 from django_boost.urls.converters import (

--- a/django_boost/urls/converters/__init__.py
+++ b/django_boost/urls/converters/__init__.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.urls`` path converters."""
+
 from __future__ import annotations
 
 from django.urls import register_converter

--- a/django_boost/utils/__init__.py
+++ b/django_boost/utils/__init__.py
@@ -1,3 +1,5 @@
+"""General-purpose helper functions and classes."""
+
 from __future__ import annotations
 
 from collections.abc import Container, Iterable, Iterator, Sequence

--- a/django_boost/utils/functions/__init__.py
+++ b/django_boost/utils/functions/__init__.py
@@ -1,3 +1,5 @@
+"""Re-exported helpers from ``django_boost.utils.functions`` submodules."""
+
 from __future__ import annotations
 
 from django_boost.utils.functions.json import json_to_model, model_to_json

--- a/django_boost/views/__init__.py
+++ b/django_boost/views/__init__.py
@@ -1,0 +1,1 @@
+"""View extensions: drop-in replacements for Django's generic views, plus reusable mixins."""

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 commands = flake8 .
 
 [flake8]
-ignore = D100,D101,D102,D103,D104,D105,D106,D107
+ignore = D100,D101,D102,D103,D105,D106,D107
 exclude = 
     .git,
     .tox,


### PR DESCRIPTION
## Summary
Stacked on #404. Enable flake8's `D104` (missing docstring in public package) check, previously disabled via `tox.ini`'s `ignore` list. Adds a one-line docstring to each of the 27 `__init__.py` files under `django_boost/` that lacked one.