### PR TITLE
Enable flake8 D107 and add __init__ docstrings

### DIFF
--- a/django_boost/db/router.py
+++ b/django_boost/db/router.py
@@ -11,6 +11,7 @@ class DatabaseRouter:
     """Route Django apps to database aliases from DATABASE_APPS_MAPPING."""
 
     def __init__(self) -> None:
+        """Load the app-to-database mapping from ``settings.DATABASE_APPS_MAPPING``."""
         self.db_map: dict[str, str] = getattr(
             settings, "DATABASE_APPS_MAPPING", {})
 

--- a/django_boost/forms/mixins.py
+++ b/django_boost/forms/mixins.py
@@ -9,9 +9,10 @@ from django_boost.utils.attribute import getattr_chain
 
 
 class FormUserKwargsMixin:
-    """Mixin to add `User model` to form instance variable."""
+    """Mixin that pulls a ``user`` keyword argument into ``self.user``."""
 
     def __init__(self, *args, **kwargs):
+        """Pop the ``user`` keyword argument into ``self.user`` before delegating to the form."""
         self.user = kwargs.pop('user')
         super().__init__(*args, **kwargs)
 

--- a/django_boost/forms/mixins.py
+++ b/django_boost/forms/mixins.py
@@ -42,6 +42,7 @@ class FieldRenameMixin:
     rename_fields = {}
 
     def __init__(self, *args, **kwargs):
+        """Rename fields in ``self.fields`` per ``rename_fields`` after the form initializes."""
         super().__init__(*args, **kwargs)
         for key, value in self.rename_fields.items():
             if key != value:
@@ -131,6 +132,7 @@ class RelatedModelInlineMixin:
     inline_fields = None
 
     def __init__(self, *args, **kwargs):
+        """Add form fields for each related model's ``inline_fields`` after the form initializes."""
         super().__init__(*args, **kwargs)
         self._related_field_model = {}
         for field, related_fields in self.inline_fields.items():

--- a/django_boost/forms/widgets.py
+++ b/django_boost/forms/widgets.py
@@ -34,6 +34,7 @@ class InvertCheckboxInput(CheckboxInput):
     """Returns false if checked, true if not checked."""
 
     def __init__(self, attrs=None, check_test=None):
+        """Fall back to treating ``False``, ``None``, and ``''`` as checked when ``check_test`` is omitted."""
         super().__init__(attrs)
         self.check_test = boolean_check if check_test is None else check_test
 

--- a/django_boost/http/response.py
+++ b/django_boost/http/response.py
@@ -166,6 +166,7 @@ class HttpExceptionBase(Exception):
 class HttpRedirectExceptionBase(HttpExceptionBase):
 
     def __init__(self, redirect_to, *args):
+        """Store the redirect target as ``self.url``."""
         self.url = redirect_to
         super(HttpRedirectExceptionBase, self).__init__(*args)
 
@@ -206,6 +207,7 @@ class Http405(HttpExceptionBase):
     response_class = HttpResponseNotAllowed
 
     def __init__(self, permitted_methods=(), *args):
+        """Store the allowed HTTP methods as ``self.permitted_methods``."""
         self.permitted_methods = permitted_methods
         super().__init__(*args)
 

--- a/django_boost/models/deletion.py
+++ b/django_boost/models/deletion.py
@@ -32,6 +32,7 @@ def get_logical_delete_field(model):
 class LogicalDeletionCollector(Collector):
 
     def __init__(self, using, origin=None, deleted_at=None):
+        """Store ``deleted_at`` to use as the logical-deletion timestamp/flag value."""
         super().__init__(using=using, origin=origin)
         self.origin = origin
         self.deleted_at = deleted_at

--- a/django_boost/models/fields/__init__.py
+++ b/django_boost/models/fields/__init__.py
@@ -20,6 +20,7 @@ class ColorCodeField(CharField):
     default_validators = [validate_color_code]
 
     def __init__(self, *args, upper=False, lower=False, **kwargs):
+        """Fix ``max_length`` to 7 and pick the upper/lower normalization to apply."""
         kwargs.update({"max_length": 7})
         if upper and lower:
             raise AssertionError(
@@ -73,6 +74,7 @@ class ColorCodeFiled(ColorCodeField):
     """
 
     def __init__(self, *args, **kwargs):
+        """Warn that ``ColorCodeFiled`` is deprecated before delegating to ``ColorCodeField``."""
         warnings.warn(
             "'ColorCodeFiled' is a deprecated misspelling of 'ColorCodeField'"
             " and will be removed in django-boost 4.0; use 'ColorCodeField'"

--- a/django_boost/urls/static.py
+++ b/django_boost/urls/static.py
@@ -10,6 +10,7 @@ from django_boost.views.generic import StaticView
 class StaticFileConnector:
 
     def __init__(self, path):
+        """Build a ``urls.path()`` entry for every file under ``path``."""
         self._urls = []
 
         for base, _, files in os.walk(path):

--- a/django_boost/utils/__init__.py
+++ b/django_boost/utils/__init__.py
@@ -22,6 +22,7 @@ class Loop(Iterator[tuple["Loop[_T]", _T]]):
     last: bool
 
     def __init__(self, iterable: Sequence[_T]) -> None:
+        """Wrap ``iterable`` in an ``enumerate()`` to track position per iteration."""
         self.iterable = enumerate(iterable)
         self.length = len(iterable)
 

--- a/django_boost/utils/html.py
+++ b/django_boost/utils/html.py
@@ -14,6 +14,7 @@ class HTMLSpaceLessCompressor(HTMLParser):
     WHITESPACE_PRESERVING_ELEMENTS = frozenset({'pre', 'textarea'})
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the output buffer and whitespace-tracking state."""
         super().__init__(*args, **kwargs)
         self.buffer = StringIO()
         self._raw_depth = 0

--- a/django_boost/validators/collection.py
+++ b/django_boost/validators/collection.py
@@ -18,7 +18,7 @@ class ContainAnyValidator(BaseValidator):
     message = _('The input must contain one of "%s"\'s.')
 
     def __init__(self, elements: Iterable[Any], message: Any = None) -> None:
-        # Set limit_value via BaseValidator so its __eq__ can compare validators.
+        """Delegate to ``BaseValidator`` so ``limit_value`` supports validator equality checks."""
         super().__init__(elements, message)
 
     def __call__(self, value: Any) -> None:

--- a/django_boost/validators/integer.py
+++ b/django_boost/validators/integer.py
@@ -23,6 +23,7 @@ class NonZeroValidator(BaseValidator):
     code = 'non_zero'
 
     def __init__(self, message: Any = None) -> None:
+        """Override the default message when one is given."""
         if message:
             self.message = message
 

--- a/django_boost/validators/json.py
+++ b/django_boost/validators/json.py
@@ -19,6 +19,7 @@ class JsonValidator(BaseValidator):
     code = 'json value'
 
     def __init__(self, message: Any = None) -> None:
+        """Override the default message when one is given."""
         if message:
             self.message = message
 

--- a/django_boost/views/generic.py
+++ b/django_boost/views/generic.py
@@ -74,6 +74,7 @@ class BaseModelCLUDViews:
     success_url = None
 
     def __init__(self, app_name=None):
+        """Fall back to the model's lowercased class name when ``app_name`` is omitted."""
         if self.model:
             model_name = self.model.__name__.lower()
         else:

--- a/docs/form_mixins.rst
+++ b/docs/form_mixins.rst
@@ -84,3 +84,27 @@ Also can inline multiple relationships.
 
 .. autoclass:: django_boost.forms.mixins.FieldRenameMixin
 
+FormUserKwargsMixin
+---------------------
+
+Mixin that pulls a ``user`` keyword argument into ``self.user``.
+
+Pair it with ``django_boost.views.mixins.ViewUserKwargsMixin``, which adds
+the current request's user to the form kwargs, so the form can access it
+without the view passing it explicitly to ``form_valid``/``form_invalid``.
+
+::
+
+  from django import forms
+  from django_boost.forms.mixins import FormUserKwargsMixin
+  from django_boost.views.mixins import ViewUserKwargsMixin
+  from django.views.generic import FormView
+
+  class MyForm(FormUserKwargsMixin, forms.Form):
+      def clean(self):
+          cleaned_data = super().clean()
+          cleaned_data['owner'] = self.user
+          return cleaned_data
+
+  class MyFormView(ViewUserKwargsMixin, FormView):
+      form_class = MyForm

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 commands = flake8 .
 
 [flake8]
-ignore = D100,D101,D102,D103,D105,D106,D107
+ignore = D100,D101,D102,D103,D105,D106
 exclude = 
     .git,
     .tox,


### PR DESCRIPTION
## Summary
Stacked on #405. Enable flake8's `D107` (missing docstring in `__init__`) check, previously disabled via `tox.ini`'s `ignore` list. Adds a one-line docstring to each of the 17 `__init__` methods that lacked one, describing what that constructor does.

## Notes
`FormUserKwargsMixin` additionally gets a `docs/form_mixins.rst` entry, since it's exported via `__all__` but had no documentation at all.