### PR TITLE
Add logical deletion date filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ### Added
 
+- `LogicalDeletionModelAdmin` now includes a deletion-date filter with today, 7/30/90-day, older-than-90-day, and inclusive custom-range options.
 - Decimal path converters `decimal`, `signed_decimal`, `positive_decimal`, `negative_decimal`, `non_negative_decimal`, `non_positive_decimal` and `non_zero_decimal`, covering decimal ranges Django's built-in `float` converter cannot express; `decimal` is an alias of `non_negative_decimal`.
 - Float path converters `signed_float`, `positive_float`, `negative_float`, `non_negative_float`, `non_positive_float` and `non_zero_float`, symmetric with the existing signed-integer and decimal converter families; `float` is now an explicit alias of `non_negative_float` (same regex and behavior as before).
 

--- a/README.md
+++ b/README.md
@@ -834,6 +834,22 @@ from django_boost.admin.sites import register_all
 register_all(models, admin_class=admin.CustomAdmin)
 ```
 
+For models using `LogicalDeletionMixin`, `LogicalDeletionModelAdmin` adds the
+hard-delete action plus alive/deleted-state and deletion-date filters. The date
+filter includes common 7/30/90-day periods and an inclusive custom range.
+
+```py
+from django.contrib import admin
+from django_boost.admin import LogicalDeletionModelAdmin
+
+from .models import Article
+
+
+@admin.register(Article)
+class ArticleAdmin(LogicalDeletionModelAdmin):
+    pass
+```
+
 ## Shortcut Functions
 
 ```py

--- a/django_boost/admin/__init__.py
+++ b/django_boost/admin/__init__.py
@@ -8,10 +8,11 @@ from django.contrib.auth.admin import UserAdmin
 from django_boost.forms import UserChangeForm, UserCreationForm
 from django_boost.models import EmailUser
 
+from .filters import LogicalDeletedDateFilter
 from .mixins import LogicalDeletionModelAdminMixin
 from .sites import register_all
 
-__all__ = ["EmailUserAdmin",
+__all__ = ["EmailUserAdmin", "LogicalDeletedDateFilter",
            "LogicalDeletionModelAdmin",
            "register_all"]
 

--- a/django_boost/admin/filters.py
+++ b/django_boost/admin/filters.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
+from datetime import datetime, time, timedelta
+
 from django.contrib import admin
+from django.contrib.admin.filters import ListFilter
+from django.core.exceptions import ValidationError
+from django.forms import DateField
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+
+
+__all__ = ["LogicalDeletedDateFilter", "LogicalDeletedFilter"]
 
 
 class LogicalDeletedFilter(admin.SimpleListFilter):
@@ -23,3 +33,157 @@ class LogicalDeletedFilter(admin.SimpleListFilter):
             return queryset.alive()
         if value == 'dead':
             return queryset.dead()
+
+    def choices(self, changelist):  # noqa: D102
+        for index, choice in enumerate(super().choices(changelist)):
+            if index == 1:
+                choice = dict(choice)
+                choice['query_string'] = changelist.get_query_string(
+                    {self.parameter_name: 'alive'},
+                    [
+                        LogicalDeletedDateFilter.period_parameter,
+                        LogicalDeletedDateFilter.from_parameter,
+                        LogicalDeletedDateFilter.to_parameter,
+                    ],
+                )
+            yield choice
+
+
+class LogicalDeletedDateFilter(admin.FieldListFilter):
+    """Filter logically deleted objects by common periods or an inclusive date range."""
+
+    template = 'boost/admin/logical_deleted_date_filter.html'
+    title = _('deleted date')
+
+    period_parameter = 'deleted_period'
+    from_parameter = 'deleted_from'
+    to_parameter = 'deleted_to'
+
+    def __init__(self, field, request, params, model, model_admin, field_path):  # noqa: D107
+        self.field = field
+        self.field_path = field_path
+        self.lookup_choices = (
+            ('all_deleted', _('All deleted')),
+            ('today', _('Today')),
+            ('past_7_days', _('Past 7 days')),
+            ('past_30_days', _('Past 30 days')),
+            ('past_90_days', _('Past 90 days')),
+            ('older_than_90_days', _('More than 90 days ago')),
+        )
+        ListFilter.__init__(self, request, params, model, model_admin)
+        for parameter in self.expected_parameters():
+            if parameter in params:
+                value = params.pop(parameter)
+                if isinstance(value, (list, tuple)):
+                    value = value[-1]
+                self.used_parameters[parameter] = value
+
+        excluded = set(self.expected_parameters()) | {'delete_state', 'p'}
+        self.preserved_parameters = [
+            (key, value)
+            for key, values in request.GET.lists()
+            if key not in excluded
+            for value in values
+        ]
+        self.errors = []
+
+    def expected_parameters(self):  # noqa: D102
+        return [self.period_parameter, self.from_parameter, self.to_parameter]
+
+    def has_output(self):  # noqa: D102
+        return True
+
+    def choices(self, changelist):  # noqa: D102
+        own_parameters = self.expected_parameters()
+        has_range = bool(self.from_value or self.to_value)
+        yield {
+            'selected': self.value() is None and not has_range,
+            'query_string': changelist.get_query_string(remove=own_parameters),
+            'display': _('All'),
+        }
+        for lookup, title in self.lookup_choices:
+            yield {
+                'selected': self.value() == lookup and not has_range,
+                'query_string': changelist.get_query_string(
+                    {self.period_parameter: lookup},
+                    [self.from_parameter, self.to_parameter, 'delete_state'],
+                ),
+                'display': title,
+            }
+
+    def value(self):
+        """Return the selected preset period."""
+        return self.used_parameters.get(self.period_parameter)
+
+    @property
+    def from_value(self):
+        """Return the submitted inclusive start date."""
+        return self.used_parameters.get(self.from_parameter, '')
+
+    @property
+    def to_value(self):
+        """Return the submitted inclusive end date."""
+        return self.used_parameters.get(self.to_parameter, '')
+
+    def queryset(self, request, queryset):  # noqa: D102
+        if self.from_value or self.to_value:
+            return self._range_queryset(queryset)
+
+        today = self._local_today()
+        tomorrow = self._start_of_day(today + timedelta(days=1))
+        period = self.value()
+        lookups = {}
+        if period == 'all_deleted':
+            lookups[f'{self.field_path}__isnull'] = False
+        elif period == 'today':
+            lookups[f'{self.field_path}__gte'] = self._start_of_day(today)
+            lookups[f'{self.field_path}__lt'] = tomorrow
+        elif period in {'past_7_days', 'past_30_days', 'past_90_days'}:
+            days = int(period.split('_')[1])
+            lookups[f'{self.field_path}__gte'] = self._start_of_day(
+                today - timedelta(days=days - 1))
+            lookups[f'{self.field_path}__lt'] = tomorrow
+        elif period == 'older_than_90_days':
+            lookups[f'{self.field_path}__lt'] = self._start_of_day(
+                today - timedelta(days=89))
+        else:
+            return queryset
+        return queryset.filter(**lookups)
+
+    def _range_queryset(self, queryset):
+        date_field = DateField(input_formats=['%Y-%m-%d'])
+        start = end = None
+        try:
+            if self.from_value:
+                start = date_field.clean(self.from_value)
+            if self.to_value:
+                end = date_field.clean(self.to_value)
+        except ValidationError as error:
+            self.errors.extend(error.messages)
+            return queryset
+
+        if start and end and start > end:
+            self.errors.append(_('Start date must be on or before end date.'))
+            return queryset
+
+        lookups = {}
+        if start:
+            lookups[f'{self.field_path}__gte'] = self._start_of_day(start)
+        if end:
+            lookups[f'{self.field_path}__lt'] = self._start_of_day(
+                end + timedelta(days=1))
+        return queryset.filter(**lookups)
+
+    @staticmethod
+    def _local_today():
+        now = timezone.now()
+        if timezone.is_aware(now):
+            now = timezone.localtime(now)
+        return now.date()
+
+    @staticmethod
+    def _start_of_day(value):
+        result = datetime.combine(value, time.min)
+        if timezone.is_aware(timezone.now()):
+            result = timezone.make_aware(result, timezone.get_current_timezone())
+        return result

--- a/django_boost/admin/mixins.py
+++ b/django_boost/admin/mixins.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from .actions import hard_delete_selected
-from .filters import LogicalDeletedFilter
+from .filters import LogicalDeletedDateFilter, LogicalDeletedFilter
 
 
 class LogicalDeletionModelAdminMixin:
-    """Mixin that adds the hard-delete action and dead/alive filter to a ``ModelAdmin``."""
+    """Mixin adding hard deletion and logical-deletion filters to a ``ModelAdmin``."""
 
     def hard_delete_queryset(self, request, queryset):  # noqa: D102
         queryset.delete(hard=True)
@@ -24,5 +24,11 @@ class LogicalDeletionModelAdminMixin:
 
     def get_list_filter(self, request):  # noqa: D102
         filters = super().get_list_filter(request)
-        filters = list(filters) + [LogicalDeletedFilter]
+        manager = self.model._default_manager
+        get_field_name = getattr(manager, 'get_deleted_flag_field_name', None)
+        field_name = get_field_name() if get_field_name else 'deleted_at'
+        filters = list(filters) + [
+            LogicalDeletedFilter,
+            (field_name, LogicalDeletedDateFilter),
+        ]
         return filters

--- a/django_boost/templates/boost/admin/logical_deleted_date_filter.html
+++ b/django_boost/templates/boost/admin/logical_deleted_date_filter.html
@@ -1,0 +1,37 @@
+{% load i18n %}
+<details data-filter-title="{{ title }}" open>
+  <summary>
+    {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
+  </summary>
+  <ul>
+  {% for choice in choices %}
+    <li{% if choice.selected %} class="selected"{% endif %}>
+      <a href="{{ choice.query_string|iriencode }}">{{ choice.display }}</a>
+    </li>
+  {% endfor %}
+  </ul>
+  <form method="get" style="box-sizing: border-box; padding: 0 15px 12px;">
+    {% for name, value in spec.preserved_parameters %}
+      <input type="hidden" name="{{ name }}" value="{{ value }}">
+    {% endfor %}
+    <p style="margin: 0 0 8px;">
+      <label for="boost-deleted-from" style="display: block; margin-bottom: 4px;">{% translate "From" %}</label>
+      <input id="boost-deleted-from" type="date" name="{{ spec.from_parameter }}" value="{{ spec.from_value }}" style="box-sizing: border-box; width: 100%;">
+    </p>
+    <p style="margin: 0 0 8px;">
+      <label for="boost-deleted-to" style="display: block; margin-bottom: 4px;">{% translate "To" %}</label>
+      <input id="boost-deleted-to" type="date" name="{{ spec.to_parameter }}" value="{{ spec.to_value }}" style="box-sizing: border-box; width: 100%;">
+    </p>
+    {% if spec.errors %}
+      <ul class="errorlist" style="margin: 0 0 8px; padding: 0;">
+      {% for error in spec.errors %}
+        <li>{{ error }}</li>
+      {% endfor %}
+      </ul>
+    {% endif %}
+    <div style="display: flex; align-items: center; gap: 8px;">
+      <button type="submit" class="button">{% translate "Apply" %}</button>
+      <a href="{{ choices.0.query_string|iriencode }}">{% translate "Clear" %}</a>
+    </div>
+  </form>
+</details>

--- a/docs/admin_site_utilities.rst
+++ b/docs/admin_site_utilities.rst
@@ -5,3 +5,25 @@ Admin Site Utilities
 
 
 .. autofunction:: django_boost.admin.sites.register_all
+
+
+Logical deletion admin
+----------------------
+
+Use :class:`django_boost.admin.LogicalDeletionModelAdmin` for a model based on
+:class:`django_boost.models.LogicalDeletionMixin`::
+
+    from django.contrib import admin
+    from django_boost.admin import LogicalDeletionModelAdmin
+
+    from .models import Article
+
+
+    @admin.register(Article)
+    class ArticleAdmin(LogicalDeletionModelAdmin):
+        pass
+
+The change list includes filters for alive/deleted state and deletion date.
+The deletion-date filter offers all deleted items, today, the past 7, 30, or
+90 calendar days, items older than 90 days, and an inclusive custom date
+range. Date boundaries use Django's current time zone.

--- a/tests/tests/admin/test_filters.py
+++ b/tests/tests/admin/test_filters.py
@@ -1,0 +1,354 @@
+from datetime import datetime, timedelta, timezone as datetime_timezone
+from unittest import mock
+from zoneinfo import ZoneInfo
+
+from django.contrib.admin import AdminSite, ModelAdmin
+from django.template.loader import render_to_string
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from django_boost.admin.filters import LogicalDeletedDateFilter, LogicalDeletedFilter
+from django_boost.admin.mixins import LogicalDeletionModelAdminMixin
+from tests.tests.logical_deletion.models import LogicalDeletionModel
+
+
+class _AllowAllUser:
+    is_active = True
+    is_staff = True
+    is_superuser = True
+
+    def has_perm(self, perm, obj=None):
+        return True
+
+
+class _LogicalDeletionAdmin(LogicalDeletionModelAdminMixin, ModelAdmin):
+    pass
+
+
+class LogicalDeletedDateFilterTests(TestCase):
+    """Tests for deletion-date presets and inclusive custom ranges."""
+
+    model = LogicalDeletionModel
+    now = datetime(2026, 7, 11, 12, tzinfo=datetime_timezone.utc)
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.model_admin = ModelAdmin(self.model, AdminSite())
+        self.alive = self.model.objects.create(name='alive')
+        self.deleted = {
+            days: self.model.objects.create(
+                name=str(days), deleted_at=self.now - timedelta(days=days))
+            for days in (0, 6, 7, 29, 89, 90)
+        }
+
+    def _filter(self, **parameters):
+        request = self.factory.get('/', parameters)
+        params = {key: request.GET.getlist(key) for key in request.GET}
+        field = self.model._meta.get_field('deleted_at')
+        return LogicalDeletedDateFilter(
+            field, request, params, self.model, self.model_admin,
+            field_path='deleted_at')
+
+    def _filtered_ids(self, **parameters):
+        filter_ = self._filter(**parameters)
+        with mock.patch('django_boost.admin.filters.timezone.now', return_value=self.now):
+            queryset = filter_.queryset(None, self.model.objects.all())
+        return set(queryset.values_list('pk', flat=True))
+
+    def _changelist(self, **parameters):
+        request = self.factory.get('/', parameters)
+        request.user = _AllowAllUser()
+        model_admin = _LogicalDeletionAdmin(self.model, AdminSite())
+        return model_admin.get_changelist_instance(request)
+
+    @staticmethod
+    def _date_filter(changelist):
+        return next(
+            filter_
+            for filter_ in changelist.filter_specs
+            if isinstance(filter_, LogicalDeletedDateFilter)
+        )
+
+    def test_all_deleted_excludes_alive_objects(self):
+        self.assertEqual(
+            self._filtered_ids(deleted_period='all_deleted'),
+            {item.pk for item in self.deleted.values()},
+        )
+
+    def test_today_uses_the_current_local_calendar_day(self):
+        self.assertEqual(
+            self._filtered_ids(deleted_period='today'),
+            {self.deleted[0].pk},
+        )
+
+    def test_past_periods_cover_the_named_number_of_calendar_days(self):
+        self.assertEqual(
+            self._filtered_ids(deleted_period='past_7_days'),
+            {self.deleted[0].pk, self.deleted[6].pk},
+        )
+        self.assertEqual(
+            self._filtered_ids(deleted_period='past_30_days'),
+            {self.deleted[days].pk for days in (0, 6, 7, 29)},
+        )
+        self.assertEqual(
+            self._filtered_ids(deleted_period='past_90_days'),
+            {self.deleted[days].pk for days in (0, 6, 7, 29, 89)},
+        )
+
+    def test_older_than_90_days_does_not_overlap_past_90_days(self):
+        self.assertEqual(
+            self._filtered_ids(deleted_period='older_than_90_days'),
+            {self.deleted[90].pk},
+        )
+
+    def test_custom_range_includes_both_submitted_dates(self):
+        self.assertEqual(
+            self._filtered_ids(deleted_from='2026-07-04', deleted_to='2026-07-05'),
+            {self.deleted[6].pk, self.deleted[7].pk},
+        )
+
+    def test_custom_range_accepts_a_single_boundary(self):
+        self.assertEqual(
+            self._filtered_ids(deleted_to='2026-04-12'),
+            {self.deleted[90].pk},
+        )
+
+    def test_custom_range_accepts_start_only(self):
+        self.assertEqual(
+            self._filtered_ids(deleted_from='2026-07-04'),
+            {self.deleted[days].pk for days in (0, 6, 7)},
+        )
+
+    def test_custom_range_same_day_includes_the_whole_day(self):
+        at_start = self.model.objects.create(
+            name='start',
+            deleted_at=datetime(2026, 7, 5, tzinfo=datetime_timezone.utc),
+        )
+        at_end = self.model.objects.create(
+            name='end',
+            deleted_at=datetime(
+                2026, 7, 5, 23, 59, 59, tzinfo=datetime_timezone.utc),
+        )
+        next_day = self.model.objects.create(
+            name='next',
+            deleted_at=datetime(2026, 7, 6, tzinfo=datetime_timezone.utc),
+        )
+
+        filtered_ids = self._filtered_ids(
+            deleted_from='2026-07-05', deleted_to='2026-07-05')
+
+        self.assertEqual(
+            filtered_ids,
+            {self.deleted[6].pk, at_start.pk, at_end.pk},
+        )
+        self.assertNotIn(next_day.pk, filtered_ids)
+
+    def test_no_period_returns_the_unfiltered_queryset(self):
+        expected = set(self.model.objects.values_list('pk', flat=True))
+
+        self.assertEqual(self._filtered_ids(), expected)
+        self.assertEqual(
+            self._filtered_ids(deleted_period='unknown-period'), expected)
+
+    def test_django_42_scalar_parameters_are_not_truncated(self):
+        request = self.factory.get('/', {'deleted_from': '2026-07-04'})
+        field = self.model._meta.get_field('deleted_at')
+
+        filter_ = LogicalDeletedDateFilter(
+            field,
+            request,
+            {'deleted_from': '2026-07-04'},
+            self.model,
+            self.model_admin,
+            field_path='deleted_at',
+        )
+
+        self.assertEqual(filter_.from_value, '2026-07-04')
+
+    def test_invalid_range_is_ignored_and_exposes_an_error(self):
+        filter_ = self._filter(
+            deleted_from='2026-07-12', deleted_to='2026-07-11')
+
+        queryset = filter_.queryset(None, self.model.objects.all())
+
+        self.assertEqual(set(queryset), set(self.model.objects.all()))
+        self.assertEqual(
+            filter_.errors,
+            ['Start date must be on or before end date.'],
+        )
+
+    def test_invalid_date_is_ignored_and_exposes_an_error(self):
+        filter_ = self._filter(deleted_from='not-a-date')
+
+        queryset = filter_.queryset(None, self.model.objects.all())
+
+        self.assertEqual(set(queryset), set(self.model.objects.all()))
+        self.assertTrue(filter_.errors)
+
+    def test_model_admin_changelist_accepts_range_parameters(self):
+        request = self.factory.get(
+            '/', {'deleted_from': '2026-07-04', 'deleted_to': '2026-07-05'})
+        request.user = _AllowAllUser()
+        model_admin = _LogicalDeletionAdmin(self.model, AdminSite())
+
+        changelist = model_admin.get_changelist_instance(request)
+
+        self.assertEqual(
+            set(changelist.result_list.values_list('pk', flat=True)),
+            {self.deleted[6].pk, self.deleted[7].pk},
+        )
+
+    def test_state_filter_returns_alive_and_dead_objects(self):
+        alive = self._changelist(delete_state='alive')
+        dead = self._changelist(delete_state='dead')
+
+        self.assertEqual(
+            set(alive.result_list.values_list('pk', flat=True)),
+            {self.alive.pk},
+        )
+        self.assertEqual(
+            set(dead.result_list.values_list('pk', flat=True)),
+            {item.pk for item in self.deleted.values()},
+        )
+
+    def test_date_filter_choices_select_the_current_preset(self):
+        changelist = self._changelist(
+            deleted_period='past_30_days', delete_state='alive', q='article')
+        choices = list(self._date_filter(changelist).choices(changelist))
+
+        selected = [choice for choice in choices if choice['selected']]
+
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(str(selected[0]['display']), 'Past 30 days')
+        self.assertIn('deleted_period=past_30_days', selected[0]['query_string'])
+        self.assertIn('q=article', selected[0]['query_string'])
+        self.assertNotIn('delete_state', selected[0]['query_string'])
+        self.assertNotIn('deleted_from', selected[0]['query_string'])
+        self.assertNotIn('deleted_to', selected[0]['query_string'])
+
+    def test_custom_range_marks_no_preset_as_selected(self):
+        changelist = self._changelist(
+            deleted_from='2026-07-04', deleted_to='2026-07-05', q='article')
+        choices = list(self._date_filter(changelist).choices(changelist))
+
+        self.assertFalse(any(choice['selected'] for choice in choices))
+        self.assertIn('q=article', choices[0]['query_string'])
+        self.assertNotIn('deleted_from', choices[0]['query_string'])
+        self.assertNotIn('deleted_to', choices[0]['query_string'])
+
+    def test_range_form_preserves_only_unrelated_changelist_parameters(self):
+        filter_ = self._filter(
+            deleted_period='past_30_days',
+            deleted_from='2026-07-04',
+            deleted_to='2026-07-05',
+            delete_state='alive',
+            p='2',
+            q='article',
+            o='1',
+            category=['news', 'release'],
+        )
+
+        self.assertEqual(
+            filter_.preserved_parameters,
+            [
+                ('q', 'article'),
+                ('o', '1'),
+                ('category', 'news'),
+                ('category', 'release'),
+            ],
+        )
+
+    def test_alive_choice_clears_an_active_deletion_date_range(self):
+        request = self.factory.get(
+            '/', {'deleted_from': '2026-07-04', 'deleted_to': '2026-07-05'})
+        request.user = _AllowAllUser()
+        model_admin = _LogicalDeletionAdmin(self.model, AdminSite())
+        changelist = model_admin.get_changelist_instance(request)
+        state_filter = next(
+            filter_
+            for filter_ in changelist.filter_specs
+            if isinstance(filter_, LogicalDeletedFilter)
+        )
+
+        alive_choice = list(state_filter.choices(changelist))[1]
+
+        self.assertIn('delete_state=alive', alive_choice['query_string'])
+        self.assertNotIn('deleted_from', alive_choice['query_string'])
+        self.assertNotIn('deleted_to', alive_choice['query_string'])
+
+    def test_range_form_template_renders_submitted_values_and_errors(self):
+        filter_ = self._filter(
+            deleted_from='2026-07-12', deleted_to='2026-07-11')
+        filter_.queryset(None, self.model.objects.all())
+
+        html = render_to_string(
+            filter_.template,
+            {
+                'title': filter_.title,
+                'choices': [
+                    {
+                        'selected': False,
+                        'query_string': '?',
+                        'display': 'All',
+                    },
+                ],
+                'spec': filter_,
+            },
+        )
+
+        self.assertIn('type="date"', html)
+        self.assertIn('value="2026-07-12"', html)
+        self.assertIn('Start date must be on or before end date.', html)
+
+    def test_today_uses_the_current_non_utc_timezone(self):
+        local_today = self.model.objects.create(
+            name='local',
+            deleted_at=datetime(2026, 7, 11, 15, tzinfo=datetime_timezone.utc),
+        )
+        previous_local_day = self.model.objects.create(
+            name='prior',
+            deleted_at=datetime(
+                2026, 7, 11, 14, 59, 59, tzinfo=datetime_timezone.utc),
+        )
+        now = datetime(2026, 7, 11, 15, 30, tzinfo=datetime_timezone.utc)
+
+        with timezone.override(ZoneInfo('Asia/Tokyo')):
+            with mock.patch(
+                    'django_boost.admin.filters.timezone.now', return_value=now):
+                queryset = self._filter(
+                    deleted_period='today').queryset(
+                        None, self.model.objects.all())
+
+        filtered_ids = set(queryset.values_list('pk', flat=True))
+        self.assertEqual(filtered_ids, {local_today.pk})
+        self.assertNotIn(previous_local_day.pk, filtered_ids)
+
+    def test_custom_range_uses_the_current_non_utc_timezone(self):
+        at_start = self.model.objects.create(
+            name='tzstart',
+            deleted_at=datetime(2026, 7, 11, 15, tzinfo=datetime_timezone.utc),
+        )
+        before_start = self.model.objects.create(
+            name='tzprior',
+            deleted_at=datetime(
+                2026, 7, 11, 14, 59, 59, tzinfo=datetime_timezone.utc),
+        )
+        at_end = self.model.objects.create(
+            name='tzend',
+            deleted_at=datetime(
+                2026, 7, 12, 14, 59, 59, tzinfo=datetime_timezone.utc),
+        )
+        next_day = self.model.objects.create(
+            name='tznext',
+            deleted_at=datetime(2026, 7, 12, 15, tzinfo=datetime_timezone.utc),
+        )
+
+        with timezone.override(ZoneInfo('Asia/Tokyo')):
+            queryset = self._filter(
+                deleted_from='2026-07-12', deleted_to='2026-07-12',
+            ).queryset(None, self.model.objects.all())
+
+        filtered_ids = set(queryset.values_list('pk', flat=True))
+        self.assertEqual(filtered_ids, {at_start.pk, at_end.pk})
+        self.assertNotIn(before_start.pk, filtered_ids)
+        self.assertNotIn(next_day.pk, filtered_ids)

--- a/tests/tests/admin/test_mixins.py
+++ b/tests/tests/admin/test_mixins.py
@@ -1,8 +1,12 @@
 from django.contrib.admin import AdminSite, ModelAdmin
 from django.contrib.auth.models import Group, User
+from django.db import models
 from django.test import RequestFactory, SimpleTestCase
+from django.test.utils import isolate_apps
 
+from django_boost.admin.filters import LogicalDeletedDateFilter, LogicalDeletedFilter
 from django_boost.admin.mixins import LogicalDeletionModelAdminMixin
+from django_boost.models.manager import LogicalDeletionManager
 
 
 class _AllowAllUser:
@@ -47,3 +51,36 @@ class LogicalDeletionAdminActionLeakTests(SimpleTestCase):
         logical_admin = LogicalAdmin(User, site)
 
         self.assertIn("hard_delete_selected", logical_admin.get_actions(self._request()))
+
+    def test_logical_deletion_filters_are_available(self):
+        logical_admin = LogicalAdmin(User, AdminSite())
+
+        self.assertEqual(
+            logical_admin.get_list_filter(self._request()),
+            [
+                LogicalDeletedFilter,
+                ('deleted_at', LogicalDeletedDateFilter),
+            ],
+        )
+
+    def test_date_filter_uses_the_managers_custom_delete_flag_field(self):
+        with isolate_apps('tests'):
+            class RemovedManager(LogicalDeletionManager):
+                delete_flag_field = 'removed_at'
+
+            class CustomFieldModel(models.Model):
+                removed_at = models.DateTimeField(null=True, default=None)
+                objects = RemovedManager()
+
+                class Meta:
+                    app_label = 'tests'
+
+            model_admin = LogicalAdmin(CustomFieldModel, AdminSite())
+
+            self.assertEqual(
+                model_admin.get_list_filter(self._request()),
+                [
+                    LogicalDeletedFilter,
+                    ('removed_at', LogicalDeletedDateFilter),
+                ],
+            )


### PR DESCRIPTION
## Summary

- add deletion-date presets to `LogicalDeletionModelAdmin`
- add an inclusive custom date-range form with timezone-aware boundaries
- clear contradictory alive/date filters and show invalid-range errors without breaking the changelist
- document and export `LogicalDeletedDateFilter`

Closes #116

## Validation

- `python manage.py test`: 482 tests passed
- Django 4.2 admin tests: 18 tests passed
- Django 5.2 admin tests: 18 tests passed
- `flake8 .`
- `sphinx-build -M html docs docs/_build`
- `git diff --check`
