### PR TITLE
Enable flake8 D103 for public functions

### DIFF
--- a/django_boost/admin/actions.py
+++ b/django_boost/admin/actions.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext as _, gettext_lazy
 
 
 def hard_delete_selected(modeladmin, request, queryset):
-
+    """Admin action that physically deletes the selection, bypassing logical deletion."""
     opts = modeladmin.model._meta
     app_label = opts.app_label
 

--- a/django_boost/checks.py
+++ b/django_boost/checks.py
@@ -90,6 +90,7 @@ def _get_models(app_configs):
 
 
 def check_database_router(app_configs, **kwargs):
+    """Validate ``DATABASE_APPS_MAPPING`` when django_boost's router is enabled."""
     errors = []
     if not _setting_contains("DATABASE_ROUTERS", DATABASE_ROUTER):
         return errors
@@ -145,6 +146,7 @@ def check_database_router(app_configs, **kwargs):
 
 
 def check_redirect_correct_hostname_middleware(app_configs, **kwargs):
+    """Validate ``CORRECT_HOST`` when ``RedirectCorrectHostnameMiddleware`` is enabled."""
     errors = []
     if not _setting_contains("MIDDLEWARE", REDIRECT_CORRECT_HOSTNAME_MIDDLEWARE):
         return errors
@@ -186,6 +188,7 @@ def check_redirect_correct_hostname_middleware(app_configs, **kwargs):
 
 
 def check_user_agent_extra(app_configs, **kwargs):
+    """Require the optional ``user-agents`` package when the ``user_agent`` context processor is configured."""
     if not _templates_use_user_agent_context_processor() or _user_agents_available():
         return []
 
@@ -250,6 +253,7 @@ def _check_logical_deletion_model(model):
 
 
 def check_logical_deletion_models(app_configs, **kwargs):
+    """Validate every model using ``LogicalDeletionMixin`` across the project."""
     errors = []
     for model in _get_models(app_configs):
         errors.extend(_check_logical_deletion_model(model))
@@ -257,6 +261,7 @@ def check_logical_deletion_models(app_configs, **kwargs):
 
 
 def check_admin_tools_requires_admin(app_configs, **kwargs):
+    """Require ``django.contrib.admin`` when an admin_tools app is installed."""
     admin_tools_installed = apps.is_installed(ADMIN_TOOLS_APP) or apps.is_installed(LEGACY_ADMIN_TOOLS_APP)
     if not admin_tools_installed or apps.is_installed(DJANGO_ADMIN_APP):
         return []
@@ -272,6 +277,7 @@ def check_admin_tools_requires_admin(app_configs, **kwargs):
 
 
 def check_emailuser_deprecated(app_configs, **kwargs):
+    """Warn when ``AUTH_USER_MODEL`` still points at the deprecated built-in ``EmailUser``."""
     if getattr(settings, "AUTH_USER_MODEL", None) != EMAILUSER_MODEL:
         return []
 

--- a/django_boost/context_processors.py
+++ b/django_boost/context_processors.py
@@ -6,6 +6,7 @@ from django_boost.user_agents import parse_user_agent
 
 
 def user_agent(request):
+    """Add parsed user-agent details (browser, device, OS, bot/mobile/tablet flags) to the template context."""
     agent = request.META.get('HTTP_USER_AGENT', '')
     user_agent = parse_user_agent(agent)
     context = {'user_agent': agent,

--- a/django_boost/core/__init__.py
+++ b/django_boost/core/__init__.py
@@ -6,6 +6,7 @@ from django_boost import __version__ as VERSION
 
 
 def get_version() -> str:
+    """Return django_boost's version string (``django_boost.__version__``)."""
     return VERSION
 
 
@@ -17,4 +18,5 @@ EMPTY = Empty()
 
 
 def is_empty(obj: object) -> bool:
+    """Return `True` if `obj` is the `EMPTY` sentinel, `False` otherwise."""
     return isinstance(obj, Empty)

--- a/django_boost/models/deletion.py
+++ b/django_boost/models/deletion.py
@@ -11,6 +11,7 @@ from django.db.models.deletion import Collector
 
 
 def get_logical_delete_field(model):
+    """Return ``model``'s logical-deletion flag field, or ``None`` if it doesn't use logical deletion."""
     if not hasattr(model, 'get_deleted_value'):
         return None
 

--- a/django_boost/templatetags/boost.py
+++ b/django_boost/templatetags/boost.py
@@ -274,4 +274,5 @@ register.simple_tag(literal_eval, name="literal")
 
 @register.simple_tag(name="var")
 def var(value):
+    """Return ``value`` unchanged, for assigning an expression to a template variable via ``as``."""
     return value

--- a/django_boost/templatetags/boost_query.py
+++ b/django_boost/templatetags/boost_query.py
@@ -9,23 +9,26 @@ register = template.Library()
 
 @register.filter
 def filter(queryset, arg):
+    """Filter ``queryset`` by a single ``"field=value"`` argument."""
     k, v = arg.split("=", 1)
     return queryset.filter(**{k: v})
 
 
 @register.filter
-def order_by(queryset, arg):
+def order_by(queryset, arg):  # noqa: D103
     return queryset.order_by(arg)
 
 
 @register.filter
 def exclude(queryset, arg):
+    """Exclude from ``queryset`` by a single ``"field=value"`` argument."""
     k, v = arg.split("=", 1)
     return queryset.exclude(**{k: v})
 
 
 @register.filter
 def dead(queryset):
+    """Return the queryset's dead items via its ``dead`` manager method, if available, else unchanged."""
     if hasattr(queryset, 'dead') and callable(queryset.dead):
         return queryset.dead()
     return queryset
@@ -33,6 +36,7 @@ def dead(queryset):
 
 @register.filter
 def alive(queryset):
+    """Return the queryset's alive items via its ``alive`` manager method, if available, else unchanged."""
     if hasattr(queryset, 'alive') and callable(queryset.alive):
         return queryset.alive()
     return queryset

--- a/django_boost/templatetags/boost_url.py
+++ b/django_boost/templatetags/boost_url.py
@@ -16,17 +16,19 @@ register = Library()
 @register.filter(name="urlencode", is_safe=True)
 @stringfilter
 def urlencode(value, arg="/"):
+    """URL-encode ``value``, passing ``arg`` as the characters to leave unescaped."""
     return parse.quote(value, safe=arg)
 
 
 @register.filter(name="urldecode")
 @stringfilter
-def urldecode(value):
+def urldecode(value):  # noqa: D103
     return parse.unquote(value)
 
 
 @register.simple_tag
 def replace_parameters(request, *args):
+    """Return the current query string with the given ``key, value, ...`` pairs replaced."""
     arg_len = len(args)
     if arg_len % 2 != 0:
         raise LookupError(
@@ -38,5 +40,5 @@ def replace_parameters(request, *args):
 
 
 @register.simple_tag
-def get_querystring(request, value):
+def get_querystring(request, value):  # noqa: D103
     return request.GET.get(value, None)

--- a/django_boost/templatetags/mimetype.py
+++ b/django_boost/templatetags/mimetype.py
@@ -11,6 +11,7 @@ register = Library()
 
 @register.filter(name="mimetype")
 def mimetype(value):
+    """Guess a MIME type from a bare extension, a leading-dot extension, or a full filename."""
     if "." not in value:
         value = "." + value
     if value.startswith("."):

--- a/django_boost/urls/converters/__init__.py
+++ b/django_boost/urls/converters/__init__.py
@@ -114,5 +114,6 @@ BOOST_CONVERTERS = {
 
 
 def register_boost_converters():
+    """Register all of django_boost's URL converters (``BOOST_CONVERTERS``) with Django."""
     for name, klass in BOOST_CONVERTERS.items():
         register_converter(klass, name)

--- a/django_boost/urls/static.py
+++ b/django_boost/urls/static.py
@@ -29,6 +29,7 @@ class StaticFileConnector:
 
 
 def load_static_files(path):
+    """Return the ``urls.path()`` entries built by ``StaticFileConnector`` for every file under ``path``."""
     return StaticFileConnector(path).urls
 
 

--- a/django_boost/user_agents.py
+++ b/django_boost/user_agents.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 
 def parse_user_agent(agent):
+    """Parse a User-Agent string, raising ``ImproperlyConfigured`` if the ``user-agents`` extra isn't installed."""
     try:
         from user_agents import parse
     except ImportError as exc:

--- a/django_boost/utils/functions/json.py
+++ b/django_boost/utils/functions/json.py
@@ -31,6 +31,7 @@ def model_to_json(model, fields=(), exclude=()):
 
 
 def json_to_model(model_class, dic, fields=(), exclude=()):
+    """Build an unsaved ``model_class`` instance from a dict shaped like ``model_to_json``'s output."""
     model = model_class()
     for f in model._meta.fields:
         if fields and f.name not in fields:

--- a/django_boost/utils/html.py
+++ b/django_boost/utils/html.py
@@ -129,10 +129,12 @@ class HTMLSpaceLessCompressor(HTMLParser):
 
 
 def strip_spaces_between_tags(value: str) -> str:
+    """Remove ignorable whitespace between HTML tags in a single, already-complete string."""
     return HTMLSpaceLessCompressor().compress(value)
 
 
 def compress_stream(chunks: Iterable[bytes], charset: str) -> Iterator[bytes]:
+    """Remove ignorable whitespace between HTML tags across a chunked byte stream."""
     compressor = HTMLSpaceLessCompressor()
     decoder = codecs.getincrementaldecoder(charset)()
     for chunk in chunks:
@@ -147,6 +149,7 @@ def compress_stream(chunks: Iterable[bytes], charset: str) -> Iterator[bytes]:
 
 
 async def acompress_stream(chunks: AsyncIterable[bytes], charset: str) -> AsyncIterator[bytes]:
+    """Async counterpart to ``compress_stream``, for an async byte-chunk source."""
     compressor = HTMLSpaceLessCompressor()
     decoder = codecs.getincrementaldecoder(charset)()
     async for chunk in chunks:

--- a/django_boost/utils/version.py
+++ b/django_boost/utils/version.py
@@ -49,6 +49,7 @@ def get_complete_version(version: _Version | None = None) -> _Version:
 
 
 def get_docs_version(version: _Version | None = None) -> str:
+    """Return the X.Y version used to pick a Read the Docs version, or ``'dev'`` for a pre-release."""
     version = get_complete_version(version)
     if version[3] != 'final':
         return 'dev'

--- a/django_boost/validators/color.py
+++ b/django_boost/validators/color.py
@@ -18,5 +18,5 @@ class ColorCodeValidator(RegexValidator):
 color_code_validator = ColorCodeValidator()
 
 
-def validate_color_code(value: str) -> None:
+def validate_color_code(value: str) -> None:  # noqa: D103
     return color_code_validator(value)

--- a/django_boost/validators/integer.py
+++ b/django_boost/validators/integer.py
@@ -35,5 +35,5 @@ class NonZeroValidator(BaseValidator):
 non_zero_validator = NonZeroValidator()
 
 
-def validate_non_zero(value: Any) -> None:
+def validate_non_zero(value: Any) -> None:  # noqa: D103
     return non_zero_validator(value)

--- a/django_boost/validators/json.py
+++ b/django_boost/validators/json.py
@@ -33,5 +33,5 @@ class JsonValidator(BaseValidator):
 json_validator = JsonValidator()
 
 
-def validate_json(value: str) -> None:
+def validate_json(value: str) -> None:  # noqa: D103
     return json_validator(value)

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 commands = flake8 .
 
 [flake8]
-ignore = D100,D101,D102,D103
+ignore = D100,D101,D102
 exclude = 
     .git,
     .tox,


### PR DESCRIPTION
## Summary
Enable flake8's `D103` (missing docstring in public function) check, previously disabled via `tox.ini`'s `ignore` list. 33 violations, split into one commit per module group for review:

- System checks (`checks.py`)
- Template tags/filters (`templatetags/`)
- HTML compression helpers (`utils/html.py`)
- Admin action and user-agent helpers
- Core and version helpers
- Models/urls/json individual utilities
- Validator convenience delegates (suppressed, see Notes)

## Notes
6 of the 33 are suppressed with `# noqa: D103` instead of given a docstring, where the function is a direct one-line delegate to a well-known API with no argument transformation (`order_by`, `urldecode`, `get_querystring`) or to an already-documented validator instance (`validate_color_code`, `validate_non_zero`, `validate_json`) — a docstring there would only restate the code.