### PR TITLE
Enable flake8 D106 for nested Meta classes

### DIFF
--- a/django_boost/forms/__init__.py
+++ b/django_boost/forms/__init__.py
@@ -30,6 +30,8 @@ class UserCreationForm(BaseUserCreationForm):
     """A form that creates a user, with no privileges, from the active user model's ``USERNAME_FIELD`` and password."""
 
     class Meta(BaseUserCreationForm.Meta):
+        """Use the active user model and its ``USERNAME_FIELD`` instead of Django's hardcoded ``username``."""
+
         model = get_user_model()
         fields = (model.USERNAME_FIELD,)
         field_classes = {
@@ -41,6 +43,8 @@ class UserChangeForm(BaseUserChangeForm):
     """A form for changing an existing user, using the active user model's ``USERNAME_FIELD``."""
 
     class Meta(BaseUserChangeForm.Meta):
+        """Use the active user model and its ``USERNAME_FIELD`` instead of Django's hardcoded ``username``."""
+
         model = get_user_model()
         fields = "__all__"
         field_classes = {

--- a/django_boost/models/__init__.py
+++ b/django_boost/models/__init__.py
@@ -30,12 +30,12 @@ class AbstractEmailUser(AbstractUser):
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = ['username']
 
-    class Meta(AbstractUser.Meta):
+    class Meta(AbstractUser.Meta):  # noqa: D106
         abstract = True
 
 
 class EmailUser(AbstractEmailUser):
     """Email login user model."""
 
-    class Meta(AbstractEmailUser.Meta):
+    class Meta(AbstractEmailUser.Meta):  # noqa: D106
         swappable = 'AUTH_USER_MODEL'

--- a/django_boost/models/mixins.py
+++ b/django_boost/models/mixins.py
@@ -30,7 +30,7 @@ class JsonMixin:
 class UUIDModelMixin(models.Model):
     """replace `id` from` AutoField` to `UUIDField`."""
 
-    class Meta:
+    class Meta:  # noqa: D106
         abstract = True
     id = models.UUIDField(default=uuid.uuid4,
                           primary_key=True, unique=True, editable=False)
@@ -39,7 +39,7 @@ class UUIDModelMixin(models.Model):
 class TimeStampModelMixin(models.Model):
     """The fields `created_at` and `updated_at` are added."""
 
-    class Meta:
+    class Meta:  # noqa: D106
         abstract = True
     created_at = models.DateTimeField(verbose_name=_("created date"), auto_now_add=True)
     updated_at = models.DateTimeField(verbose_name=_("updated date"), auto_now=True)
@@ -51,7 +51,7 @@ class LogicalDeletionMixin(models.Model):
     deleted_at = models.DateTimeField(
         verbose_name=_("deleted date"), blank=True, null=True, default=None, editable=False)
 
-    class Meta:
+    class Meta:  # noqa: D106
         abstract = True
 
     objects = LogicalDeletionManager()

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 commands = flake8 .
 
 [flake8]
-ignore = D100,D101,D102,D103,D105,D106
+ignore = D100,D101,D102,D103,D105
 exclude = 
     .git,
     .tox,


### PR DESCRIPTION
## Summary
Stacked on #406. Enable flake8's `D106` (missing docstring in public nested class) check, previously disabled via `tox.ini`'s `ignore` list.

## Notes
All 7 violations are Django's standard `class Meta:` idiom. 5 are plain `abstract = True` / `swappable = 'AUTH_USER_MODEL'` boilerplate that any Django developer already recognizes, so they're suppressed with `# noqa: D106` rather than given a restating docstring. The other 2 (`UserCreationForm.Meta`, `UserChangeForm.Meta`) do something non-obvious — they use the active user model's `USERNAME_FIELD` instead of Django's hardcoded `username` — so those get a real docstring explaining it.