### PR TITLE
:bug: Serve 404 from StaticView when the file is missing at request time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `StaticView` now responds with a 404 instead of a 500 when its file is missing at request time (e.g. removed or rotated after the route was registered), matching Django's own static view.
+
 ## [3.2.3] - 2026-07-07
 
 ### Fixed

--- a/django_boost/views/base.py
+++ b/django_boost/views/base.py
@@ -6,7 +6,7 @@ import warnings
 from functools import update_wrapper
 
 from django.core.exceptions import ImproperlyConfigured
-from django.http import FileResponse
+from django.http import FileResponse, Http404
 from django.utils.decorators import classonlymethod
 from django.views import View as _View
 from django.views.generic import CreateView as _CreateView
@@ -115,4 +115,9 @@ class StaticResponseMixin:
 class StaticView(StaticResponseMixin, _View):
 
     def get(self, request, *args, **kwargs):
-        return self.create_response()
+        try:
+            return self.create_response()
+        except FileNotFoundError:
+            # A file present when the route was registered may be gone at
+            # request time; serve 404 as Django's own static view does.
+            raise Http404

--- a/tests/tests/views/tests.py
+++ b/tests/tests/views/tests.py
@@ -112,3 +112,18 @@ class StaticViewContentTypeTests(TestCase):
             self.assertEqual(response.status_code, 200)
         finally:
             response.close()
+
+
+class StaticViewMissingFileTests(TestCase):
+    """A StaticView whose file is gone responds 404, not 500."""
+
+    def test_missing_file_raises_http404(self):
+        from django.http import Http404
+        from django.test import RequestFactory
+
+        class FileView(StaticView):
+            static_name = os.path.join(
+                os.path.dirname(__file__), 'does_not_exist.xyz')
+
+        with self.assertRaises(Http404):
+            FileView().get(RequestFactory().get('/missing'))


### PR DESCRIPTION
## Summary

`include_static_files` registers a `StaticView` route per file at URLconf load time. If a file is removed or rotated after startup, `create_response` raised a bare `FileNotFoundError`, which escaped the view as a 500. `StaticView.get` now converts it to `Http404`, matching Django's own `static.serve`. `StaticResponseMixin.create_response` still raises `FileNotFoundError`, so the mixin stays HTTP-agnostic and its multi-candidate fallback is unchanged.
