### PR TITLE
Prevent LogicalDeletion revive/delete from being triggered by templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - Comparing two `JsonValidator` (or two `NonZeroValidator`) instances no longer raises `AttributeError`.
 - The `mimetype` template filter now returns an empty string for an unknown extension (instead of the literal `None`) and accepts a non-string value instead of raising `TypeError`.
 - `ReAuthenticationRequiredMixin(logout=True)` no longer returns a 405 instead of logging out on Django 5.0+.
+- `LogicalDeletionMixin.revive`, `LogicalDeletionQuerySet.revive`, and `LogicalDeletionManager.delete`/`revive` can no longer be triggered by rendering a template variable, matching Django's own `delete`/`update`.
 
 ## [3.2.4] - 2026-07-11
 

--- a/django_boost/models/manager.py
+++ b/django_boost/models/manager.py
@@ -23,6 +23,8 @@ class LogicalDeletionManager(Manager):
     def delete(self, hard=False, deleted_at=None):  # noqa: D102
         return self.get_queryset().delete(hard=hard, deleted_at=deleted_at)
 
+    delete.alters_data = True
+
     def alive(self):
         """Return not logically deleted items queryset."""
         return self.get_queryset().alive()
@@ -34,3 +36,5 @@ class LogicalDeletionManager(Manager):
     def revive(self):
         """Revive logical deleted items."""
         return self.get_queryset().revive()
+
+    revive.alters_data = True

--- a/django_boost/models/mixins.py
+++ b/django_boost/models/mixins.py
@@ -83,6 +83,8 @@ class LogicalDeletionMixin(models.Model):
         self.deleted_at = None
         return self.save(force_update=force_update, using=using)
 
+    revive.alters_data = True
+
     def is_dead(self):
         """Return True if the item is dead."""
         return self.deleted_at is not None

--- a/django_boost/models/query.py
+++ b/django_boost/models/query.py
@@ -72,3 +72,6 @@ class LogicalDeletionQuerySet(QuerySet):
         """Revive logical delete items."""
         field_name = self.get_delete_flag_field_name()
         return self.update(**{field_name: None})
+
+    revive.alters_data = True
+    revive.queryset_only = True

--- a/tests/tests/logical_deletion/tests.py
+++ b/tests/tests/logical_deletion/tests.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.deletion import ProtectedError
 from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
+from django.template import Context, Template
 from django.test import TestCase, override_settings
 from django.test.utils import isolate_apps
 from django.utils.timezone import now
@@ -439,3 +440,49 @@ class LogicalDeletionManagerCustomFieldTests(TestCase):
             queryset = CustomFieldModel.objects.filter(pk__gt=0).alive()
 
         self.assertEqual(queryset.get_delete_flag_field_name(), "removed_at")
+
+
+class AltersDataTests(TestCase):
+    """Data-altering logical-deletion methods must not be callable from
+    templates, matching Django's own Model.delete/QuerySet.delete/update."""
+    from .models import LogicalDeletionModel
+
+    model = LogicalDeletionModel
+
+    def test_instance_revive_is_not_called_by_templates(self):
+        item = self.model.objects.create(name="0")
+        item.delete()
+
+        Template("{{ object.revive }}").render(Context({"object": item}))
+
+        item.refresh_from_db()
+        self.assertIsNotNone(item.deleted_at)
+
+    def test_queryset_revive_is_not_called_by_templates(self):
+        item = self.model.objects.create(name="1")
+        item.delete()
+        queryset = self.model.objects.filter(pk=item.pk)
+
+        Template("{{ queryset.revive }}").render(Context({"queryset": queryset}))
+
+        item.refresh_from_db()
+        self.assertIsNotNone(item.deleted_at)
+
+    def test_manager_delete_is_not_called_by_templates(self):
+        item = self.model.objects.create(name="2")
+
+        Template("{{ manager.delete }}").render(
+            Context({"manager": self.model.objects}))
+
+        item.refresh_from_db()
+        self.assertIsNone(item.deleted_at)
+
+    def test_manager_revive_is_not_called_by_templates(self):
+        item = self.model.objects.create(name="3")
+        item.delete()
+
+        Template("{{ manager.revive }}").render(
+            Context({"manager": self.model.objects}))
+
+        item.refresh_from_db()
+        self.assertIsNotNone(item.deleted_at)


### PR DESCRIPTION
## Summary

`LogicalDeletionMixin.revive`, `LogicalDeletionQuerySet.revive`, and `LogicalDeletionManager.delete`/`revive` lacked `alters_data`, so Django's template engine would silently call them (reviving or deleting rows) when they appeared bare in a template variable — unlike `Model.delete`/`QuerySet.delete`/`update`, which are already protected.

## Verification

Reproduced and fixed via TDD in the devcontainer (Python 3.12 × Django 5.2.15): full suite (498 tests), flake8, and mypy all pass.