### PR TITLE
:memo: Improve TypeError message in model_to_json to show actual typename

### DIFF
--- a/django_boost/utils/functions/json.py
+++ b/django_boost/utils/functions/json.py
@@ -28,8 +28,10 @@ def model_to_json(model, fields=(), exclude=()):
         json_data = [model_to_json(m, fields, exclude) for m in model]
         return json_data
 
-    raise TypeError('argument must be {} or {}'.format(
-        models.Model, models.QuerySet))
+    raise TypeError(
+        'model_to_json() argument must be a Model or QuerySet, not %s'
+        % type(model).__name__
+    )
 
 
 def json_to_model(model_class, dic, fields=(), exclude=()):

--- a/tests/tests/utils/functions/test_json.py
+++ b/tests/tests/utils/functions/test_json.py
@@ -21,6 +21,13 @@ class ModelToJsonTests(TestCase):
         self.assertIsInstance(result, list)
         self.assertEqual([d["name"] for d in result], ["a", "b"])
 
+    def test_invalid_argument_raises_type_error(self):
+        with self.assertRaisesMessage(
+            TypeError,
+            "model_to_json() argument must be a Model or QuerySet, not str",
+        ):
+            model_to_json("not-a-model")
+
 
 class JsonToModelTests(TestCase):
 


### PR DESCRIPTION
When model_to_json() is called with an invalid argument type, the error message now shows the class name (e.g. 'str') instead of the opaque class object representation, making debugging easier.

Before: argument must be <class 'django.db.models.Model'> or <class 'django.db.models.query.QuerySet'>
After:  model_to_json() argument must be a Model or QuerySet, not str

Checklist - While not every PR needs it, new features should consider this list:  

- [ ] Does this have tests?  
- [ ] Does this have documentation?  
- [ ] Does this break the public API (Requires major version bump)?  
- [ ] Is this a new feature (Requires minor version bump)?  
