### PR TITLE
Enable flake8 D102 for public methods (last docstring check)

### DIFF
--- a/django_boost/admin/filters.py
+++ b/django_boost/admin/filters.py
@@ -11,13 +11,13 @@ class LogicalDeletedFilter(admin.SimpleListFilter):
     title = 'delete state'
     parameter_name = 'delete_state'
 
-    def lookups(self, request, model_admin):
+    def lookups(self, request, model_admin):  # noqa: D102
         return (
             ('alive', ('Alive')),
             ('dead', ('Dead')),
         )
 
-    def queryset(self, request, queryset):
+    def queryset(self, request, queryset):  # noqa: D102
         value = self.value()
         if value == 'alive':
             return queryset.alive()

--- a/django_boost/admin/mixins.py
+++ b/django_boost/admin/mixins.py
@@ -9,10 +9,10 @@ from .filters import LogicalDeletedFilter
 class LogicalDeletionModelAdminMixin:
     """Mixin that adds the hard-delete action and dead/alive filter to a ``ModelAdmin``."""
 
-    def hard_delete_queryset(self, request, queryset):
+    def hard_delete_queryset(self, request, queryset):  # noqa: D102
         queryset.delete(hard=True)
 
-    def get_actions(self, request):
+    def get_actions(self, request):  # noqa: D102
         # Add the action to this admin's own action set only; add_action()
         # would register it on the shared AdminSite and leak it to every
         # other model admin.
@@ -22,7 +22,7 @@ class LogicalDeletionModelAdminMixin:
             actions[name] = (func, name, description)
         return actions
 
-    def get_list_filter(self, request):
+    def get_list_filter(self, request):  # noqa: D102
         filters = super().get_list_filter(request)
         filters = list(filters) + [LogicalDeletedFilter]
         return filters

--- a/django_boost/admin_tools/apps.py
+++ b/django_boost/admin_tools/apps.py
@@ -12,7 +12,7 @@ class AdminToolsConfig(AppConfig):
 
     name = 'django_boost.admin_tools'
 
-    def ready(self):
+    def ready(self):  # noqa: D102
         warnings.warn(
             "'django_boost.admin_tools' is deprecated and will be removed in "
             "django-boost 4.0; use 'django_boost.contrib.admin_tools' instead.",

--- a/django_boost/apps.py
+++ b/django_boost/apps.py
@@ -19,5 +19,6 @@ class DjangoBoostConfig(AppConfig):
     default_auto_field = 'django.db.models.AutoField'
 
     def ready(self):
+        """Register django_boost's system checks (``django_boost.checks.CHECKS``)."""
         for check in CHECKS:
             checks.register(check, self.name)

--- a/django_boost/contrib/admin_tools/management/commands/adminsitelog.py
+++ b/django_boost/contrib/admin_tools/management/commands/adminsitelog.py
@@ -23,10 +23,11 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
                             ">": "gt", }
     OUTPUT_FIELDS = ("id", "action", "detail", "user", "time")
 
-    def get_sortable_fields(self, model):
+    def get_sortable_fields(self, model):  # noqa: D102
         return sorted(get_field_names_from_opts(model._meta))
 
     def get_log_entry_model(self):
+        """Return Django admin's ``LogEntry`` model, raising if ``django.contrib.admin`` isn't installed."""
         from django.apps import apps
         if not apps.is_installed("django.contrib.admin"):
             raise CommandError(
@@ -36,6 +37,7 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
         return LogEntry
 
     def get_sortable_fields_help(self):
+        """Return the sortable field names for ``--help``, or a hint if admin isn't installed."""
         from django.apps import apps
         if not apps.is_installed("django.contrib.admin"):
             return "(requires 'django.contrib.admin' in INSTALLED_APPS)"
@@ -61,13 +63,14 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
         return {"%s__%s" % (condition[:index], lookup):
                 condition[index + len(op):]}
 
-    def parse_filter(self, conditions):
+    def parse_filter(self, conditions):  # noqa: D102
         parsed = {}
         for condition in conditions:
             parsed.update(self._parse_filter(condition))
         return parsed
 
     def get_row_data(self, log, **options):
+        """Map a ``LogEntry`` to the OUTPUT_FIELDS row dict, classifying it as Added/Changed/Deleted."""
         if log.is_addition():
             action = "Added"
             detail = log.object_repr
@@ -87,6 +90,7 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
         }
 
     def print_log(self, log, **options):
+        """Write one colorized ``id | action | object | user | time`` line for ``log``."""
         fmt = "{id} | {action} | {object} | {user} | {time}"
         fmap = self.get_row_data(log, **options)
         if fmap["action"] == "Added":
@@ -98,7 +102,7 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
         fmap["object"] = fmap.pop("detail")
         self.stdout.write(fmt.format_map(fmap))
 
-    def print_text(self, rows, **options):
+    def print_text(self, rows, **options):  # noqa: D102
         self.stdout.write(" | ".join(self.OUTPUT_FIELDS))
         for log in rows:
             self.print_log(log, **options)
@@ -115,7 +119,7 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
             if hasattr(user, field):
                 return getattr(user, field)
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser):  # noqa: D102
         supported_fields_str = self.get_sortable_fields_help()
         parser.add_argument('-d', '--delete',
                             action='store_true', help='Delete displayed logs.')
@@ -144,7 +148,7 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
         self.add_format_option(parser)
         self.add_confirm_option(parser)
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # noqa: D102
         LogEntry = self.get_log_entry_model()
         queryset = LogEntry.objects.all()
 

--- a/django_boost/contrib/admin_tools/management/commands/listsuperuser.py
+++ b/django_boost/contrib/admin_tools/management/commands/listsuperuser.py
@@ -14,15 +14,15 @@ class Command(OutputFormatMixin, BaseCommand):
     help = "List super users."
     OUTPUT_FIELDS = ("email", "active", "staff", "last_login")
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser):  # noqa: D102
         self.add_format_option(parser)
 
-    def get_queryset(self):
+    def get_queryset(self):  # noqa: D102
         User = get_user_model()
         return User.objects.filter(
             is_superuser=True).order_by(User.USERNAME_FIELD)
 
-    def get_row_data(self, user, **options):
+    def get_row_data(self, user, **options):  # noqa: D102
         email_field = user.get_email_field_name()
         return {
             "email": getattr(user, email_field, "") or "",
@@ -31,5 +31,5 @@ class Command(OutputFormatMixin, BaseCommand):
             "last_login": str(user.last_login) if user.last_login else "(never)",
         }
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # noqa: D102
         self.print_formatted(self.get_queryset(), **options)

--- a/django_boost/db/router.py
+++ b/django_boost/db/router.py
@@ -17,20 +17,20 @@ class DatabaseRouter:
         self.db_map: dict[str, str] = getattr(
             settings, "DATABASE_APPS_MAPPING", {})
 
-    def db_for_read(self, model: type[Model], **hints: Any) -> str | None:
+    def db_for_read(self, model: type[Model], **hints: Any) -> str | None:  # noqa: D102
         return self.db_map.get(model._meta.app_label, None)
 
-    def db_for_write(self, model: type[Model], **hints: Any) -> str | None:
+    def db_for_write(self, model: type[Model], **hints: Any) -> str | None:  # noqa: D102
         return self.db_map.get(model._meta.app_label, None)
 
-    def allow_relation(self, obj1: Model, obj2: Model, **hints: Any) -> bool | None:
+    def allow_relation(self, obj1: Model, obj2: Model, **hints: Any) -> bool | None:  # noqa: D102
         db1 = self.db_map.get(obj1._meta.app_label)
         db2 = self.db_map.get(obj2._meta.app_label)
         if db1 and db2:
             return db1 == db2
         return None
 
-    def allow_migrate(self, db: str, app_label: str, model: Any = None,
+    def allow_migrate(self, db: str, app_label: str, model: Any = None,  # noqa: D102
                       **hints: Any) -> bool | None:
         if app_label in self.db_map:
             return self.db_map[app_label] == db

--- a/django_boost/forms/mixins.py
+++ b/django_boost/forms/mixins.py
@@ -66,6 +66,7 @@ class MatchedObjectGetMixin:
     field_lookup = {}
 
     def get_queryset(self):
+        """Return ``queryset``, or fall back to ``model``'s/the form's own default manager."""
         if self.queryset is None:
             if self.model:
                 return self.model._default_manager.all()
@@ -156,6 +157,7 @@ class RelatedModelInlineMixin:
                 self.fields['%s_%s' % (field, field_name)] = field_object
 
     def save(self, commit=True):
+        """Save the form, then create/update each related model from its ``inline_fields``."""
         object = super().save(commit=False)
 
         def save_inline():

--- a/django_boost/forms/widgets.py
+++ b/django_boost/forms/widgets.py
@@ -40,7 +40,7 @@ class InvertCheckboxInput(CheckboxInput):
         super().__init__(attrs)
         self.check_test = boolean_check if check_test is None else check_test
 
-    def value_from_datadict(self, data, files, name):
+    def value_from_datadict(self, data, files, name):  # noqa: D102
         return not super().value_from_datadict(data, files, name)
 
 

--- a/django_boost/http/response.py
+++ b/django_boost/http/response.py
@@ -163,7 +163,7 @@ class HttpExceptionBase(Exception):
     response_class = HttpResponse
 
     @property
-    def status_code(self):
+    def status_code(self):  # noqa: D102
         return self.response_class.status_code
 
 

--- a/django_boost/management/commands/adminsitelog.py
+++ b/django_boost/management/commands/adminsitelog.py
@@ -25,7 +25,7 @@ class Command(_Command):
     that have not migrated -- so correctly configured projects are not warned.
     """
 
-    def execute(self, *args, **options):
+    def execute(self, *args, **options):  # noqa: D102
         if not apps.is_installed(ADMIN_TOOLS_APP):
             warnings.warn(
                 "Running 'adminsitelog' from 'django_boost' is deprecated; add "

--- a/django_boost/management/commands/deletemigrations.py
+++ b/django_boost/management/commands/deletemigrations.py
@@ -14,7 +14,7 @@ from django_boost.management.mixins import ConfirmOptionMixin, QuitOptionMixin
 class Command(ConfirmOptionMixin, QuitOptionMixin, AppCommand):  # noqa: D101
     help = "delete migration files."
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser):  # noqa: D102
         super().add_arguments(parser)
         self.add_quit_option(parser)
         self.add_confirm_option(parser)
@@ -34,7 +34,7 @@ class Command(ConfirmOptionMixin, QuitOptionMixin, AppCommand):  # noqa: D101
             file_list.append(path)
         return file_list
 
-    def handle_app_config(self, app_config, **options):
+    def handle_app_config(self, app_config, **options):  # noqa: D102
         self.if_needed_make_quit(**options)
         app_path = app_config.path
         migration_dir = os.path.join(app_path, MIGRATIONS_MODULE_NAME)

--- a/django_boost/management/commands/migrate_emailuser.py
+++ b/django_boost/management/commands/migrate_emailuser.py
@@ -49,14 +49,14 @@ class Command(BaseCommand):  # noqa: D101
     help = ("Adopt the legacy django_boost_emailuser table and content type into your own "
             "AUTH_USER_MODEL app, then finish migrating.")
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser):  # noqa: D102
         parser.add_argument("--database", default=DEFAULT_DB_ALIAS)
         parser.add_argument(
             "--target-migration", default="0001_initial",
             help="Migration in the target app that creates the user model "
                  "(default: 0001_initial).")
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # noqa: D102
         using = options["database"]
         target = getattr(settings, "AUTH_USER_MODEL", "") or ""
         if target == LEGACY_USER_MODEL or "." not in target:

--- a/django_boost/management/commands/startapp_plus.py
+++ b/django_boost/management/commands/startapp_plus.py
@@ -12,7 +12,7 @@ class Command(TemplateCommand):  # noqa: D101
     )
     missing_args_message = "You must provide an application name."
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # noqa: D102
         app_name = options.pop('name')
         target = options.pop('directory')
         template_type = 'app'

--- a/django_boost/management/mixins.py
+++ b/django_boost/management/mixins.py
@@ -27,15 +27,15 @@ class OutputFormatMixin:
     }
     OUTPUT_FIELDS = ()
 
-    def supported_formats(self):
+    def supported_formats(self):  # noqa: D102
         return [self.TEXT_FORMAT, *self.DELIMITED_FORMATS]
 
-    def add_format_option(self, parser):
+    def add_format_option(self, parser):  # noqa: D102
         parser.add_argument('--format', choices=self.supported_formats(),
                             default=self.TEXT_FORMAT,
                             help="Output format.")
 
-    def get_row_data(self, obj, **options):
+    def get_row_data(self, obj, **options):  # noqa: D102
         raise NotImplementedError(
             "%s must implement get_row_data() returning a mapping with keys %s"
             % (type(self).__name__, tuple(self.OUTPUT_FIELDS)))
@@ -49,14 +49,14 @@ class OutputFormatMixin:
                 % (type(self).__name__, ", ".join(missing)))
         return [data[field] for field in self.OUTPUT_FIELDS]
 
-    def print_text(self, rows, **options):
+    def print_text(self, rows, **options):  # noqa: D102
         self.stdout.write(" | ".join(self.OUTPUT_FIELDS))
         for obj in rows:
             self.stdout.write(
                 " | ".join(str(value)
                            for value in self._row_values(obj, **options)))
 
-    def print_delimited(self, rows, delimiter, **options):
+    def print_delimited(self, rows, delimiter, **options):  # noqa: D102
         stream = StringIO()
         writer = csv.writer(stream, delimiter=delimiter)
         writer.writerow(self.OUTPUT_FIELDS)
@@ -64,7 +64,7 @@ class OutputFormatMixin:
             writer.writerow(self._row_values(obj, **options))
         self.stdout.write(stream.getvalue(), ending="")
 
-    def print_formatted(self, rows, **options):
+    def print_formatted(self, rows, **options):  # noqa: D102
         output_format = options["format"]
         if output_format == self.TEXT_FORMAT:
             self.print_text(rows, **options)
@@ -80,10 +80,10 @@ class OutputFormatMixin:
 class ConfirmOptionMixin:
     """Add a ``-y`` option and a ``confirm()`` helper that prompts unless it's set."""
 
-    def add_confirm_option(self, parser):
+    def add_confirm_option(self, parser):  # noqa: D102
         parser.add_argument('-y', action='store_true')
 
-    def confirm(self, message, **options):
+    def confirm(self, message, **options):  # noqa: D102
         if not options.get('y', False):
             answer = None
             while not answer or answer not in "yn":
@@ -100,10 +100,10 @@ class ConfirmOptionMixin:
 class QuitOptionMixin:
     """Add a ``-q``/``--quit`` option that silences ``self.stdout``/``self.stderr``."""
 
-    def add_quit_option(self, parser):
+    def add_quit_option(self, parser):  # noqa: D102
         parser.add_argument('-q', '--quit', action='store_true',
                             help="Don't output to standard output.")
 
-    def if_needed_make_quit(self, **options):
+    def if_needed_make_quit(self, **options):  # noqa: D102
         if options.get('quit', False):
             self.stderr = self.stdout = StringIO()

--- a/django_boost/management/templates.py
+++ b/django_boost/management/templates.py
@@ -17,6 +17,7 @@ class TemplateCommand(CommandVersion, DjangoTemplateCommand):
     """Django's own ``TemplateCommand`` plus ``--version`` support and a django-boost app template default."""
 
     def handle_template(self, template, subdir):
+        """Resolve the template directory, overlaying django-boost's extras onto the built-in default."""
         base = super().handle_template(template, subdir)
         # Only enhance the built-in template; a user-supplied --template is left untouched.
         if template is not None:

--- a/django_boost/middleware/__init__.py
+++ b/django_boost/middleware/__init__.py
@@ -55,7 +55,7 @@ class RedirectCorrectHostnameMiddleware(MiddlewareMixin):
     but it is useful when the setting is troublesome or when using services such as heroku.
     """
 
-    def process_request(self, request):
+    def process_request(self, request):  # noqa: D102
         # Return the redirect from process_request rather than overriding
         # __call__, so MiddlewareMixin's own __call__/__acall__ short-circuit
         # correctly under both WSGI and ASGI. A synchronous __call__ override
@@ -93,6 +93,7 @@ class HttpStatusCodeExceptionMiddleware(MiddlewareMixin):
     """
 
     def get_template_from_status_code(self, status_code, request=None):
+        """Render the status page template for ``status_code``, falling back to a plain-text message."""
         message = STATUS_MESSAGES[status_code]
         try:
             if settings.DEBUG:
@@ -107,6 +108,7 @@ class HttpStatusCodeExceptionMiddleware(MiddlewareMixin):
             return "%s %s" % (status_code, message)
 
     def process_exception(self, request, e):
+        """Turn an ``HttpExceptionBase`` into its response, or a redirect for ``HttpRedirectExceptionBase``."""
         if isinstance(e, HttpRedirectExceptionBase):
             return e.response_class(e.url)
         elif isinstance(e, HttpExceptionBase):

--- a/django_boost/middleware/html.py
+++ b/django_boost/middleware/html.py
@@ -42,6 +42,7 @@ class SpaceLessMiddleware(MiddlewareMixin):
     def process_response(
             self, request: HttpRequest,
             response: HttpResponseBase) -> HttpResponseBase:
+        """Compress an HTML response's body, streaming or fixed, in place."""
         if 'text/html' in response.get('Content-Type', ''):
             if response.streaming:
                 # streaming is only True for StreamingHttpResponse, which is

--- a/django_boost/models/deletion.py
+++ b/django_boost/models/deletion.py
@@ -42,6 +42,7 @@ class LogicalDeletionCollector(Collector):
         self.deleted_at = deleted_at
 
     def can_fast_delete(self, objs, from_field=None):
+        """Disable Django's fast-delete path for models that use logical deletion."""
         model = getattr(objs, 'model', None)
         if model is None:
             if hasattr(objs, '_meta'):
@@ -53,11 +54,12 @@ class LogicalDeletionCollector(Collector):
         return super().can_fast_delete(objs, from_field=from_field)
 
     def get_deleted_value(self, model):
+        """Return the explicit ``deleted_at`` override, or ``model``'s own default."""
         if self.deleted_at is not None:
             return self.deleted_at
         return model.get_deleted_value()
 
-    def delete(self):
+    def delete(self):  # noqa: D102
         for model, instances in self.data.items():
             self.data[model] = sorted(instances, key=attrgetter('pk'))
 

--- a/django_boost/models/fields/__init__.py
+++ b/django_boost/models/fields/__init__.py
@@ -36,7 +36,7 @@ class ColorCodeField(CharField):
             self.normalize = self._no_convert
         super().__init__(*args, **kwargs)
 
-    def deconstruct(self):
+    def deconstruct(self):  # noqa: D102
         name, path, args, kwargs = super().deconstruct()
         if self.upper:
             kwargs["upper"] = True
@@ -53,13 +53,13 @@ class ColorCodeField(CharField):
     def _no_convert(self, value):
         return value
 
-    def pre_save(self, model_instance, add):
+    def pre_save(self, model_instance, add):  # noqa: D102
         return self.normalize(super().pre_save(model_instance, add))
 
-    def to_python(self, value):
+    def to_python(self, value):  # noqa: D102
         return self.normalize(super().to_python(value))
 
-    def formfield(self, **kwargs):
+    def formfield(self, **kwargs):  # noqa: D102
         return super().formfield(**{
             'form_class': fields.ColorCodeField,
             **kwargs,
@@ -94,7 +94,7 @@ class SplitDateTimeField(models.DateTimeField):
     The effect on DB is the same as django.db.models.DateTimeField.
     """
 
-    def formfield(self, **kwargs):
+    def formfield(self, **kwargs):  # noqa: D102
         kwargs.update({'form_class': forms.SplitDateTimeField})
         return super().formfield(**kwargs)
 

--- a/django_boost/models/manager.py
+++ b/django_boost/models/manager.py
@@ -12,15 +12,15 @@ class LogicalDeletionManager(Manager):
 
     delete_flag_field = "deleted_at"
 
-    def get_deleted_flag_field_name(self):
+    def get_deleted_flag_field_name(self):  # noqa: D102
         return self.delete_flag_field
 
-    def get_queryset(self):
+    def get_queryset(self):  # noqa: D102
         qs = LogicalDeletionQuerySet(self.model, using=self._db, hints=self._hints)
         qs.delete_flag_field = self.get_deleted_flag_field_name()
         return qs
 
-    def delete(self, hard=False, deleted_at=None):
+    def delete(self, hard=False, deleted_at=None):  # noqa: D102
         return self.get_queryset().delete(hard=hard, deleted_at=deleted_at)
 
     def alive(self):

--- a/django_boost/models/mixins.py
+++ b/django_boost/models/mixins.py
@@ -61,9 +61,11 @@ class LogicalDeletionMixin(models.Model):
 
     @classmethod
     def get_deleted_value(cls):
+        """Return the default ``deleted_at`` timestamp; override to use a different sentinel."""
         return now()
 
     def delete(self, using=None, keep_parents=False, hard=False, deleted_at=None):
+        """Mark the instance dead, or physically delete it when ``hard=True``."""
         if hard:
             return super().delete(using=using, keep_parents=keep_parents)
         if self.pk is None:

--- a/django_boost/models/query.py
+++ b/django_boost/models/query.py
@@ -13,7 +13,7 @@ class LogicalDeletionQuerySet(QuerySet):
 
     delete_flag_field = "deleted_at"
 
-    def get_delete_flag_field_name(self):
+    def get_delete_flag_field_name(self):  # noqa: D102
         return self.delete_flag_field
 
     def _clone(self):
@@ -26,6 +26,7 @@ class LogicalDeletionQuerySet(QuerySet):
         return clone
 
     def delete(self, hard=False, deleted_at=None):
+        """Mark matched rows dead, or physically delete them when ``hard=True``."""
         if hard:
             return super().delete()
         if hasattr(self, '_not_support_combined_queries'):
@@ -59,11 +60,11 @@ class LogicalDeletionQuerySet(QuerySet):
     delete.alters_data = True
     delete.queryset_only = True
 
-    def alive(self):
+    def alive(self):  # noqa: D102
         field_name = self.get_delete_flag_field_name()
         return self.filter(**{field_name: None})
 
-    def dead(self):
+    def dead(self):  # noqa: D102
         field_name = self.get_delete_flag_field_name()
         return self.exclude(**{field_name: None})
 

--- a/django_boost/template/base.py
+++ b/django_boost/template/base.py
@@ -19,6 +19,7 @@ class StrictInvalidTemplateVariable(str):
     default_message = "Template variable or property '{name}' is invalid or missing."
 
     def __new__(cls, message=None, exception_class=ValueError):
+        """Validate ``exception_class`` and ``message`` before building the ``'%s'`` sentinel instance."""
         if not (isinstance(exception_class, type) and issubclass(exception_class, Exception)):
             raise TypeError("exception_class must be an Exception subclass, "
                             "got %r." % (exception_class,))

--- a/django_boost/test/testcase.py
+++ b/django_boost/test/testcase.py
@@ -16,18 +16,18 @@ __unittest = True
 class TestCase(DjangoTestCase):
     """Django's own ``TestCase`` plus ``assertStatusCode*`` assertions."""
 
-    def assertStatusCodeEqual(self, response: HttpResponseBase, code: int,
+    def assertStatusCodeEqual(self, response: HttpResponseBase, code: int,  # noqa: D102
                               msg: object = None) -> None:
         self.assertEqual(response.status_code, code, msg)
 
-    def assertStatusCodeNotEqual(self, response: HttpResponseBase, code: int,
+    def assertStatusCodeNotEqual(self, response: HttpResponseBase, code: int,  # noqa: D102
                                  msg: object = None) -> None:
         self.assertNotEqual(response.status_code, code, msg)
 
-    def assertStatusCodeIn(self, response: HttpResponseBase,
+    def assertStatusCodeIn(self, response: HttpResponseBase,  # noqa: D102
                            codes: Iterable[int], msg: object = None) -> None:
         self.assertIn(response.status_code, codes, msg)
 
-    def assertStatusCodeNotIn(self, response: HttpResponseBase,
+    def assertStatusCodeNotIn(self, response: HttpResponseBase,  # noqa: D102
                               codes: Iterable[int], msg: object = None) -> None:
         self.assertNotIn(response.status_code, codes, msg)

--- a/django_boost/urls/converters/__init__.py
+++ b/django_boost/urls/converters/__init__.py
@@ -27,7 +27,7 @@ class HexConverter:
 
     regex = '[0-9a-fA-F]+'
 
-    def to_url(self, value):
+    def to_url(self, value):  # noqa: D102
         if isinstance(value, int):
             return hex(value)[2:]
         return str(value)
@@ -42,7 +42,7 @@ class OctConverter:
 
     regex = '[0-7]+'
 
-    def to_url(self, value):
+    def to_url(self, value):  # noqa: D102
         if isinstance(value, int):
             return oct(value)[2:]
         return str(value)
@@ -57,39 +57,39 @@ class BinConverter:
 
     regex = '[01]+'
 
-    def to_url(self, value):
+    def to_url(self, value):  # noqa: D102
         if isinstance(value, int):
             return bin(value)[2:]
         return str(value)
 
 
 class HexIntConverter(HexConverter):  # noqa: D101
-    def to_python(self, value):
+    def to_python(self, value):  # noqa: D102
         return int(value, 16)
 
 
 class OctIntConverter(OctConverter):  # noqa: D101
-    def to_python(self, value):
+    def to_python(self, value):  # noqa: D102
         return int(value, 8)
 
 
 class BinIntConverter(BinConverter):  # noqa: D101
-    def to_python(self, value):
+    def to_python(self, value):  # noqa: D102
         return int(value, 2)
 
 
 class HexStrConverter(HexConverter):  # noqa: D101
-    def to_python(self, value):
+    def to_python(self, value):  # noqa: D102
         return value
 
 
 class OctStrConverter(OctConverter):  # noqa: D101
-    def to_python(self, value):
+    def to_python(self, value):  # noqa: D102
         return value
 
 
 class BinStrConverter(BinConverter):  # noqa: D101
-    def to_python(self, value):
+    def to_python(self, value):  # noqa: D102
         return value
 
 

--- a/django_boost/urls/converters/_numeric.py
+++ b/django_boost/urls/converters/_numeric.py
@@ -26,8 +26,8 @@ class BaseSignedNumericConverter(Generic[_T]):
     # mypy 1.x enforces it (mypy 2.x currently doesn't, but don't rely on that).
     _parse: staticmethod[[str], _T]
 
-    def to_python(self, value: str) -> _T:
+    def to_python(self, value: str) -> _T:  # noqa: D102
         return self._parse(value)
 
-    def to_url(self, value: _T | str) -> str:
+    def to_url(self, value: _T | str) -> str:  # noqa: D102
         return str(value)

--- a/django_boost/urls/converters/date.py
+++ b/django_boost/urls/converters/date.py
@@ -39,11 +39,13 @@ class DateConverter:
     regex: ClassVar[str] = REGEX_DATE
 
     def to_url(self, value: datetime | str) -> str:
+        """Render ``value`` as ``Y/M/D``, accepting either a ``datetime`` or an already-formatted string."""
         if isinstance(value, datetime):
             return f"{value.year}/{value.month}/{value.day}"
         return str(value)
 
     def to_python(self, value: datetime | str) -> datetime:
+        """Parse a ``Y/M/D`` string into a ``datetime``, passing an already-parsed ``datetime`` through."""
         if isinstance(value, datetime):
             return value
         # strptime's %Y needs 4 digits, but the regex accepts 1-4; build the

--- a/django_boost/urls/converters/integer.py
+++ b/django_boost/urls/converters/integer.py
@@ -17,10 +17,10 @@ class BaseIntConverter:
 
     regex: ClassVar[str]
 
-    def to_python(self, value: str) -> int:
+    def to_python(self, value: str) -> int:  # noqa: D102
         return int(value)
 
-    def to_url(self, value: int | str) -> str:
+    def to_url(self, value: int | str) -> str:  # noqa: D102
         return str(value)
 
 

--- a/django_boost/urls/static.py
+++ b/django_boost/urls/static.py
@@ -30,7 +30,7 @@ class StaticFileConnector:
                                  StaticView.as_view(static_name=full_path)))
 
     @property
-    def urls(self):
+    def urls(self):  # noqa: D102
         return self._urls
 
 

--- a/django_boost/utils/html.py
+++ b/django_boost/utils/html.py
@@ -31,7 +31,7 @@ class HTMLSpaceLessCompressor(HTMLParser):
         self._pending_ws = ''
         self._run_started = False
 
-    def handle_data(self, data: str) -> None:
+    def handle_data(self, data: str) -> None:  # noqa: D102
         if self._raw_depth > 0:
             # Raw CDATA (script/style): escaping would corrupt the JS/CSS.
             self.buffer.write(data)
@@ -55,7 +55,7 @@ class HTMLSpaceLessCompressor(HTMLParser):
         self._pending_ws = data[len(stripped):]
         self.buffer.write(escape(stripped, quote=False))
 
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:  # noqa: D102
         self._end_run()
         self.buffer.write("<%s" % tag)
         if attrs:
@@ -67,7 +67,7 @@ class HTMLSpaceLessCompressor(HTMLParser):
         elif tag in self.WHITESPACE_PRESERVING_ELEMENTS:
             self._preserve_depth += 1
 
-    def handle_endtag(self, tag: str) -> None:
+    def handle_endtag(self, tag: str) -> None:  # noqa: D102
         self._end_run()
         self.buffer.write("</%s>" % tag)
         if tag in self.RAW_TEXT_ELEMENTS:
@@ -75,7 +75,7 @@ class HTMLSpaceLessCompressor(HTMLParser):
         elif tag in self.WHITESPACE_PRESERVING_ELEMENTS:
             self._preserve_depth -= 1
 
-    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:  # noqa: D102
         self._end_run()
         self.buffer.write("<%s" % tag)
         if attrs:
@@ -83,11 +83,11 @@ class HTMLSpaceLessCompressor(HTMLParser):
             self.buffer.write(self._render_attrs(attrs))
         self.buffer.write("/>")
 
-    def handle_decl(self, decl: str) -> None:
+    def handle_decl(self, decl: str) -> None:  # noqa: D102
         self._end_run()
         self.buffer.write("<!%s>" % decl)
 
-    def handle_comment(self, data: str) -> None:
+    def handle_comment(self, data: str) -> None:  # noqa: D102
         # Comments are dropped, but a comment still ends the current text run
         # so the text on either side is stripped separately, as with a tag.
         self._end_run()
@@ -98,6 +98,7 @@ class HTMLSpaceLessCompressor(HTMLParser):
             for name, value in attrs)
 
     def close(self) -> None:
+        """Close the parser, then drop the last text run's trailing whitespace."""
         # super().close() flushes text the parser was still buffering (e.g. a
         # trailing "&" that looked like the start of an entity); _end_run()
         # then drops that last run's trailing whitespace.
@@ -128,6 +129,7 @@ class HTMLSpaceLessCompressor(HTMLParser):
         return self._drain()
 
     def compress(self, data: str) -> str:
+        """Compress a single, already-complete string in one call."""
         return self.feed_chunk(data) + self.finalize()
 
 

--- a/django_boost/validators/collection.py
+++ b/django_boost/validators/collection.py
@@ -23,7 +23,7 @@ class ContainAnyValidator(BaseValidator):
         """Delegate to ``BaseValidator`` so ``limit_value`` supports validator equality checks."""
         super().__init__(elements, message)
 
-    def __call__(self, value: Any) -> None:
+    def __call__(self, value: Any) -> None:  # noqa: D102
         if not contain_any(value, self.limit_value):
             message: Any = self.message
             try:

--- a/django_boost/validators/integer.py
+++ b/django_boost/validators/integer.py
@@ -28,7 +28,7 @@ class NonZeroValidator(BaseValidator):
         """Delegate to ``BaseValidator`` so ``limit_value`` supports validator equality checks."""
         super().__init__(None, message)
 
-    def __call__(self, value: Any) -> None:
+    def __call__(self, value: Any) -> None:  # noqa: D102
         if value == 0:
             raise ValidationError(self.message, code=self.code)
 

--- a/django_boost/validators/json.py
+++ b/django_boost/validators/json.py
@@ -25,7 +25,7 @@ class JsonValidator(BaseValidator):
         """Delegate to ``BaseValidator`` so ``limit_value`` supports validator equality checks."""
         super().__init__(None, message)
 
-    def __call__(self, value: Any) -> None:
+    def __call__(self, value: Any) -> None:  # noqa: D102
         try:
             json.loads(value)
         except JSONDecodeError:

--- a/django_boost/views/base.py
+++ b/django_boost/views/base.py
@@ -117,7 +117,7 @@ class StaticResponseMixin:
 class StaticView(StaticResponseMixin, _View):
     """View that serves a single static file, e.g. via ``include_static_files``."""
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):  # noqa: D102
         try:
             return self.create_response()
         except FileNotFoundError:

--- a/django_boost/views/generic.py
+++ b/django_boost/views/generic.py
@@ -85,7 +85,7 @@ class BaseModelCLUDViews:
             model_name = None
         self.app_name = app_name or model_name
 
-    def get_success_url(self):
+    def get_success_url(self):  # noqa: D102
         if self.success_url is None:
             return reverse('%s:list' % self.app_name)
         return self.success_url
@@ -102,32 +102,32 @@ class BaseModelCLUDViews:
             view_kwargs['fields'] = '__all__'
         return view_kwargs
 
-    def update(self, request, *args, **kwargs):
+    def update(self, request, *args, **kwargs):  # noqa: D102
         view_kwargs = self._form_view_kwargs(self.update_view)
         view = self._as_view(self.update_view, **view_kwargs)
         return view(request, *args, **kwargs)
 
-    def create(self, request, *args, **kwargs):
+    def create(self, request, *args, **kwargs):  # noqa: D102
         view_kwargs = self._form_view_kwargs(self.create_view)
         view = self._as_view(self.create_view, **view_kwargs)
         return view(request, *args, **kwargs)
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request, *args, **kwargs):  # noqa: D102
         view_kwargs = {'success_url': self.get_success_url(), }
         view = self._as_view(self.delete_view, **view_kwargs)
         return view(request, *args, **kwargs)
 
-    def list(self, request, *args, **kwargs):
+    def list(self, request, *args, **kwargs):  # noqa: D102
         view_kwargs = {}
         view = self._as_view(self.list_view, **view_kwargs)
         return view(request, *args, **kwargs)
 
-    def detail(self, request, *args, **kwargs):
+    def detail(self, request, *args, **kwargs):  # noqa: D102
         view_kwargs = {}
         view = self._as_view(self.detail_view, **view_kwargs)
         return view(request, *args, **kwargs)
 
-    def get_urls(self):
+    def get_urls(self):  # noqa: D102
         urlpatterns = []
         if self.list_view:
             urlpatterns += [path(self.list_url_pattern,
@@ -147,7 +147,7 @@ class BaseModelCLUDViews:
         return urlpatterns
 
     @property
-    def urls(self):
+    def urls(self):  # noqa: D102
         return (self.get_urls(), self.app_name)
 
 

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -33,7 +33,7 @@ class CSRFExemptMixin:
     """Mixin that exempts the view's ``dispatch()`` from CSRF protection."""
 
     @method_decorator(csrf_exempt)
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):  # noqa: D102
         return super().dispatch(request, *args, **kwargs)
 
 
@@ -42,7 +42,7 @@ class DynamicRedirectMixin(RedirectURLMixin):
 
     success_url = None
 
-    def get_success_url(self):
+    def get_success_url(self):  # noqa: D102
         url = self.get_redirect_url()
         return url or self.success_url or super().get_success_url()
 
@@ -54,7 +54,7 @@ class RedirectToDetailMixin:
     url_kwarg: str = 'pk'
     object_field_name: str = 'pk'
 
-    def get_success_url(self):
+    def get_success_url(self):  # noqa: D102
         field = getattr(self.object, self.object_field_name)
         kw = {self.url_kwarg: field}
         return reverse(self.success_url_name, kwargs=kw)
@@ -66,7 +66,7 @@ class AllowContentTypeMixin:
     allowed_content_types: Sequence[str] | None = None
     strictly = True
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):  # noqa: D102
         allow_types = self.get_allowed_content_types()
         if self.strictly and request.content_type not in allow_types:
             return HttpResponseUnsupportedMediaType('415 '
@@ -74,7 +74,7 @@ class AllowContentTypeMixin:
                                                     content_type='text/html')
         return super().dispatch(request, *args, **kwargs)
 
-    def get_allowed_content_types(self):
+    def get_allowed_content_types(self):  # noqa: D102
         if self.allowed_content_types is None:
             return []
         return self.allowed_content_types
@@ -87,13 +87,14 @@ class LimitedTermMixin:
     start_datetime = None
     end_datetime = None
 
-    def get_start_datetime(self):
+    def get_start_datetime(self):  # noqa: D102
         return self.start_datetime
 
-    def get_end_datetime(self):
+    def get_end_datetime(self):  # noqa: D102
         return self.end_datetime
 
     def is_allowed_term(self, access_datetime):
+        """Return True if access_datetime falls within [start_datetime, end_datetime), either bound optional."""
         start_datetime = self.get_start_datetime()
         end_datetime = self.get_end_datetime()
         if end_datetime is start_datetime is None:
@@ -104,7 +105,7 @@ class LimitedTermMixin:
             return access_datetime < end_datetime
         return start_datetime < access_datetime < end_datetime
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):  # noqa: D102
         if not self.is_allowed_term(now()):
             raise self.exception_class
         return super().dispatch(request, *args, **kwargs)
@@ -119,6 +120,7 @@ class JsonRequestMixin(AllowContentTypeMixin):
     encoding = 'utf-8'
 
     def get_encoding(self):
+        """Return the charset declared on the request, or ``self.encoding`` as fallback."""
         # Honor a charset declared on the request; fall back to the default.
         return self.request.content_params.get('charset') or self.encoding
 
@@ -131,6 +133,7 @@ class JsonRequestMixin(AllowContentTypeMixin):
 
     @property
     def json(self):
+        """Lazily parse and cache the request body as JSON."""
         if hasattr(self, "_json"):
             return self._json
         setattr(self, "_json", self.__json())
@@ -148,13 +151,14 @@ class JsonResponseMixin:
     extra_context = None
 
     def get_context_data(self, **kwargs):
+        """Merge ``extra_context`` with the given kwargs into a fresh dict."""
         # Copy extra_context into a fresh dict; updating it in place would
         # mutate the shared class attribute and leak kwargs across requests.
         context = dict(self.extra_context or {})
         context.update(kwargs)
         return context
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):  # noqa: D102
         return self.response_class(self.get_context_data())
 
     post = get
@@ -183,10 +187,10 @@ class AnonymousRequiredMixin:
 
     redirect_authenticated_url = None
 
-    def get_redirect_authenticated_url(self):
+    def get_redirect_authenticated_url(self):  # noqa: D102
         return self.redirect_authenticated_url or settings.LOGIN_REDIRECT_URL
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):  # noqa: D102
         if request.user.is_authenticated:
             return redirect(self.get_redirect_authenticated_url())
         return super().dispatch(request, *args, **kwargs)
@@ -229,6 +233,7 @@ class ReAuthenticationRequiredMixin(AccessMixin):
     logout = False
 
     def get_interval(self):
+        """Return ``interval`` as a ``timedelta``, raising if it's unset."""
         if self.interval is None:
             raise ImproperlyConfigured(
                 "%(cls)s is missing interval."
@@ -242,12 +247,13 @@ class ReAuthenticationRequiredMixin(AccessMixin):
         return timedelta(seconds=self.interval)
 
     def need_reauthentication(self, user, delta):
+        """Return True if ``user`` last logged in more than ``delta`` ago."""
         if user.last_login is None:
             # Never recorded a login (last_login is nullable); require re-auth.
             return True
         return (user.last_login + delta) < now()
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):  # noqa: D102
         if not request.user.is_authenticated:
             return self.handle_no_permission()
 
@@ -274,7 +280,7 @@ class StaffMemberRequiredMixin(AccessMixin):
     permission_denied_message = 'Only staff members can access'
     superuser = False
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):  # noqa: D102
         if request.user.is_staff:
             return super().dispatch(request, *args, **kwargs)
         if self.superuser and request.user.is_superuser:
@@ -287,7 +293,7 @@ class SuperuserRequiredMixin(AccessMixin):
 
     permission_denied_message = 'Only super user can access'
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):  # noqa: D102
         if request.user.is_superuser:
             return super().dispatch(request, *args, **kwargs)
         return self.handle_no_permission()
@@ -300,7 +306,7 @@ class ViewUserKwargsMixin:
     consumes the ``user`` kwarg on the form side.
     """
 
-    def get_form_kwargs(self):
+    def get_form_kwargs(self):  # noqa: D102
         kwargs = super().get_form_kwargs()
         kwargs['user'] = self.request.user
         return kwargs
@@ -313,12 +319,12 @@ class UserAgentMixin:
     tablet_template_name: str | None = None
     mobile_template_name: str | None = None
 
-    def setup(self, request, *args, **kwargs):
+    def setup(self, request, *args, **kwargs):  # noqa: D102
         super().setup(request, *args, **kwargs)
         user_agent = request.META.get('HTTP_USER_AGENT', '')
         self.request.user_agent = parse_user_agent(user_agent)
 
-    def get_template_names(self):
+    def get_template_names(self):  # noqa: D102
         tmp = super().get_template_names()
         if self.request.user_agent.is_pc and self.pc_template_name:
             return [self.pc_template_name] + tmp

--- a/django_boost/views/simple.py
+++ b/django_boost/views/simple.py
@@ -56,6 +56,6 @@ class StringView(ResponseContentMixin, View):
 
     """
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):  # noqa: D102
         content = self.get_content(**kwargs)
         return self.content_to_response(content)

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,7 @@ deps =
 commands = flake8 .
 
 [flake8]
-ignore = D102
-exclude = 
+exclude =
     .git,
     .tox,
     .vscode,


### PR DESCRIPTION
## Summary
Stacked on the D101 PR. Enable flake8's `D102` (missing docstring in public method) check, the last of the docstring checks disabled via `tox.ini`'s `ignore` list — `tox.ini` no longer needs an `ignore` line at all. 131 violations split into one commit per module group.

## Notes
Most of the 131 are suppressed with `# noqa: D102` (104 of 131) rather than given a restating docstring, for the same reasons established in the D101/D103 rounds: the containing class's docstring already names/explains the method (e.g. `CSRFExemptMixin`'s docstring already says what its `dispatch()` override does), or the method is a well-known framework protocol override (Django's URL converter `to_python`/`to_url`, `HTMLParser`'s `handle_*` callbacks, `DATABASE_ROUTERS`' `db_for_read`/`db_for_write`/etc.) whose behavior is standard. The 27 with real docstrings are the ones with non-obvious branching/fallback logic not covered elsewhere (e.g. `LogicalDeletionCollector.can_fast_delete`, `AdminSiteLog.get_log_entry_model`, `HTMLSpaceLessCompressor.close`).