### PR TITLE
Fix RelatedModelInlineMixin form dropping its own many-to-many on save()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Saving a `RelatedModelInlineMixin` form no longer discards the base model's own many-to-many field values.
+
 ## [3.3.0] - 2026-07-16
 
 ### Added

--- a/django_boost/forms/mixins.py
+++ b/django_boost/forms/mixins.py
@@ -195,6 +195,7 @@ class RelatedModelInlineMixin:
 
         if commit:
             save_inline()
+            self._save_m2m()
         else:
             # Honor Django's ModelForm.save(commit=False) contract: perform no
             # DB writes now and defer them (plus the base form's own m2m) to

--- a/tests/tests/forms_mixins/forms.py
+++ b/tests/tests/forms_mixins/forms.py
@@ -37,3 +37,12 @@ class ReverseOneToOneHasManyToManyModelForm(RelatedModelInlineMixin,
     class Meta:
         model = models.ReverseOneToOneHasManyToManyModel
         fields = ('name',)
+
+
+class ReverseOneToOneHasManyToManyRelatedModelForm(RelatedModelInlineMixin,
+                                                   forms.ModelForm):
+    inline_fields = {'forward': ('name',)}
+
+    class Meta:
+        model = models.ReverseOneToOneHasManyToManyRelatedModel
+        fields = ('items',)

--- a/tests/tests/forms_mixins/tests.py
+++ b/tests/tests/forms_mixins/tests.py
@@ -215,6 +215,18 @@ class TestRelatedModelInlineMixins(TestCase):
         self.assertEqual(obj.name, 'sample')
         self.assertEqual(list(obj.reverse.items.all()), [self.item2])
 
+    def test_commit_true_saves_base_forms_own_many_to_many(self):
+        from .forms import ReverseOneToOneHasManyToManyRelatedModelForm
+
+        form = ReverseOneToOneHasManyToManyRelatedModelForm(
+            {'items': [self.item1.pk], 'forward_name': 'sample'})
+        self.assertTrue(form.is_valid())
+
+        obj = form.save()
+
+        obj.refresh_from_db()
+        self.assertEqual(list(obj.items.all()), [self.item1])
+
     @classmethod
     def tearDownClass(cls):
         pass


### PR DESCRIPTION
## Summary

`RelatedModelInlineMixin.save(commit=True)` calls `super().save(commit=False)` but never calls `_save_m2m()`, so a many-to-many field defined directly on the form's own model (as opposed to one reached through `inline_fields`) was silently discarded on save.

## Verification

Reproduced and fixed via TDD in the devcontainer (Python 3.12 × Django 5.2.15): full suite (495 tests), flake8, and mypy all pass.