### PR TITLE
Fix LogicalDeletionManager doing a physical delete without the mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Fixed
 
 - Saving a `RelatedModelInlineMixin` form no longer discards the base model's own many-to-many field values.
+- `LogicalDeletionManager` used on a model without `LogicalDeletionMixin` now performs a logical delete instead of a physical delete.
 
 ## [3.3.0] - 2026-07-16
 

--- a/django_boost/models/deletion.py
+++ b/django_boost/models/deletion.py
@@ -10,18 +10,19 @@ from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db import models, transaction
 from django.db.models import signals, sql
 from django.db.models.deletion import Collector
+from django.utils.timezone import now
 
 
 def get_logical_delete_field(model):
     """Return ``model``'s logical-deletion flag field, or ``None`` if it doesn't use logical deletion."""
-    if not hasattr(model, 'get_deleted_value'):
-        return None
-
-    get_field_name = getattr(model._default_manager, 'get_deleted_flag_field_name', None)
+    manager = model._default_manager
+    get_field_name = getattr(manager, 'get_deleted_flag_field_name', None)
     if callable(get_field_name):
         field_name = get_field_name()
+    elif hasattr(manager, 'delete_flag_field'):
+        field_name = manager.delete_flag_field
     else:
-        field_name = getattr(model._default_manager, 'delete_flag_field', 'deleted_at')
+        return None
 
     try:
         return model._meta.get_field(field_name)
@@ -57,7 +58,9 @@ class LogicalDeletionCollector(Collector):
         """Return the explicit ``deleted_at`` override, or ``model``'s own default."""
         if self.deleted_at is not None:
             return self.deleted_at
-        return model.get_deleted_value()
+        if hasattr(model, 'get_deleted_value'):
+            return model.get_deleted_value()
+        return now()
 
     def delete(self):  # noqa: D102
         for model, instances in self.data.items():

--- a/tests/tests/logical_deletion/models.py
+++ b/tests/tests/logical_deletion/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from django_boost.models.manager import LogicalDeletionManager
 from django_boost.models.mixins import LogicalDeletionMixin
 
 
@@ -68,3 +69,9 @@ class NonFastPhysicalGrandChild(models.Model):
         NonFastPhysicalChild, related_name='grandchildren',
         on_delete=models.CASCADE)
     name = models.CharField(max_length=8)
+
+
+class ManagerOnlyLogicalDeletionModel(models.Model):
+    name = models.CharField(max_length=8)
+    deleted_at = models.DateTimeField(null=True, default=None)
+    objects = LogicalDeletionManager()

--- a/tests/tests/logical_deletion/tests.py
+++ b/tests/tests/logical_deletion/tests.py
@@ -486,3 +486,28 @@ class AltersDataTests(TestCase):
 
         item.refresh_from_db()
         self.assertIsNotNone(item.deleted_at)
+
+
+class ManagerOnlyLogicalDeletionTests(TestCase):
+    """LogicalDeletionManager must still soft-delete when the model does not
+    inherit LogicalDeletionMixin (manager-only configuration)."""
+    from .models import ManagerOnlyLogicalDeletionModel
+
+    model = ManagerOnlyLogicalDeletionModel
+
+    def test_delete_marks_row_dead_instead_of_removing_it(self):
+        item = self.model.objects.create(name="0")
+
+        self.model.objects.filter(pk=item.pk).delete()
+
+        item.refresh_from_db()
+        self.assertIsNotNone(item.deleted_at)
+        self.assertEqual(self.model.objects.count(), 1)
+
+    def test_alive_and_dead_reflect_the_delete(self):
+        item = self.model.objects.create(name="0")
+
+        self.model.objects.filter(pk=item.pk).delete()
+
+        self.assertEqual(self.model.objects.alive().count(), 0)
+        self.assertEqual(self.model.objects.dead().count(), 1)


### PR DESCRIPTION
## Summary

A model using `LogicalDeletionManager` directly (without inheriting `LogicalDeletionMixin`) was silently hard-deleted on `delete()`, because the logical-delete detection gated on a classmethod only the mixin defines.

## Verification

Reproduced and fixed via TDD in the devcontainer (Python 3.12 × Django 5.2.15): full suite, flake8, and mypy all pass.