### PR TITLE
Fix ReAuthenticationRequiredMixin(logout=True) 405 on Django 5.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - Comparing two `JsonValidator` (or two `NonZeroValidator`) instances no longer raises `AttributeError`.
 - The `mimetype` template filter now returns an empty string for an unknown extension (instead of the literal `None`) and accepts a non-string value instead of raising `TypeError`.
+- `ReAuthenticationRequiredMixin(logout=True)` no longer returns a 405 instead of logging out on Django 5.0+.
 
 ## [3.2.4] - 2026-07-11
 

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -7,9 +7,9 @@ from datetime import timedelta
 from typing import Sequence
 
 from django.conf import settings
+from django.contrib.auth import logout as auth_logout
 from django.contrib.auth.mixins import AccessMixin
-from django.contrib.auth.views import (RedirectURLMixin, logout_then_login,
-                                       redirect_to_login)
+from django.contrib.auth.views import RedirectURLMixin, redirect_to_login
 from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404, JsonResponse
 from django.shortcuts import redirect
@@ -259,9 +259,11 @@ class ReAuthenticationRequiredMixin(AccessMixin):
 
         delta = self.get_interval()
         if self.need_reauthentication(request.user, delta):
-
             if self.logout:
-                return logout_then_login(request, self.get_login_url())
+                # logout_then_login() dispatches to LogoutView, which only
+                # accepts POST from Django 5.0 (GET logout was removed); call
+                # auth_logout() directly so this works for any request method.
+                auth_logout(request)
 
             return redirect_to_login(self.request.get_full_path(),
                                      self.get_login_url(),

--- a/tests/tests/views_mixins/tests.py
+++ b/tests/tests/views_mixins/tests.py
@@ -121,6 +121,15 @@ class TestViewMixins(TestCase):
         self.assertStatusCodeEqual(response, 200)
         self.client.logout()
 
+    def test_re_authentication_required_logout(self):
+        from django.contrib.auth import get_user
+
+        self.client.force_login(self.user)
+        response = self.client.get('/re_auth/logout/')
+        self.assertStatusCodeEqual(response, 302)
+        self.assertEqual(response.url, '/accounts/login/?next=/re_auth/logout/')
+        self.assertFalse(get_user(self.client).is_authenticated)
+
     def test_anonymous_required(self):
         url = '/anonymous_only/'
         response = self.client.get(url)

--- a/tests/tests/views_mixins/urls.py
+++ b/tests/tests/views_mixins/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
          views.LimitedTermAfterStartView.as_view()),
     path('limited_term/after/end/', views.LimitedTermAfterEndView.as_view()),
     path('re_auth/', views.ReAuthenticationRequiredView.as_view()),
+    path('re_auth/logout/', views.ReAuthenticationRequiredLogoutView.as_view()),
     path('anonymous_only/', views.AnonymousRequiredView.as_view()),
     path('anonymous_only/custom/',
          views.AnonymousRequiredCustomRedirectView.as_view()),

--- a/tests/tests/views_mixins/views.py
+++ b/tests/tests/views_mixins/views.py
@@ -88,6 +88,13 @@ class ReAuthenticationRequiredView(ReAuthenticationRequiredMixin,
     interval = 100
 
 
+class ReAuthenticationRequiredLogoutView(ReAuthenticationRequiredMixin,
+                                         TemplateView):
+    template_name = "boost/test/index.html"
+    interval = -1
+    logout = True
+
+
 class AnonymousRequiredView(AnonymousRequiredMixin, TemplateView):
     template_name = "boost/test/index.html"
 


### PR DESCRIPTION
## Summary
`ReAuthenticationRequiredMixin(logout=True)` forwarded the current request (any method, typically GET) to `logout_then_login()`, which dispatches to `LogoutView`. Django 5.0 dropped GET support from `LogoutView` (`http_method_names` became `["post", "options"]`), so a GET now gets a 405 instead of being logged out and redirected. Calls `auth_logout()` directly instead, which has no method restriction, then redirects via the same `redirect_to_login()` already used for `logout=False`.

## Notes
The `logout=True` path had no test coverage before this change (the existing test view only exercises the default `logout=False`).
