### PR TITLE
Add decimal path converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Added
+
+- Decimal path converters `decimal`, `signed_decimal`, `positive_decimal`, `negative_decimal`, `non_negative_decimal`, `non_positive_decimal` and `non_zero_decimal`, covering decimal ranges Django's built-in `float` converter cannot express; `decimal` is an alias of `non_negative_decimal`.
+
 ## [3.2.4] - 2026-07-11
 
 ### Fixed

--- a/django_boost/urls/converters/__init__.py
+++ b/django_boost/urls/converters/__init__.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from django.urls import register_converter
 
 from django_boost.urls.converters.date import DateConverter
+from django_boost.urls.converters.decimal import (
+    NegativeDecimalConverter, NonNegativeDecimalConverter,
+    NonPositiveDecimalConverter, NonZeroDecimalConverter,
+    PositiveDecimalConverter, SignedDecimalConverter)
 from django_boost.urls.converters.integer import (
     NegativeIntConverter, NonNegativeIntConverter, NonPositiveIntConverter,
     NonZeroIntConverter, PositiveIntConverter, SignedIntConverter)
@@ -110,6 +114,13 @@ BOOST_CONVERTERS = {
     'non_negative_int': NonNegativeIntConverter,
     'non_positive_int': NonPositiveIntConverter,
     'non_zero_int': NonZeroIntConverter,
+    'decimal': NonNegativeDecimalConverter,
+    'signed_decimal': SignedDecimalConverter,
+    'positive_decimal': PositiveDecimalConverter,
+    'negative_decimal': NegativeDecimalConverter,
+    'non_negative_decimal': NonNegativeDecimalConverter,
+    'non_positive_decimal': NonPositiveDecimalConverter,
+    'non_zero_decimal': NonZeroDecimalConverter,
 }
 
 

--- a/django_boost/urls/converters/decimal.py
+++ b/django_boost/urls/converters/decimal.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import decimal
+from typing import ClassVar
+
+# branch 1: integer part has a non-zero digit (fraction optional)
+# branch 2: integer part is all zeros, but the fraction has a non-zero digit
+_POSITIVE = r'(?:[0-9]*[1-9][0-9]*(?:\.[0-9]+)?|0+\.[0-9]*[1-9][0-9]*)'
+# the whole value is zero, e.g. 0, 00, 0.0, 0.00
+_ZERO = r'0+(?:\.0+)?'
+
+
+class BaseDecimalConverter:
+    """Shared behavior for the signed-decimal path converters.
+
+    Each subclass only declares ``regex``. Sign/zero classification looks
+    at the whole value (integer part and fractional part together) rather
+    than the integer part alone, so e.g. ``0.5`` counts as positive even
+    though its integer part is ``0``. Parsing and reversing are common:
+    the matched text is always a valid ``decimal.Decimal`` literal.
+    """
+
+    regex: ClassVar[str]
+
+    def to_python(self, value: str) -> decimal.Decimal:
+        return decimal.Decimal(value)
+
+    def to_url(self, value: decimal.Decimal | str) -> str:
+        return str(value)
+
+
+class SignedDecimalConverter(BaseDecimalConverter):
+    regex: ClassVar[str] = r'-?[0-9]+(?:\.[0-9]+)?'
+
+
+class PositiveDecimalConverter(BaseDecimalConverter):
+    regex: ClassVar[str] = _POSITIVE
+
+
+class NegativeDecimalConverter(BaseDecimalConverter):
+    regex: ClassVar[str] = f'-{_POSITIVE}'
+
+
+class NonNegativeDecimalConverter(BaseDecimalConverter):
+    regex: ClassVar[str] = r'[0-9]+(?:\.[0-9]+)?'
+
+
+class NonPositiveDecimalConverter(BaseDecimalConverter):
+    regex: ClassVar[str] = f'{_ZERO}|-{_POSITIVE}'
+
+
+class NonZeroDecimalConverter(BaseDecimalConverter):
+    regex: ClassVar[str] = f'-?{_POSITIVE}'

--- a/docs/path_converters.rst
+++ b/docs/path_converters.rst
@@ -126,3 +126,52 @@ non_zero_int
 ``non_zero_int`` matches non-zero integers.
 
 This is passed as ``int`` type to the python program.
+
+decimal
+~~~~~~~
+
+``decimal`` matches ``[0-9]+([.][0-9]+)?`` (alias of ``non_negative_decimal``).
+
+This is passed as ``decimal.Decimal`` type to the python program.
+
+signed_decimal
+~~~~~~~~~~~~~~
+
+``signed_decimal`` matches any decimal number, including negatives.
+
+This is passed as ``decimal.Decimal`` type to the python program.
+
+positive_decimal
+~~~~~~~~~~~~~~~~
+
+``positive_decimal`` matches decimals greater than ``0``.
+
+This is passed as ``decimal.Decimal`` type to the python program.
+
+negative_decimal
+~~~~~~~~~~~~~~~~
+
+``negative_decimal`` matches decimals less than ``0``.
+
+This is passed as ``decimal.Decimal`` type to the python program.
+
+non_negative_decimal
+~~~~~~~~~~~~~~~~~~~~~
+
+``non_negative_decimal`` matches decimals greater than or equal to ``0``.
+
+This is passed as ``decimal.Decimal`` type to the python program.
+
+non_positive_decimal
+~~~~~~~~~~~~~~~~~~~~~
+
+``non_positive_decimal`` matches decimals less than or equal to ``0``.
+
+This is passed as ``decimal.Decimal`` type to the python program.
+
+non_zero_decimal
+~~~~~~~~~~~~~~~~
+
+``non_zero_decimal`` matches non-zero decimals.
+
+This is passed as ``decimal.Decimal`` type to the python program.

--- a/tests/tests/urls/converters/test_decimal.py
+++ b/tests/tests/urls/converters/test_decimal.py
@@ -1,0 +1,153 @@
+import decimal
+import re
+
+from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
+
+from django_boost.test import TestCase
+from django_boost.urls.converters.decimal import (
+    NegativeDecimalConverter, NonNegativeDecimalConverter,
+    NonPositiveDecimalConverter, NonZeroDecimalConverter,
+    PositiveDecimalConverter, SignedDecimalConverter)
+
+from .base import ConverterTestCase
+
+# (converter, predicate) — predicate(d) is True when str(d) must match the regex.
+CONVERTERS = [
+    (SignedDecimalConverter, lambda d: True),
+    (PositiveDecimalConverter, lambda d: d > 0),
+    (NegativeDecimalConverter, lambda d: d < 0),
+    (NonNegativeDecimalConverter, lambda d: d >= 0),
+    (NonPositiveDecimalConverter, lambda d: d <= 0),
+    (NonZeroDecimalConverter, lambda d: d != 0),
+]
+
+# Canonical decimal literals only (no "-0"-style signed zero — see design doc).
+DOMAIN_VALUES = [
+    '0', '0.0', '0.00', '0.5', '-0.5', '5', '-5', '5.25', '-5.25',
+    '007', '007.00', '-007', '007.5', '-007.5', '10.0', '-10.0', '10',
+]
+
+
+class TestDecimalConversion(TestCase):
+
+    def test_to_python_returns_decimal(self):
+        self.assertEqual(
+            SignedDecimalConverter().to_python('-007.5'),
+            decimal.Decimal('-7.5'))
+        self.assertEqual(
+            PositiveDecimalConverter().to_python('007.5'),
+            decimal.Decimal('7.5'))
+        self.assertEqual(
+            NegativeDecimalConverter().to_python('-5.5'),
+            decimal.Decimal('-5.5'))
+        self.assertEqual(
+            NonNegativeDecimalConverter().to_python('0'), decimal.Decimal('0'))
+        self.assertEqual(
+            NonPositiveDecimalConverter().to_python('-5'), decimal.Decimal('-5'))
+        self.assertEqual(
+            NonZeroDecimalConverter().to_python('-5'), decimal.Decimal('-5'))
+
+    def test_to_url_is_string(self):
+        self.assertEqual(
+            NegativeDecimalConverter().to_url(decimal.Decimal('-5.5')), '-5.5')
+        self.assertEqual(
+            PositiveDecimalConverter().to_url(decimal.Decimal('7.25')), '7.25')
+        self.assertEqual(
+            SignedDecimalConverter().to_url(decimal.Decimal('0')), '0')
+
+
+class TestDecimalRegex(TestCase):
+
+    def test_regex_matches_domain(self):
+        for converter, predicate in CONVERTERS:
+            fullmatch = re.compile(converter.regex).fullmatch
+            for value in DOMAIN_VALUES:
+                with self.subTest(converter=converter.__name__, value=value):
+                    self.assertEqual(
+                        bool(fullmatch(value)),
+                        predicate(decimal.Decimal(value)))
+
+    def test_regex_rejects_leading_plus(self):
+        for converter, _ in CONVERTERS:
+            fullmatch = re.compile(converter.regex).fullmatch
+            with self.subTest(converter=converter.__name__):
+                self.assertIsNone(fullmatch('+5'))
+
+    def test_regex_rejects_trailing_dot(self):
+        for converter, _ in CONVERTERS:
+            fullmatch = re.compile(converter.regex).fullmatch
+            with self.subTest(converter=converter.__name__):
+                self.assertIsNone(fullmatch('5.'))
+
+    def test_regex_leading_zeros(self):
+        cases = [
+            (PositiveDecimalConverter, '007.5', True),
+            (PositiveDecimalConverter, '000.00', False),
+            (NonZeroDecimalConverter, '-007.5', True),
+            (NonZeroDecimalConverter, '-000.00', False),
+            (NonNegativeDecimalConverter, '000.00', True),
+            (NegativeDecimalConverter, '-000.00', False),
+        ]
+        for converter, value, expected in cases:
+            fullmatch = re.compile(converter.regex).fullmatch
+            with self.subTest(converter=converter.__name__, value=value):
+                self.assertEqual(bool(fullmatch(value)), expected)
+
+
+class TestDecimalConverter(ConverterTestCase):
+
+    def test_in_domain_values_route(self):
+        case = [('signed_decimal', '5'), ('signed_decimal', '-5'),
+                ('signed_decimal', '0'), ('signed_decimal', '5.25'),
+                ('positive_decimal', '5'), ('positive_decimal', '0.5'),
+                ('negative_decimal', '-5'), ('negative_decimal', '-0.5'),
+                ('non_negative_decimal', '0'), ('non_negative_decimal', '5.5'),
+                ('non_positive_decimal', '0'), ('non_positive_decimal', '-5.5'),
+                ('non_zero_decimal', '5'), ('non_zero_decimal', '-5'),
+                ('decimal', '5.5'), ('decimal', '0'),
+                ]
+        for name, value in case:
+            with self.subTest(name=name, value=value):
+                url = reverse(name, kwargs={name: value})
+                self.assertStatusCodeEqual(self.client.get(url), 200)
+
+    def test_out_of_domain_values_do_not_reverse(self):
+        case = [('positive_decimal', '0'), ('positive_decimal', '0.00'),
+                ('positive_decimal', '-5'),
+                ('negative_decimal', '0'), ('negative_decimal', '5'),
+                ('non_negative_decimal', '-5'),
+                ('non_positive_decimal', '5'),
+                ('non_zero_decimal', '0'), ('non_zero_decimal', '0.00'),
+                ]
+        for name, value in case:
+            with self.subTest(name=name, value=value):
+                with self.assertRaises(NoReverseMatch):
+                    reverse(name, kwargs={name: value})
+
+    def test_accepts_leading_zeros(self):
+        for url in ['/positive_decimal/007.5', '/signed_decimal/-007.5',
+                    '/non_zero_decimal/-007.5', '/non_negative_decimal/000.5']:
+            with self.subTest(url=url):
+                self.assertStatusCodeEqual(self.client.get(url), 200)
+
+    def test_rejects_leading_zero_only(self):
+        # '000.00' is zero, so it must not match the strictly-nonzero converters.
+        for url in ['/positive_decimal/000.00', '/negative_decimal/-000.00',
+                    '/non_zero_decimal/000.00']:
+            with self.subTest(url=url):
+                self.assertStatusCodeEqual(self.client.get(url), 404)
+
+    def test_reverse_is_canonical(self):
+        self.assertEqual(
+            reverse('signed_decimal',
+                    kwargs={'signed_decimal': decimal.Decimal('-5.5')}),
+            '/signed_decimal/-5.5')
+        self.assertEqual(
+            reverse('positive_decimal',
+                    kwargs={'positive_decimal': decimal.Decimal('7.25')}),
+            '/positive_decimal/7.25')
+        self.assertEqual(
+            reverse('non_positive_decimal',
+                    kwargs={'non_positive_decimal': decimal.Decimal('0')}),
+            '/non_positive_decimal/0')


### PR DESCRIPTION
## Summary
Add `decimal`, `signed_decimal`, `positive_decimal`, `negative_decimal`, `non_negative_decimal`, `non_positive_decimal` and `non_zero_decimal` URL path converters, parsing segments into `decimal.Decimal` — mirroring the existing signed-integer converter family for values the built-in `int`/`float` converters can't express precisely.

## Notes
- `decimal` is a plain alias of `non_negative_decimal`, mirroring how the existing `float` converter is non-negative only.
- Sign/zero classification looks at the whole value (integer and fractional digits together), not just the integer part, so e.g. `0.5` correctly matches `positive_decimal` despite its integer part being `0`.