### PR TITLE
:bookmark: Release 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+## [3.2.2] - 2026-07-06
+
 ### Fixed
 
 - `RelatedModelInlineMixin.save(commit=False)` no longer writes to the database; its inline related objects are now persisted by `save_m2m()`, following Django's `ModelForm` contract.

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from django_boost.utils.version import get_version
 
-VERSION = (3, 2, 1, 'final', 0)
+VERSION = (3, 2, 2, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
## Summary
- Bump version to 3.2.2 and move the Unreleased changelog entries under it.