### PR TITLE
:bookmark: Release 3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+## [3.2.3] - 2026-07-07
+
 ### Fixed
 
 - `deletemigrations` now deletes only the top-level migration modules, no longer descending into subpackages under `migrations/` and removing unrelated `.py` files.

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django_boost.utils.version import get_version
 
-VERSION = (3, 2, 2, 'final', 0)
+VERSION = (3, 2, 3, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
## Summary
- Bump version to 3.2.3 and move the Unreleased changelog entries under it.