### PR TITLE
Enable flake8 D105 for magic methods

### DIFF
--- a/django_boost/models/fields/related_descriptors.py
+++ b/django_boost/models/fields/related_descriptors.py
@@ -14,6 +14,7 @@ class AutoReverseOneToOneDescriptor(ReverseOneToOneDescriptor):
 
     @atomic
     def __get__(self, instance, cls=None):
+        """Get the related object, creating it via ``get_or_create`` if it doesn't exist yet."""
         model = getattr(self.related, 'related_model', self.related.model)
         try:
             return super().__get__(instance, cls)

--- a/django_boost/template/base.py
+++ b/django_boost/template/base.py
@@ -34,5 +34,5 @@ class StrictInvalidTemplateVariable(str):
         obj.exception_class = exception_class
         return obj
 
-    def __mod__(self, missing):
+    def __mod__(self, missing):  # noqa: D105
         raise self.exception_class(self.message.format(name=missing))

--- a/django_boost/utils/__init__.py
+++ b/django_boost/utils/__init__.py
@@ -26,10 +26,11 @@ class Loop(Iterator[tuple["Loop[_T]", _T]]):
         self.iterable = enumerate(iterable)
         self.length = len(iterable)
 
-    def __iter__(self) -> Loop[_T]:
+    def __iter__(self) -> Loop[_T]:  # noqa: D105
         return self
 
     def __next__(self) -> tuple[Loop[_T], _T]:
+        """Advance one item and return ``(self, item)`` for ``for forloop, item in loop(...)``."""
         i, item = next(self.iterable)
         # Shortcuts for current loop iteration number.
         self.counter0 = i

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 commands = flake8 .
 
 [flake8]
-ignore = D100,D101,D102,D103,D105
+ignore = D100,D101,D102,D103
 exclude = 
     .git,
     .tox,


### PR DESCRIPTION
## Summary
Stacked on #412. Enable flake8's `D105` (missing docstring in magic method) check, previously disabled via `tox.ini`'s `ignore` list.

## Notes
2 of the 4 violations get a real docstring: `AutoReverseOneToOneDescriptor.__get__` (its `get_or_create` fallback isn't obvious from the class docstring alone) and `Loop.__next__` (returns the non-standard `(self, item)` shape that the `for forloop, item in loop(...)` usage relies on). The other 2 — `Loop.__iter__` (`return self`, the standard iterator idiom) and `StrictInvalidTemplateVariable.__mod__` (already fully explained by its class docstring) — are suppressed with `# noqa: D105` rather than given a restating docstring.