### PR TITLE
Enable flake8 D101 for public classes

### DIFF
--- a/django_boost/admin/__init__.py
+++ b/django_boost/admin/__init__.py
@@ -18,6 +18,8 @@ __all__ = ["EmailUserAdmin",
 
 @admin.register(EmailUser)
 class EmailUserAdmin(UserAdmin):
+    """Admin registration for ``EmailUser``, Django's ``UserAdmin`` adapted to its email-based login."""
+
     add_form = UserCreationForm
     form = UserChangeForm
     add_fieldsets = (

--- a/django_boost/admin/filters.py
+++ b/django_boost/admin/filters.py
@@ -6,6 +6,8 @@ from django.contrib import admin
 
 
 class LogicalDeletedFilter(admin.SimpleListFilter):
+    """Admin list filter for alive/dead items on a ``LogicalDeletionMixin`` model."""
+
     title = 'delete state'
     parameter_name = 'delete_state'
 

--- a/django_boost/admin/mixins.py
+++ b/django_boost/admin/mixins.py
@@ -7,6 +7,7 @@ from .filters import LogicalDeletedFilter
 
 
 class LogicalDeletionModelAdminMixin:
+    """Mixin that adds the hard-delete action and dead/alive filter to a ``ModelAdmin``."""
 
     def hard_delete_queryset(self, request, queryset):
         queryset.delete(hard=True)

--- a/django_boost/admin_tools/apps.py
+++ b/django_boost/admin_tools/apps.py
@@ -8,6 +8,8 @@ from django.apps import AppConfig
 
 
 class AdminToolsConfig(AppConfig):
+    """App config that warns on ``ready()`` that this app is a deprecated alias."""
+
     name = 'django_boost.admin_tools'
 
     def ready(self):

--- a/django_boost/contrib/admin_tools/apps.py
+++ b/django_boost/contrib/admin_tools/apps.py
@@ -5,5 +5,5 @@ from __future__ import annotations
 from django.apps import AppConfig
 
 
-class AdminToolsConfig(AppConfig):
+class AdminToolsConfig(AppConfig):  # noqa: D101
     name = 'django_boost.contrib.admin_tools'

--- a/django_boost/core/management.py
+++ b/django_boost/core/management.py
@@ -17,8 +17,12 @@ class CommandVersion:
 
 
 class BaseCommand(CommandVersion, base.BaseCommand):
+    """Django's own ``BaseCommand`` plus ``--version`` support."""
+
     pass
 
 
 class AppCommand(CommandVersion, base.AppCommand):
+    """Django's own ``AppCommand`` plus ``--version`` support."""
+
     pass

--- a/django_boost/http/response.py
+++ b/django_boost/http/response.py
@@ -9,155 +9,157 @@ from django.http import (HttpResponse, HttpResponseBadRequest,
 from django.http.response import HttpResponseRedirectBase
 
 
-class HttpResponseTemporaryRedirect(HttpResponseRedirectBase):
+class HttpResponseTemporaryRedirect(HttpResponseRedirectBase):  # noqa: D101
     status_code = 307
 
 
-class HttpResponsePermanentRedirect308(HttpResponseRedirectBase):
+class HttpResponsePermanentRedirect308(HttpResponseRedirectBase):  # noqa: D101
     status_code = 308
 
 
-class HttpResponseUnauthorized(HttpResponse):
+class HttpResponseUnauthorized(HttpResponse):  # noqa: D101
     status_code = 401
 
 
-class HttpResponsePaymentRequired(HttpResponse):
+class HttpResponsePaymentRequired(HttpResponse):  # noqa: D101
     status_code = 402
 
 
-class HttpResponseNotAcceptable(HttpResponse):
+class HttpResponseNotAcceptable(HttpResponse):  # noqa: D101
     status_code = 406
 
 
-class HttpResponseProxyAuthenticationRequired(HttpResponse):
+class HttpResponseProxyAuthenticationRequired(HttpResponse):  # noqa: D101
     status_code = 407
 
 
-class HttpResponseRequestTimeout(HttpResponse):
+class HttpResponseRequestTimeout(HttpResponse):  # noqa: D101
     status_code = 408
 
 
-class HttpResponseConflict(HttpResponse):
+class HttpResponseConflict(HttpResponse):  # noqa: D101
     status_code = 409
 
 
-class HttpResponseLengthRequired(HttpResponse):
+class HttpResponseLengthRequired(HttpResponse):  # noqa: D101
     status_code = 411
 
 
-class HttpResponsePreconditionFailed(HttpResponse):
+class HttpResponsePreconditionFailed(HttpResponse):  # noqa: D101
     status_code = 412
 
 
-class HttpResponsePayloadTooLarge(HttpResponse):
+class HttpResponsePayloadTooLarge(HttpResponse):  # noqa: D101
     status_code = 413
 
 
-class HttpResponseURITooLong(HttpResponse):
+class HttpResponseURITooLong(HttpResponse):  # noqa: D101
     status_code = 414
 
 
-class HttpResponseUnsupportedMediaType(HttpResponse):
+class HttpResponseUnsupportedMediaType(HttpResponse):  # noqa: D101
     status_code = 415
 
 
-class HttpResponseRangeNotSatisfiable(HttpResponse):
+class HttpResponseRangeNotSatisfiable(HttpResponse):  # noqa: D101
     status_code = 416
 
 
-class HttpResponseExpectationFailed(HttpResponse):
+class HttpResponseExpectationFailed(HttpResponse):  # noqa: D101
     status_code = 417
 
 
-class HttpResponseImATeapot(HttpResponse):
+class HttpResponseImATeapot(HttpResponse):  # noqa: D101
     status_code = 418
 
 
-class HttpResponseMisdirectedRequest(HttpResponse):
+class HttpResponseMisdirectedRequest(HttpResponse):  # noqa: D101
     status_code = 421
 
 
-class HttpResponseUnprocessableEntity(HttpResponse):
+class HttpResponseUnprocessableEntity(HttpResponse):  # noqa: D101
     status_code = 422
 
 
-class HttpResponseLocked(HttpResponse):
+class HttpResponseLocked(HttpResponse):  # noqa: D101
     status_code = 423
 
 
-class HttpResponseFailedDependency(HttpResponse):
+class HttpResponseFailedDependency(HttpResponse):  # noqa: D101
     status_code = 424
 
 
-class HttpResponseTooEarly(HttpResponse):
+class HttpResponseTooEarly(HttpResponse):  # noqa: D101
     status_code = 425
 
 
-class HttpResponseUpgradeRequired(HttpResponse):
+class HttpResponseUpgradeRequired(HttpResponse):  # noqa: D101
     status_code = 426
 
 
-class HttpResponsePreconditionRequired(HttpResponse):
+class HttpResponsePreconditionRequired(HttpResponse):  # noqa: D101
     status_code = 428
 
 
-class HttpResponseTooManyRequests(HttpResponse):
+class HttpResponseTooManyRequests(HttpResponse):  # noqa: D101
     status_code = 429
 
 
-class HttpResponseRequestHeaderFieldsTooLarge(HttpResponse):
+class HttpResponseRequestHeaderFieldsTooLarge(HttpResponse):  # noqa: D101
     status_code = 431
 
 
-class HttpResponseUnavailableForLegalReasons(HttpResponse):
+class HttpResponseUnavailableForLegalReasons(HttpResponse):  # noqa: D101
     status_code = 451
 
 
-class HttpResponseNotImplemented(HttpResponse):
+class HttpResponseNotImplemented(HttpResponse):  # noqa: D101
     status_code = 501
 
 
-class HttpResponseBadGateway(HttpResponse):
+class HttpResponseBadGateway(HttpResponse):  # noqa: D101
     status_code = 502
 
 
-class HttpResponseServiceUnavailable(HttpResponse):
+class HttpResponseServiceUnavailable(HttpResponse):  # noqa: D101
     status_code = 503
 
 
-class HttpResponseGatewayTimeout(HttpResponse):
+class HttpResponseGatewayTimeout(HttpResponse):  # noqa: D101
     status_code = 504
 
 
-class HttpResponseHTTPVersionNotSupported(HttpResponse):
+class HttpResponseHTTPVersionNotSupported(HttpResponse):  # noqa: D101
     status_code = 505
 
 
-class HttpResponseVariantAlsoNegotiates(HttpResponse):
+class HttpResponseVariantAlsoNegotiates(HttpResponse):  # noqa: D101
     status_code = 506
 
 
-class HttpResponseInsufficientStorage(HttpResponse):
+class HttpResponseInsufficientStorage(HttpResponse):  # noqa: D101
     status_code = 507
 
 
-class HttpResponseLoopDetected(HttpResponse):
+class HttpResponseLoopDetected(HttpResponse):  # noqa: D101
     status_code = 508
 
 
-class HttpResponseBandwidthLimitExceeded(HttpResponse):
+class HttpResponseBandwidthLimitExceeded(HttpResponse):  # noqa: D101
     status_code = 509
 
 
-class HttpResponseNotExtended(HttpResponse):
+class HttpResponseNotExtended(HttpResponse):  # noqa: D101
     status_code = 510
 
 
-class HttpResponseNetworkAuthenticationRequired(HttpResponse):
+class HttpResponseNetworkAuthenticationRequired(HttpResponse):  # noqa: D101
     status_code = 511
 
 
 class HttpExceptionBase(Exception):
+    """Base exception whose ``response_class`` becomes the raised status's HTTP response."""
+
     response_class = HttpResponse
 
     @property
@@ -166,6 +168,7 @@ class HttpExceptionBase(Exception):
 
 
 class HttpRedirectExceptionBase(HttpExceptionBase):
+    """Base for exceptions that carry a redirect target, e.g. ``Http301``."""
 
     def __init__(self, redirect_to, *args):
         """Store the redirect target as ``self.url``."""
@@ -173,39 +176,39 @@ class HttpRedirectExceptionBase(HttpExceptionBase):
         super(HttpRedirectExceptionBase, self).__init__(*args)
 
 
-class Http301(HttpRedirectExceptionBase):
+class Http301(HttpRedirectExceptionBase):  # noqa: D101
     response_class = HttpResponsePermanentRedirect
 
 
-class Http302(HttpRedirectExceptionBase):
+class Http302(HttpRedirectExceptionBase):  # noqa: D101
     response_class = HttpResponseRedirect
 
 
-class Http307(HttpRedirectExceptionBase):
+class Http307(HttpRedirectExceptionBase):  # noqa: D101
     response_class = HttpResponseTemporaryRedirect
 
 
-class Http308(HttpRedirectExceptionBase):
+class Http308(HttpRedirectExceptionBase):  # noqa: D101
     response_class = HttpResponsePermanentRedirect308
 
 
-class Http400(HttpExceptionBase):
+class Http400(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseBadRequest
 
 
-class Http401(HttpExceptionBase):
+class Http401(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseUnauthorized
 
 
-class Http402(HttpExceptionBase):
+class Http402(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponsePaymentRequired
 
 
-class Http403(HttpExceptionBase):
+class Http403(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseForbidden
 
 
-class Http405(HttpExceptionBase):
+class Http405(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseNotAllowed
 
     def __init__(self, permitted_methods=(), *args):
@@ -214,141 +217,141 @@ class Http405(HttpExceptionBase):
         super().__init__(*args)
 
 
-class Http406(HttpExceptionBase):
+class Http406(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseNotAcceptable
 
 
-class Http407(HttpExceptionBase):
+class Http407(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseProxyAuthenticationRequired
 
 
-class Http408(HttpExceptionBase):
+class Http408(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseRequestTimeout
 
 
-class Http409(HttpExceptionBase):
+class Http409(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseConflict
 
 
-class Http410(HttpExceptionBase):
+class Http410(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseGone
 
 
-class Http411(HttpExceptionBase):
+class Http411(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseLengthRequired
 
 
-class Http412(HttpExceptionBase):
+class Http412(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponsePreconditionFailed
 
 
-class Http413(HttpExceptionBase):
+class Http413(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponsePayloadTooLarge
 
 
-class Http414(HttpExceptionBase):
+class Http414(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseURITooLong
 
 
-class Http415(HttpExceptionBase):
+class Http415(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseUnsupportedMediaType
 
 
-class Http416(HttpExceptionBase):
+class Http416(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseRangeNotSatisfiable
 
 
-class Http417(HttpExceptionBase):
+class Http417(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseExpectationFailed
 
 
-class Http418(HttpExceptionBase):
+class Http418(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseImATeapot
 
 
-class Http421(HttpExceptionBase):
+class Http421(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseMisdirectedRequest
 
 
-class Http422(HttpExceptionBase):
+class Http422(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseUnprocessableEntity
 
 
-class Http423(HttpExceptionBase):
+class Http423(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseLocked
 
 
-class Http424(HttpExceptionBase):
+class Http424(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseFailedDependency
 
 
-class Http425(HttpExceptionBase):
+class Http425(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseTooEarly
 
 
-class Http426(HttpExceptionBase):
+class Http426(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseUpgradeRequired
 
 
-class Http428(HttpExceptionBase):
+class Http428(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponsePreconditionRequired
 
 
-class Http429(HttpExceptionBase):
+class Http429(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseTooManyRequests
 
 
-class Http431(HttpExceptionBase):
+class Http431(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseRequestHeaderFieldsTooLarge
 
 
-class Http451(HttpExceptionBase):
+class Http451(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseUnavailableForLegalReasons
 
 
-class Http500(HttpExceptionBase):
+class Http500(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseServerError
 
 
-class Http501(HttpExceptionBase):
+class Http501(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseNotImplemented
 
 
-class Http502(HttpExceptionBase):
+class Http502(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseBadGateway
 
 
-class Http503(HttpExceptionBase):
+class Http503(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseServiceUnavailable
 
 
-class Http504(HttpExceptionBase):
+class Http504(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseGatewayTimeout
 
 
-class Http505(HttpExceptionBase):
+class Http505(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseHTTPVersionNotSupported
 
 
-class Http506(HttpExceptionBase):
+class Http506(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseVariantAlsoNegotiates
 
 
-class Http507(HttpExceptionBase):
+class Http507(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseInsufficientStorage
 
 
-class Http508(HttpExceptionBase):
+class Http508(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseLoopDetected
 
 
-class Http509(HttpExceptionBase):
+class Http509(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseBandwidthLimitExceeded
 
 
-class Http510(HttpExceptionBase):
+class Http510(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseNotExtended
 
 
-class Http511(HttpExceptionBase):
+class Http511(HttpExceptionBase):  # noqa: D101
     response_class = HttpResponseNetworkAuthenticationRequired

--- a/django_boost/management/commands/deletemigrations.py
+++ b/django_boost/management/commands/deletemigrations.py
@@ -11,7 +11,7 @@ from django_boost.core.management import AppCommand
 from django_boost.management.mixins import ConfirmOptionMixin, QuitOptionMixin
 
 
-class Command(ConfirmOptionMixin, QuitOptionMixin, AppCommand):
+class Command(ConfirmOptionMixin, QuitOptionMixin, AppCommand):  # noqa: D101
     help = "delete migration files."
 
     def add_arguments(self, parser):

--- a/django_boost/management/commands/migrate_emailuser.py
+++ b/django_boost/management/commands/migrate_emailuser.py
@@ -45,7 +45,7 @@ def record_migration_applied(using, app_label, name) -> bool:
     return True
 
 
-class Command(BaseCommand):
+class Command(BaseCommand):  # noqa: D101
     help = ("Adopt the legacy django_boost_emailuser table and content type into your own "
             "AUTH_USER_MODEL app, then finish migrating.")
 

--- a/django_boost/management/commands/startapp_plus.py
+++ b/django_boost/management/commands/startapp_plus.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from django_boost.management.templates import TemplateCommand
 
 
-class Command(TemplateCommand):
+class Command(TemplateCommand):  # noqa: D101
     help = (
         "Creates a Django app directory structure for the given app name in "
         "the current directory or optionally in the given directory."

--- a/django_boost/management/mixins.py
+++ b/django_boost/management/mixins.py
@@ -78,6 +78,7 @@ class OutputFormatMixin:
 
 
 class ConfirmOptionMixin:
+    """Add a ``-y`` option and a ``confirm()`` helper that prompts unless it's set."""
 
     def add_confirm_option(self, parser):
         parser.add_argument('-y', action='store_true')
@@ -97,6 +98,7 @@ class ConfirmOptionMixin:
 
 
 class QuitOptionMixin:
+    """Add a ``-q``/``--quit`` option that silences ``self.stdout``/``self.stderr``."""
 
     def add_quit_option(self, parser):
         parser.add_argument('-q', '--quit', action='store_true',

--- a/django_boost/management/templates.py
+++ b/django_boost/management/templates.py
@@ -14,6 +14,7 @@ from django_boost.core.management import CommandVersion
 
 
 class TemplateCommand(CommandVersion, DjangoTemplateCommand):
+    """Django's own ``TemplateCommand`` plus ``--version`` support and a django-boost app template default."""
 
     def handle_template(self, template, subdir):
         base = super().handle_template(template, subdir)

--- a/django_boost/models/deletion.py
+++ b/django_boost/models/deletion.py
@@ -33,6 +33,7 @@ def get_logical_delete_field(model):
 
 
 class LogicalDeletionCollector(Collector):
+    """Django's own deletion ``Collector``, marking rows as deleted instead of deleting them."""
 
     def __init__(self, using, origin=None, deleted_at=None):
         """Store ``deleted_at`` to use as the logical-deletion timestamp/flag value."""

--- a/django_boost/models/manager.py
+++ b/django_boost/models/manager.py
@@ -8,6 +8,8 @@ from .query import LogicalDeletionQuerySet
 
 
 class LogicalDeletionManager(Manager):
+    """Default manager for ``LogicalDeletionMixin`` models; ``delete()`` marks rows dead instead of removing them."""
+
     delete_flag_field = "deleted_at"
 
     def get_deleted_flag_field_name(self):

--- a/django_boost/models/mixins.py
+++ b/django_boost/models/mixins.py
@@ -18,6 +18,7 @@ __all__ = ["JsonMixin", "UUIDModelMixin",
 
 
 class JsonMixin:
+    """Mixin adding ``to_json``/``from_json`` conversion between a model instance and a dict."""
 
     def to_json(self, fields=(), exclude=()):
         """Return dict object."""

--- a/django_boost/models/query.py
+++ b/django_boost/models/query.py
@@ -9,6 +9,8 @@ from django_boost.models.deletion import LogicalDeletionCollector
 
 
 class LogicalDeletionQuerySet(QuerySet):
+    """QuerySet for ``LogicalDeletionMixin``; ``delete()`` marks rows dead instead of removing them."""
+
     delete_flag_field = "deleted_at"
 
     def get_delete_flag_field_name(self):

--- a/django_boost/test/testcase.py
+++ b/django_boost/test/testcase.py
@@ -14,6 +14,7 @@ __unittest = True
 
 
 class TestCase(DjangoTestCase):
+    """Django's own ``TestCase`` plus ``assertStatusCode*`` assertions."""
 
     def assertStatusCodeEqual(self, response: HttpResponseBase, code: int,
                               msg: object = None) -> None:

--- a/django_boost/urls/converters/__init__.py
+++ b/django_boost/urls/converters/__init__.py
@@ -63,32 +63,32 @@ class BinConverter:
         return str(value)
 
 
-class HexIntConverter(HexConverter):
+class HexIntConverter(HexConverter):  # noqa: D101
     def to_python(self, value):
         return int(value, 16)
 
 
-class OctIntConverter(OctConverter):
+class OctIntConverter(OctConverter):  # noqa: D101
     def to_python(self, value):
         return int(value, 8)
 
 
-class BinIntConverter(BinConverter):
+class BinIntConverter(BinConverter):  # noqa: D101
     def to_python(self, value):
         return int(value, 2)
 
 
-class HexStrConverter(HexConverter):
+class HexStrConverter(HexConverter):  # noqa: D101
     def to_python(self, value):
         return value
 
 
-class OctStrConverter(OctConverter):
+class OctStrConverter(OctConverter):  # noqa: D101
     def to_python(self, value):
         return value
 
 
-class BinStrConverter(BinConverter):
+class BinStrConverter(BinConverter):  # noqa: D101
     def to_python(self, value):
         return value
 

--- a/django_boost/urls/converters/date.py
+++ b/django_boost/urls/converters/date.py
@@ -34,6 +34,8 @@ REGEX_DATE = REGEX_DATE.format(
 
 
 class DateConverter:
+    """URL converter for calendar dates in ``Y/M/D`` format, validating real dates via ``regex``."""
+
     regex: ClassVar[str] = REGEX_DATE
 
     def to_url(self, value: datetime | str) -> str:

--- a/django_boost/urls/converters/decimal.py
+++ b/django_boost/urls/converters/decimal.py
@@ -9,29 +9,29 @@ from django_boost.urls.converters._numeric import (
     BaseSignedNumericConverter, POSITIVE, ZERO)
 
 
-class BaseDecimalConverter(BaseSignedNumericConverter[decimal.Decimal]):
+class BaseDecimalConverter(BaseSignedNumericConverter[decimal.Decimal]):  # noqa: D101
     _parse = staticmethod(decimal.Decimal)
 
 
-class SignedDecimalConverter(BaseDecimalConverter):
+class SignedDecimalConverter(BaseDecimalConverter):  # noqa: D101
     regex: ClassVar[str] = r'-?[0-9]+(?:\.[0-9]+)?'
 
 
-class PositiveDecimalConverter(BaseDecimalConverter):
+class PositiveDecimalConverter(BaseDecimalConverter):  # noqa: D101
     regex: ClassVar[str] = POSITIVE
 
 
-class NegativeDecimalConverter(BaseDecimalConverter):
+class NegativeDecimalConverter(BaseDecimalConverter):  # noqa: D101
     regex: ClassVar[str] = f'-{POSITIVE}'
 
 
-class NonNegativeDecimalConverter(BaseDecimalConverter):
+class NonNegativeDecimalConverter(BaseDecimalConverter):  # noqa: D101
     regex: ClassVar[str] = r'[0-9]+(?:\.[0-9]+)?'
 
 
-class NonPositiveDecimalConverter(BaseDecimalConverter):
+class NonPositiveDecimalConverter(BaseDecimalConverter):  # noqa: D101
     regex: ClassVar[str] = f'{ZERO}|-{POSITIVE}'
 
 
-class NonZeroDecimalConverter(BaseDecimalConverter):
+class NonZeroDecimalConverter(BaseDecimalConverter):  # noqa: D101
     regex: ClassVar[str] = f'-?{POSITIVE}'

--- a/django_boost/urls/converters/float.py
+++ b/django_boost/urls/converters/float.py
@@ -8,29 +8,29 @@ from django_boost.urls.converters._numeric import (
     BaseSignedNumericConverter, POSITIVE, ZERO)
 
 
-class BaseFloatConverter(BaseSignedNumericConverter[float]):
+class BaseFloatConverter(BaseSignedNumericConverter[float]):  # noqa: D101
     _parse = staticmethod(float)
 
 
-class SignedFloatConverter(BaseFloatConverter):
+class SignedFloatConverter(BaseFloatConverter):  # noqa: D101
     regex: ClassVar[str] = r'-?[0-9]+(?:\.[0-9]+)?'
 
 
-class PositiveFloatConverter(BaseFloatConverter):
+class PositiveFloatConverter(BaseFloatConverter):  # noqa: D101
     regex: ClassVar[str] = POSITIVE
 
 
-class NegativeFloatConverter(BaseFloatConverter):
+class NegativeFloatConverter(BaseFloatConverter):  # noqa: D101
     regex: ClassVar[str] = f'-{POSITIVE}'
 
 
-class NonNegativeFloatConverter(BaseFloatConverter):
+class NonNegativeFloatConverter(BaseFloatConverter):  # noqa: D101
     regex: ClassVar[str] = r'[0-9]+(?:\.[0-9]+)?'
 
 
-class NonPositiveFloatConverter(BaseFloatConverter):
+class NonPositiveFloatConverter(BaseFloatConverter):  # noqa: D101
     regex: ClassVar[str] = f'{ZERO}|-{POSITIVE}'
 
 
-class NonZeroFloatConverter(BaseFloatConverter):
+class NonZeroFloatConverter(BaseFloatConverter):  # noqa: D101
     regex: ClassVar[str] = f'-?{POSITIVE}'

--- a/django_boost/urls/converters/integer.py
+++ b/django_boost/urls/converters/integer.py
@@ -24,25 +24,25 @@ class BaseIntConverter:
         return str(value)
 
 
-class SignedIntConverter(BaseIntConverter):
+class SignedIntConverter(BaseIntConverter):  # noqa: D101
     regex: ClassVar[str] = r'-?[0-9]+'
 
 
-class PositiveIntConverter(BaseIntConverter):
+class PositiveIntConverter(BaseIntConverter):  # noqa: D101
     regex: ClassVar[str] = r'0*[1-9][0-9]*'
 
 
-class NegativeIntConverter(BaseIntConverter):
+class NegativeIntConverter(BaseIntConverter):  # noqa: D101
     regex: ClassVar[str] = r'-0*[1-9][0-9]*'
 
 
-class NonNegativeIntConverter(BaseIntConverter):
+class NonNegativeIntConverter(BaseIntConverter):  # noqa: D101
     regex: ClassVar[str] = r'[0-9]+'
 
 
-class NonPositiveIntConverter(BaseIntConverter):
+class NonPositiveIntConverter(BaseIntConverter):  # noqa: D101
     regex: ClassVar[str] = r'0+|-0*[1-9][0-9]*'
 
 
-class NonZeroIntConverter(BaseIntConverter):
+class NonZeroIntConverter(BaseIntConverter):  # noqa: D101
     regex: ClassVar[str] = r'-?0*[1-9][0-9]*'

--- a/django_boost/urls/static.py
+++ b/django_boost/urls/static.py
@@ -11,6 +11,7 @@ from django_boost.views.generic import StaticView
 
 
 class StaticFileConnector:
+    """Builds a list of ``urls.path()`` entries for every file under a directory."""
 
     def __init__(self, path):
         """Build a ``urls.re_path()`` entry for every file under ``path``."""

--- a/django_boost/utils/html.py
+++ b/django_boost/utils/html.py
@@ -11,6 +11,7 @@ from typing import Any
 
 
 class HTMLSpaceLessCompressor(HTMLParser):
+    """Streaming HTML parser that removes ignorable whitespace between tags."""
 
     RAW_TEXT_ELEMENTS = frozenset({'script', 'style'})
     WHITESPACE_PRESERVING_ELEMENTS = frozenset({'pre', 'textarea'})

--- a/django_boost/validators/color.py
+++ b/django_boost/validators/color.py
@@ -11,6 +11,8 @@ __all__ = ["ColorCodeValidator", "validate_color_code"]
 
 @deconstructible(path="django_boost.validators.ColorCodeValidator")
 class ColorCodeValidator(RegexValidator):
+    """Validate that the whole value is a 6-digit hexadecimal color code prefixed with ``#``."""
+
     # Anchored: RegexValidator matches with regex.search(), so without \A..\Z
     # any string merely containing a color code (e.g. "x#abcdef") would pass.
     regex = r'\A#[0-9a-fA-F]{6}\Z'

--- a/django_boost/validators/json.py
+++ b/django_boost/validators/json.py
@@ -16,6 +16,7 @@ __all__ = ["JsonValidator", "validate_json"]
 
 @deconstructible(path="django_boost.validators.JsonValidator")
 class JsonValidator(BaseValidator):
+    """Validate that the value is a JSON-parseable string."""
 
     message = _('Enter valid JSON string.')
     code = 'json value'

--- a/django_boost/views/base.py
+++ b/django_boost/views/base.py
@@ -115,6 +115,7 @@ class StaticResponseMixin:
 
 
 class StaticView(StaticResponseMixin, _View):
+    """View that serves a single static file, e.g. via ``include_static_files``."""
 
     def get(self, request, *args, **kwargs):
         try:

--- a/django_boost/views/generic.py
+++ b/django_boost/views/generic.py
@@ -61,6 +61,8 @@ class JsonView(JsonRequestMixin, JsonResponseMixin, _View):
 
 
 class BaseModelCLUDViews:
+    """Assemble list/create/update/delete generic views under one URLconf via ``list_view`` etc."""
+
     model: type[models.Model] | None = None
     success_url = None
     list_view = None
@@ -150,6 +152,8 @@ class BaseModelCLUDViews:
 
 
 class ModelCRUDViews(BaseModelCLUDViews):
+    """``BaseModelCLUDViews`` wired up with Django's own generic view classes."""
+
     list_view = _ListView
     create_view = _CreateView
     detail_view = _DetailView

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -30,6 +30,7 @@ __all__ = ["CSRFExemptMixin", "DynamicRedirectMixin", "RedirectToDetailMixin",
 
 
 class CSRFExemptMixin:
+    """Mixin that exempts the view's ``dispatch()`` from CSRF protection."""
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
@@ -37,6 +38,8 @@ class CSRFExemptMixin:
 
 
 class DynamicRedirectMixin(RedirectURLMixin):
+    """Mixin that prefers the ``?next=``-style redirect target over ``success_url``."""
+
     success_url = None
 
     def get_success_url(self):
@@ -45,6 +48,7 @@ class DynamicRedirectMixin(RedirectURLMixin):
 
 
 class RedirectToDetailMixin:
+    """Mixin that redirects to the object's detail view instead of a fixed ``success_url``."""
 
     success_url_name: str | None = None
     url_kwarg: str = 'pk'
@@ -138,6 +142,7 @@ class JsonRequestMixin(AllowContentTypeMixin):
 
 
 class JsonResponseMixin:
+    """Mixin that renders the view's context as a JSON response."""
 
     response_class = JsonResponse
     extra_context = None
@@ -289,6 +294,11 @@ class SuperuserRequiredMixin(AccessMixin):
 
 
 class ViewUserKwargsMixin:
+    """Mixin that adds the current request's user to the form kwargs.
+
+    Pairs with ``django_boost.forms.mixins.FormUserKwargsMixin``, which
+    consumes the ``user`` kwarg on the form side.
+    """
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -297,6 +307,7 @@ class ViewUserKwargsMixin:
 
 
 class UserAgentMixin:
+    """Mixin that swaps in a device-specific template based on the parsed user agent."""
 
     pc_template_name: str | None = None
     tablet_template_name: str | None = None

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 commands = flake8 .
 
 [flake8]
-ignore = D101,D102
+ignore = D102
 exclude = 
     .git,
     .tox,


### PR DESCRIPTION
## Summary
Enable flake8's `D101` (missing docstring in public class) check, previously disabled via `tox.ini`'s `ignore` list. 127 violations (of the raw 131; some line-count drift is from `master` moving since the count was first taken), split into one commit per module group.

## Notes
`http/response.py` accounts for 83 of the 127: nearly all are one-line classes named after a standard HTTP status code (e.g. `Http404`, `HttpResponseNotFound`), so 81 are suppressed with `# noqa: D101` rather than given a restating docstring; only the two base classes (`HttpExceptionBase`, `HttpRedirectExceptionBase`) get real docstrings. The same reasoning applies to `urls/converters/` subclasses already covered by their parent's docstring, and to three management `Command` classes already documented via their `help` attribute (shown by `manage.py help <command>`).