### PR TITLE
Enable flake8 D100 for public modules

### DIFF
--- a/django_boost/admin/actions.py
+++ b/django_boost/admin/actions.py
@@ -1,3 +1,5 @@
+"""Admin actions for Django's ``django.contrib.admin``."""
+
 from __future__ import annotations
 
 from django.contrib import messages

--- a/django_boost/admin/filters.py
+++ b/django_boost/admin/filters.py
@@ -1,3 +1,5 @@
+"""Admin list filters for Django's ``django.contrib.admin``."""
+
 from __future__ import annotations
 
 from django.contrib import admin

--- a/django_boost/admin/mixins.py
+++ b/django_boost/admin/mixins.py
@@ -1,3 +1,5 @@
+"""Admin mixins for Django's ``django.contrib.admin``."""
+
 from __future__ import annotations
 
 from .actions import hard_delete_selected

--- a/django_boost/admin/sites.py
+++ b/django_boost/admin/sites.py
@@ -1,3 +1,5 @@
+"""Admin site helpers for Django's ``django.contrib.admin``."""
+
 from __future__ import annotations
 
 from inspect import getmembers, isclass

--- a/django_boost/admin_tools/apps.py
+++ b/django_boost/admin_tools/apps.py
@@ -1,3 +1,5 @@
+"""App config for the deprecated ``django_boost.admin_tools`` app."""
+
 from __future__ import annotations
 
 import warnings

--- a/django_boost/admin_tools/management/commands/listsuperuser.py
+++ b/django_boost/admin_tools/management/commands/listsuperuser.py
@@ -1,3 +1,5 @@
+"""Deprecated ``django_boost`` alias for ``contrib.admin_tools``'s ``listsuperuser`` command."""
+
 from __future__ import annotations
 
 from django_boost.contrib.admin_tools.management.commands.listsuperuser import (

--- a/django_boost/contrib/admin_tools/apps.py
+++ b/django_boost/contrib/admin_tools/apps.py
@@ -1,3 +1,5 @@
+"""App config for the ``django_boost.contrib.admin_tools`` app."""
+
 from __future__ import annotations
 
 from django.apps import AppConfig

--- a/django_boost/contrib/admin_tools/management/commands/adminsitelog.py
+++ b/django_boost/contrib/admin_tools/management/commands/adminsitelog.py
@@ -1,3 +1,5 @@
+"""The ``adminsitelog`` management command."""
+
 from __future__ import annotations
 
 from django.core.exceptions import FieldError

--- a/django_boost/contrib/admin_tools/management/commands/listsuperuser.py
+++ b/django_boost/contrib/admin_tools/management/commands/listsuperuser.py
@@ -1,3 +1,5 @@
+"""The ``listsuperuser`` management command."""
+
 from __future__ import annotations
 
 from django.contrib.auth import get_user_model

--- a/django_boost/core/management.py
+++ b/django_boost/core/management.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.core.management``."""
+
 from __future__ import annotations
 
 from django.core.management import base

--- a/django_boost/db/router.py
+++ b/django_boost/db/router.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.db`` routing."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/django_boost/forms/fields.py
+++ b/django_boost/forms/fields.py
@@ -1,3 +1,5 @@
+"""Custom form fields for Django's ``django.forms``."""
+
 from __future__ import annotations
 
 from django.forms import BooleanField, CharField

--- a/django_boost/forms/mixins.py
+++ b/django_boost/forms/mixins.py
@@ -1,3 +1,5 @@
+"""Form mixins for Django's ``django.forms``."""
+
 from __future__ import annotations
 
 from django.core.exceptions import (ImproperlyConfigured,

--- a/django_boost/forms/widgets.py
+++ b/django_boost/forms/widgets.py
@@ -1,3 +1,5 @@
+"""Custom form widgets for Django's ``django.forms``."""
+
 from __future__ import annotations
 
 from django.forms.widgets import CheckboxInput, Input, RadioSelect

--- a/django_boost/http/response.py
+++ b/django_boost/http/response.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.http``."""
+
 from __future__ import annotations
 
 from django.http import (HttpResponse, HttpResponseBadRequest,

--- a/django_boost/management/commands/adminsitelog.py
+++ b/django_boost/management/commands/adminsitelog.py
@@ -1,3 +1,5 @@
+"""Deprecated ``django_boost`` alias for ``contrib.admin_tools``'s ``adminsitelog`` command."""
+
 from __future__ import annotations
 
 import warnings

--- a/django_boost/management/commands/deletemigrations.py
+++ b/django_boost/management/commands/deletemigrations.py
@@ -1,3 +1,5 @@
+"""The ``deletemigrations`` management command."""
+
 from __future__ import annotations
 
 import os

--- a/django_boost/management/commands/migrate_emailuser.py
+++ b/django_boost/management/commands/migrate_emailuser.py
@@ -1,3 +1,5 @@
+"""The ``migrate_emailuser`` management command."""
+
 from __future__ import annotations
 
 from django.apps import apps

--- a/django_boost/management/commands/startapp_plus.py
+++ b/django_boost/management/commands/startapp_plus.py
@@ -1,3 +1,5 @@
+"""The ``startapp_plus`` management command."""
+
 from __future__ import annotations
 
 from django_boost.management.templates import TemplateCommand

--- a/django_boost/management/mixins.py
+++ b/django_boost/management/mixins.py
@@ -1,3 +1,5 @@
+"""Mixins for django_boost's own management commands."""
+
 from __future__ import annotations
 
 import csv

--- a/django_boost/management/templates.py
+++ b/django_boost/management/templates.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.core.management.templates``."""
+
 from __future__ import annotations
 
 import os

--- a/django_boost/middleware/html.py
+++ b/django_boost/middleware/html.py
@@ -1,3 +1,5 @@
+"""The ``SpaceLessMiddleware`` HTML-whitespace-compressing middleware."""
+
 from __future__ import annotations
 
 from collections.abc import AsyncIterable, Iterable

--- a/django_boost/models/deletion.py
+++ b/django_boost/models/deletion.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.db.models.deletion``."""
+
 from __future__ import annotations
 
 from collections import Counter

--- a/django_boost/models/fields/related_descriptors.py
+++ b/django_boost/models/fields/related_descriptors.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.db.models.fields.related_descriptors``."""
+
 from __future__ import annotations
 
 from django.db.models.fields.related_descriptors import (

--- a/django_boost/models/manager.py
+++ b/django_boost/models/manager.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.db.models.manager``."""
+
 from __future__ import annotations
 
 from django.db.models.manager import Manager

--- a/django_boost/models/mixins.py
+++ b/django_boost/models/mixins.py
@@ -1,3 +1,5 @@
+"""Model mixins for Django's ``django.db.models``."""
+
 from __future__ import annotations
 
 import uuid

--- a/django_boost/models/query.py
+++ b/django_boost/models/query.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.db.models.query``."""
+
 from __future__ import annotations
 
 import django

--- a/django_boost/template/base.py
+++ b/django_boost/template/base.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.template``."""
+
 from __future__ import annotations
 
 

--- a/django_boost/test/testcase.py
+++ b/django_boost/test/testcase.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.test``."""
+
 from __future__ import annotations
 
 from collections.abc import Iterable

--- a/django_boost/urls/converters/date.py
+++ b/django_boost/urls/converters/date.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.urls`` path converters."""
+
 from __future__ import annotations
 
 from datetime import datetime

--- a/django_boost/urls/converters/integer.py
+++ b/django_boost/urls/converters/integer.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.urls`` path converters."""
+
 from __future__ import annotations
 
 from typing import ClassVar

--- a/django_boost/urls/static.py
+++ b/django_boost/urls/static.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.urls``."""
+
 from __future__ import annotations
 
 import os

--- a/django_boost/utils/attribute.py
+++ b/django_boost/utils/attribute.py
@@ -1,3 +1,5 @@
+"""General-purpose attribute-access helpers."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/django_boost/utils/functions/json.py
+++ b/django_boost/utils/functions/json.py
@@ -1,3 +1,5 @@
+"""Model/JSON conversion helpers."""
+
 from __future__ import annotations
 
 from django.db import models

--- a/django_boost/utils/functions/loop.py
+++ b/django_boost/utils/functions/loop.py
@@ -1,3 +1,5 @@
+"""Loop-position predicate helpers."""
+
 from __future__ import annotations
 
 from collections.abc import Collection, Iterable, Iterator

--- a/django_boost/utils/html.py
+++ b/django_boost/utils/html.py
@@ -1,3 +1,5 @@
+"""HTML whitespace-compression helpers."""
+
 from __future__ import annotations
 
 import codecs

--- a/django_boost/utils/itertools.py
+++ b/django_boost/utils/itertools.py
@@ -1,3 +1,5 @@
+"""Extensions for Python's ``itertools``."""
+
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator

--- a/django_boost/utils/version.py
+++ b/django_boost/utils/version.py
@@ -1,3 +1,5 @@
+"""Mirrors Django's own ``django.utils.version`` for django_boost's ``VERSION``."""
+
 from __future__ import annotations
 
 from typing import TypeAlias

--- a/django_boost/validators/collection.py
+++ b/django_boost/validators/collection.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.core.validators``."""
+
 from __future__ import annotations
 
 from collections.abc import Iterable

--- a/django_boost/validators/color.py
+++ b/django_boost/validators/color.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.core.validators``."""
+
 from __future__ import annotations
 
 from django.core.validators import RegexValidator

--- a/django_boost/validators/integer.py
+++ b/django_boost/validators/integer.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.core.validators``."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/django_boost/validators/json.py
+++ b/django_boost/validators/json.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.core.validators``."""
+
 from __future__ import annotations
 
 import json

--- a/django_boost/validators/uuid.py
+++ b/django_boost/validators/uuid.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.core.validators``."""
+
 from __future__ import annotations
 
 import uuid

--- a/django_boost/views/base.py
+++ b/django_boost/views/base.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.views.generic``."""
+
 from __future__ import annotations
 
 import mimetypes

--- a/django_boost/views/generic.py
+++ b/django_boost/views/generic.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.views.generic``."""
+
 from __future__ import annotations
 
 import warnings

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -1,3 +1,5 @@
+"""View mixins for Django's ``django.views``."""
+
 from __future__ import annotations
 
 import json

--- a/django_boost/views/simple.py
+++ b/django_boost/views/simple.py
@@ -1,3 +1,5 @@
+"""Extensions for Django's ``django.views.generic``."""
+
 from __future__ import annotations
 
 from django.http import HttpResponse

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 commands = flake8 .
 
 [flake8]
-ignore = D100,D101,D102
+ignore = D101,D102
 exclude = 
     .git,
     .tox,


### PR DESCRIPTION
## Summary
Stacked on #417. Enable flake8's `D100` (missing docstring in public module) check, previously disabled via `tox.ini`'s `ignore` list. 47 violations (of the raw 50; 3 are auto-generated migration files already excluded from linting) split into one commit per directory group.

## Notes
Each module docstring states its role/relationship to the corresponding Django module (e.g. "Extensions for Django's ``django.forms``") rather than enumerating its contents, so it doesn't need updating every time a class or function is added or removed — same rationale as the earlier D104 package-docstring rollout.