### PR TITLE
Add float path converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Added
 
 - Decimal path converters `decimal`, `signed_decimal`, `positive_decimal`, `negative_decimal`, `non_negative_decimal`, `non_positive_decimal` and `non_zero_decimal`, covering decimal ranges Django's built-in `float` converter cannot express; `decimal` is an alias of `non_negative_decimal`.
+- Float path converters `signed_float`, `positive_float`, `negative_float`, `non_negative_float`, `non_positive_float` and `non_zero_float`, symmetric with the existing signed-integer and decimal converter families; `float` is now an explicit alias of `non_negative_float` (same regex and behavior as before).
 
 ## [3.2.4] - 2026-07-11
 

--- a/django_boost/urls/converters/__init__.py
+++ b/django_boost/urls/converters/__init__.py
@@ -9,6 +9,10 @@ from django_boost.urls.converters.decimal import (
     NegativeDecimalConverter, NonNegativeDecimalConverter,
     NonPositiveDecimalConverter, NonZeroDecimalConverter,
     PositiveDecimalConverter, SignedDecimalConverter)
+from django_boost.urls.converters.float import (
+    NegativeFloatConverter, NonNegativeFloatConverter,
+    NonPositiveFloatConverter, NonZeroFloatConverter,
+    PositiveFloatConverter, SignedFloatConverter)
 from django_boost.urls.converters.integer import (
     NegativeIntConverter, NonNegativeIntConverter, NonPositiveIntConverter,
     NonZeroIntConverter, PositiveIntConverter, SignedIntConverter)
@@ -89,16 +93,6 @@ class BinStrConverter(BinConverter):
         return value
 
 
-class FloatingPointConverter:
-    regex = '[0-9]+([.][0-9]+)?'
-
-    def to_python(self, value):
-        return float(value)
-
-    def to_url(self, value):
-        return str(value)
-
-
 BOOST_CONVERTERS = {
     'bin': BinIntConverter,
     'oct': OctIntConverter,
@@ -106,7 +100,13 @@ BOOST_CONVERTERS = {
     'bin_str': BinStrConverter,
     'oct_str': OctStrConverter,
     'hex_str': HexStrConverter,
-    'float': FloatingPointConverter,
+    'float': NonNegativeFloatConverter,
+    'signed_float': SignedFloatConverter,
+    'positive_float': PositiveFloatConverter,
+    'negative_float': NegativeFloatConverter,
+    'non_negative_float': NonNegativeFloatConverter,
+    'non_positive_float': NonPositiveFloatConverter,
+    'non_zero_float': NonZeroFloatConverter,
     'date': DateConverter,
     'signed_int': SignedIntConverter,
     'positive_int': PositiveIntConverter,

--- a/django_boost/urls/converters/_numeric.py
+++ b/django_boost/urls/converters/_numeric.py
@@ -22,7 +22,9 @@ class BaseSignedNumericConverter(Generic[_T]):
     """
 
     regex: ClassVar[str]
-    _parse: ClassVar[staticmethod[[str], _T]]
+    # Not ClassVar: PEP 526 disallows a type variable inside ClassVar, and
+    # mypy 1.x enforces it (mypy 2.x currently doesn't, but don't rely on that).
+    _parse: staticmethod[[str], _T]
 
     def to_python(self, value: str) -> _T:
         return self._parse(value)

--- a/django_boost/urls/converters/_numeric.py
+++ b/django_boost/urls/converters/_numeric.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import ClassVar, Generic, TypeVar
+
+_T = TypeVar('_T')
+
+# branch 1: integer part has a non-zero digit (fraction optional)
+# branch 2: integer part is all zeros, but the fraction has a non-zero digit
+POSITIVE = r'(?:[0-9]*[1-9][0-9]*(?:\.[0-9]+)?|0+\.[0-9]*[1-9][0-9]*)'
+# the whole value is zero, e.g. 0, 00, 0.0, 0.00
+ZERO = r'0+(?:\.0+)?'
+
+
+class BaseSignedNumericConverter(Generic[_T]):
+    """Shared behavior for signed decimal-notation numeric path converters.
+
+    Subclasses declare ``regex`` and ``_parse`` (a ``str -> _T`` callable,
+    wrapped in ``staticmethod``). Sign/zero classification looks at the
+    whole value (integer part and fractional part together) rather than
+    the integer part alone, so e.g. ``0.5`` counts as positive even though
+    its integer part is ``0``.
+    """
+
+    regex: ClassVar[str]
+    _parse: ClassVar[staticmethod[[str], _T]]
+
+    def to_python(self, value: str) -> _T:
+        return self._parse(value)
+
+    def to_url(self, value: _T | str) -> str:
+        return str(value)

--- a/django_boost/urls/converters/decimal.py
+++ b/django_boost/urls/converters/decimal.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.urls`` path converters."""
+
 from __future__ import annotations
 
 import decimal

--- a/django_boost/urls/converters/decimal.py
+++ b/django_boost/urls/converters/decimal.py
@@ -3,30 +3,12 @@ from __future__ import annotations
 import decimal
 from typing import ClassVar
 
-# branch 1: integer part has a non-zero digit (fraction optional)
-# branch 2: integer part is all zeros, but the fraction has a non-zero digit
-_POSITIVE = r'(?:[0-9]*[1-9][0-9]*(?:\.[0-9]+)?|0+\.[0-9]*[1-9][0-9]*)'
-# the whole value is zero, e.g. 0, 00, 0.0, 0.00
-_ZERO = r'0+(?:\.0+)?'
+from django_boost.urls.converters._numeric import (
+    BaseSignedNumericConverter, POSITIVE, ZERO)
 
 
-class BaseDecimalConverter:
-    """Shared behavior for the signed-decimal path converters.
-
-    Each subclass only declares ``regex``. Sign/zero classification looks
-    at the whole value (integer part and fractional part together) rather
-    than the integer part alone, so e.g. ``0.5`` counts as positive even
-    though its integer part is ``0``. Parsing and reversing are common:
-    the matched text is always a valid ``decimal.Decimal`` literal.
-    """
-
-    regex: ClassVar[str]
-
-    def to_python(self, value: str) -> decimal.Decimal:
-        return decimal.Decimal(value)
-
-    def to_url(self, value: decimal.Decimal | str) -> str:
-        return str(value)
+class BaseDecimalConverter(BaseSignedNumericConverter[decimal.Decimal]):
+    _parse = staticmethod(decimal.Decimal)
 
 
 class SignedDecimalConverter(BaseDecimalConverter):
@@ -34,11 +16,11 @@ class SignedDecimalConverter(BaseDecimalConverter):
 
 
 class PositiveDecimalConverter(BaseDecimalConverter):
-    regex: ClassVar[str] = _POSITIVE
+    regex: ClassVar[str] = POSITIVE
 
 
 class NegativeDecimalConverter(BaseDecimalConverter):
-    regex: ClassVar[str] = f'-{_POSITIVE}'
+    regex: ClassVar[str] = f'-{POSITIVE}'
 
 
 class NonNegativeDecimalConverter(BaseDecimalConverter):
@@ -46,8 +28,8 @@ class NonNegativeDecimalConverter(BaseDecimalConverter):
 
 
 class NonPositiveDecimalConverter(BaseDecimalConverter):
-    regex: ClassVar[str] = f'{_ZERO}|-{_POSITIVE}'
+    regex: ClassVar[str] = f'{ZERO}|-{POSITIVE}'
 
 
 class NonZeroDecimalConverter(BaseDecimalConverter):
-    regex: ClassVar[str] = f'-?{_POSITIVE}'
+    regex: ClassVar[str] = f'-?{POSITIVE}'

--- a/django_boost/urls/converters/float.py
+++ b/django_boost/urls/converters/float.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.urls`` path converters."""
+
 from __future__ import annotations
 
 from typing import ClassVar

--- a/django_boost/urls/converters/float.py
+++ b/django_boost/urls/converters/float.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+from django_boost.urls.converters._numeric import (
+    BaseSignedNumericConverter, POSITIVE, ZERO)
+
+
+class BaseFloatConverter(BaseSignedNumericConverter[float]):
+    _parse = staticmethod(float)
+
+
+class SignedFloatConverter(BaseFloatConverter):
+    regex: ClassVar[str] = r'-?[0-9]+(?:\.[0-9]+)?'
+
+
+class PositiveFloatConverter(BaseFloatConverter):
+    regex: ClassVar[str] = POSITIVE
+
+
+class NegativeFloatConverter(BaseFloatConverter):
+    regex: ClassVar[str] = f'-{POSITIVE}'
+
+
+class NonNegativeFloatConverter(BaseFloatConverter):
+    regex: ClassVar[str] = r'[0-9]+(?:\.[0-9]+)?'
+
+
+class NonPositiveFloatConverter(BaseFloatConverter):
+    regex: ClassVar[str] = f'{ZERO}|-{POSITIVE}'
+
+
+class NonZeroFloatConverter(BaseFloatConverter):
+    regex: ClassVar[str] = f'-?{POSITIVE}'

--- a/docs/path_converters.rst
+++ b/docs/path_converters.rst
@@ -74,7 +74,7 @@ The difference is that it is passed to the Python program as ``str``
 float
 ~~~~~~~
 
-``float`` match ``'[0-9]+([.][0-9]+)?'``
+``float`` matches ``[0-9]+([.][0-9]+)?`` (alias of ``non_negative_float``).
 
 This is passed as ``float`` type to the python program.
 
@@ -175,3 +175,45 @@ non_zero_decimal
 ``non_zero_decimal`` matches non-zero decimals.
 
 This is passed as ``decimal.Decimal`` type to the python program.
+
+signed_float
+~~~~~~~~~~~~
+
+``signed_float`` matches any decimal-notation float, including negatives.
+
+This is passed as ``float`` type to the python program.
+
+positive_float
+~~~~~~~~~~~~~~
+
+``positive_float`` matches floats greater than ``0``.
+
+This is passed as ``float`` type to the python program.
+
+negative_float
+~~~~~~~~~~~~~~
+
+``negative_float`` matches floats less than ``0``.
+
+This is passed as ``float`` type to the python program.
+
+non_negative_float
+~~~~~~~~~~~~~~~~~~~
+
+``non_negative_float`` matches floats greater than or equal to ``0``.
+
+This is passed as ``float`` type to the python program.
+
+non_positive_float
+~~~~~~~~~~~~~~~~~~~
+
+``non_positive_float`` matches floats less than or equal to ``0``.
+
+This is passed as ``float`` type to the python program.
+
+non_zero_float
+~~~~~~~~~~~~~~
+
+``non_zero_float`` matches non-zero floats.
+
+This is passed as ``float`` type to the python program.

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,13 +37,10 @@ ignore_missing_imports = True
 [mypy-django_boost.*]
 ignore_errors = True
 
-[mypy-django_boost.urls.converters.date]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.urls.converters]
+ignore_errors = True
 
-[mypy-django_boost.urls.converters.integer]
+[mypy-django_boost.urls.converters.*]
 ignore_errors = False
 disallow_untyped_defs = True
 disallow_incomplete_defs = True

--- a/tests/tests/urls/converters/test_float.py
+++ b/tests/tests/urls/converters/test_float.py
@@ -1,0 +1,136 @@
+import re
+
+from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
+
+from django_boost.test import TestCase
+from django_boost.urls.converters.float import (
+    NegativeFloatConverter, NonNegativeFloatConverter,
+    NonPositiveFloatConverter, NonZeroFloatConverter,
+    PositiveFloatConverter, SignedFloatConverter)
+
+from .base import ConverterTestCase
+
+# (converter, predicate) — predicate(f) is True when str(f) must match the regex.
+CONVERTERS = [
+    (SignedFloatConverter, lambda f: True),
+    (PositiveFloatConverter, lambda f: f > 0),
+    (NegativeFloatConverter, lambda f: f < 0),
+    (NonNegativeFloatConverter, lambda f: f >= 0),
+    (NonPositiveFloatConverter, lambda f: f <= 0),
+    (NonZeroFloatConverter, lambda f: f != 0),
+]
+
+# Canonical decimal literals only (no "-0"-style signed zero — see design doc).
+DOMAIN_VALUES = [
+    '0', '0.0', '0.00', '0.5', '-0.5', '5', '-5', '5.25', '-5.25',
+    '007', '007.00', '-007', '007.5', '-007.5', '10.0', '-10.0', '10',
+]
+
+
+class TestFloatConversion(TestCase):
+
+    def test_to_python_returns_float(self):
+        self.assertEqual(SignedFloatConverter().to_python('-007.5'), -7.5)
+        self.assertEqual(PositiveFloatConverter().to_python('007.5'), 7.5)
+        self.assertEqual(NegativeFloatConverter().to_python('-5.5'), -5.5)
+        self.assertEqual(NonNegativeFloatConverter().to_python('0'), 0.0)
+        self.assertEqual(NonPositiveFloatConverter().to_python('-5'), -5.0)
+        self.assertEqual(NonZeroFloatConverter().to_python('-5'), -5.0)
+
+    def test_to_url_is_string(self):
+        self.assertEqual(NegativeFloatConverter().to_url(-5.5), '-5.5')
+        self.assertEqual(PositiveFloatConverter().to_url(7.25), '7.25')
+        self.assertEqual(SignedFloatConverter().to_url(0.0), '0.0')
+
+
+class TestFloatRegex(TestCase):
+
+    def test_regex_matches_domain(self):
+        for converter, predicate in CONVERTERS:
+            fullmatch = re.compile(converter.regex).fullmatch
+            for value in DOMAIN_VALUES:
+                with self.subTest(converter=converter.__name__, value=value):
+                    self.assertEqual(
+                        bool(fullmatch(value)), predicate(float(value)))
+
+    def test_regex_rejects_leading_plus(self):
+        for converter, _ in CONVERTERS:
+            fullmatch = re.compile(converter.regex).fullmatch
+            with self.subTest(converter=converter.__name__):
+                self.assertIsNone(fullmatch('+5'))
+
+    def test_regex_rejects_trailing_dot(self):
+        for converter, _ in CONVERTERS:
+            fullmatch = re.compile(converter.regex).fullmatch
+            with self.subTest(converter=converter.__name__):
+                self.assertIsNone(fullmatch('5.'))
+
+    def test_regex_leading_zeros(self):
+        cases = [
+            (PositiveFloatConverter, '007.5', True),
+            (PositiveFloatConverter, '000.00', False),
+            (NonZeroFloatConverter, '-007.5', True),
+            (NonZeroFloatConverter, '-000.00', False),
+            (NonNegativeFloatConverter, '000.00', True),
+            (NegativeFloatConverter, '-000.00', False),
+        ]
+        for converter, value, expected in cases:
+            fullmatch = re.compile(converter.regex).fullmatch
+            with self.subTest(converter=converter.__name__, value=value):
+                self.assertEqual(bool(fullmatch(value)), expected)
+
+
+class TestFloatConverter(ConverterTestCase):
+
+    def test_in_domain_values_route(self):
+        case = [('signed_float', '5'), ('signed_float', '-5'),
+                ('signed_float', '0'), ('signed_float', '5.25'),
+                ('positive_float', '5'), ('positive_float', '0.5'),
+                ('negative_float', '-5'), ('negative_float', '-0.5'),
+                ('non_negative_float', '0'), ('non_negative_float', '5.5'),
+                ('non_positive_float', '0'), ('non_positive_float', '-5.5'),
+                ('non_zero_float', '5'), ('non_zero_float', '-5'),
+                ('float', '5.5'), ('float', '0'),
+                ]
+        for name, value in case:
+            with self.subTest(name=name, value=value):
+                url = reverse(name, kwargs={name: value})
+                self.assertStatusCodeEqual(self.client.get(url), 200)
+
+    def test_out_of_domain_values_do_not_reverse(self):
+        case = [('positive_float', '0'), ('positive_float', '0.00'),
+                ('positive_float', '-5'),
+                ('negative_float', '0'), ('negative_float', '5'),
+                ('non_negative_float', '-5'),
+                ('non_positive_float', '5'),
+                ('non_zero_float', '0'), ('non_zero_float', '0.00'),
+                ]
+        for name, value in case:
+            with self.subTest(name=name, value=value):
+                with self.assertRaises(NoReverseMatch):
+                    reverse(name, kwargs={name: value})
+
+    def test_accepts_leading_zeros(self):
+        for url in ['/positive_float/007.5', '/signed_float/-007.5',
+                    '/non_zero_float/-007.5', '/non_negative_float/000.5']:
+            with self.subTest(url=url):
+                self.assertStatusCodeEqual(self.client.get(url), 200)
+
+    def test_rejects_leading_zero_only(self):
+        # '000.00' is zero, so it must not match the strictly-nonzero converters.
+        for url in ['/positive_float/000.00', '/negative_float/-000.00',
+                    '/non_zero_float/000.00']:
+            with self.subTest(url=url):
+                self.assertStatusCodeEqual(self.client.get(url), 404)
+
+    def test_reverse_is_canonical(self):
+        self.assertEqual(
+            reverse('signed_float', kwargs={'signed_float': -5.5}),
+            '/signed_float/-5.5')
+        self.assertEqual(
+            reverse('positive_float', kwargs={'positive_float': 7.25}),
+            '/positive_float/7.25')
+        self.assertEqual(
+            reverse('non_positive_float', kwargs={'non_positive_float': 0.0}),
+            '/non_positive_float/0.0')


### PR DESCRIPTION
## Summary
Add `signed_float`, `positive_float`, `negative_float`, `non_negative_float`, `non_positive_float` and `non_zero_float` URL path converters, symmetric with the existing signed-integer and decimal converter families (#407). `float` is now an explicit alias of `non_negative_float` (same regex and behavior as before).

Stacked on #407 — this PR targets `feature/decimal-path-converter` and should be rebased onto `master` once that merges.

## Notes
- Extracted the sign/zero regex logic shared by `decimal.py` and `float.py` into a private `_numeric.py` base, so both converters classify e.g. `0.5` as positive despite a zero integer part, without duplicating the regex derivation.
- Fixed a gap found while building this: `decimal.py` shipped in #407 without ever being registered in `mypy.ini`'s typed-module list, so it had zero real type checking. Replaced the per-module registration pattern with a package-wide wildcard so future converter submodules are covered automatically.