### PR TITLE
:bug: Route include_static_files file names literally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ### Fixed
 
-- `StaticView` now responds with a 404 instead of a 500 when its file is missing at request time (e.g. removed or rotated after the route was registered), matching Django's own static view.
+- `StaticView` now responds with a 404 instead of a 500 when its file is missing at request time.
+- `include_static_files` now routes each file name literally, so a name containing `<`/`>` (e.g. `<script>.js`) is no longer interpreted as a path converter that would match unrelated URLs.
 
 ## [3.2.3] - 2026-07-07
 

--- a/django_boost/urls/static.py
+++ b/django_boost/urls/static.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 
 from django import urls
 
@@ -10,7 +11,7 @@ from django_boost.views.generic import StaticView
 class StaticFileConnector:
 
     def __init__(self, path):
-        """Build a ``urls.path()`` entry for every file under ``path``."""
+        """Build a ``urls.re_path()`` entry for every file under ``path``."""
         self._urls = []
 
         for base, _, files in os.walk(path):
@@ -19,9 +20,11 @@ class StaticFileConnector:
                 url_path = full_path[len(path):]
                 if url_path[0] == "/":
                     url_path = url_path[1:]
+                # Match the file name literally: re.escape keeps a name like
+                # "<x>.js" from being read as a path-converter route.
                 self._urls.append(
-                    urls.path(url_path,
-                              StaticView.as_view(static_name=full_path)))
+                    urls.re_path(r"^%s$" % re.escape(url_path),
+                                 StaticView.as_view(static_name=full_path)))
 
     @property
     def urls(self):

--- a/tests/tests/test_urls.py
+++ b/tests/tests/test_urls.py
@@ -29,3 +29,20 @@ class TestStaticFileBelow(TestCase):
 
         for p in urlpatterns:
             self.assertTrue(isinstance(p, URLPattern))
+
+    def test_angle_bracket_filename_routes_literally(self):
+        import os
+        import shutil
+        import tempfile
+        from django_boost.urls.static import load_static_files
+
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp)
+        with open(os.path.join(tmp, '<script>.js'), 'w') as f:
+            f.write('x')
+
+        (pattern,) = [p.pattern for p in load_static_files(tmp)]
+        # The file name must match itself literally, not act as a path
+        # converter that captures any "<something>.js".
+        self.assertIsNotNone(pattern.match('<script>.js'))
+        self.assertIsNone(pattern.match('anything.js'))


### PR DESCRIPTION
## Summary

`include_static_files` passed each file name straight to `urls.path()`, whose route syntax reads `<name>` as a path converter. A file named `<script>.js` therefore became a wildcard route that matched any `/<something>.js` and served that one file for unrelated URLs. Build the route with `re_path(r"^%s$" % re.escape(url_path), ...)` so the file name matches literally.

## Notes

- Only the `<name>` (balanced) case was a real defect on the supported Django versions (4.2–5.2); an unbalanced `<` is treated as a literal by `path()` and did not misbehave. `re.escape` neutralizes both regardless.
