### PR TITLE
:bug: Harden the mimetype template filter for odd input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Fixed
 
 - Comparing two `JsonValidator` (or two `NonZeroValidator`) instances no longer raises `AttributeError`.
+- The `mimetype` template filter now returns an empty string for an unknown extension (instead of the literal `None`) and accepts a non-string value instead of raising `TypeError`.
 
 ## [3.2.4] - 2026-07-11
 

--- a/django_boost/templatetags/mimetype.py
+++ b/django_boost/templatetags/mimetype.py
@@ -5,15 +5,17 @@ from __future__ import annotations
 from mimetypes import guess_type
 
 from django.template import Library
+from django.template.defaultfilters import stringfilter
 
 register = Library()
 
 
 @register.filter(name="mimetype")
+@stringfilter
 def mimetype(value):
     """Guess a MIME type from a bare extension, a leading-dot extension, or a full filename."""
     if "." not in value:
         value = "." + value
     if value.startswith("."):
         value = "s" + value
-    return guess_type(value)[0]
+    return guess_type(value)[0] or ''

--- a/tests/tests/templatetags/test_mimetype.py
+++ b/tests/tests/templatetags/test_mimetype.py
@@ -15,3 +15,15 @@ class TestMimetypeTemplateTag(TestCase):
         ]
         for t, c in case:
             self.assertEqual(t, mimetype(c))
+
+    def test_mimetype_unknown_extension_returns_empty_string(self):
+        from django_boost.templatetags.mimetype import mimetype
+        self.assertEqual(mimetype('file.unknownext'), '')
+        self.assertEqual(mimetype('unknownext'), '')
+
+    def test_mimetype_coerces_non_string_input(self):
+        # str(123) == '123' happens to match a registered extension, so
+        # only the return type (not a specific value) is asserted here.
+        from django_boost.templatetags.mimetype import mimetype
+        self.assertEqual(mimetype(None), '')
+        self.assertIsInstance(mimetype(123), str)


### PR DESCRIPTION
## Summary

The `mimetype` template filter returned `None` for an unknown extension (rendered as the literal `None` in a template) and raised `TypeError` on a non-string value (e.g. an int or `None`) in its `"." not in value` check, breaking rendering of the whole template. Apply `@stringfilter` to coerce the input like Django's built-in filters, and fall back to `''` when `guess_type` finds no type.
