### PR TITLE
Fix DynamicRedirectMixin breaking model form views' get_success_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - Saving a `RelatedModelInlineMixin` form no longer discards the base model's own many-to-many field values.
 - `LogicalDeletionManager` used on a model without `LogicalDeletionMixin` now performs a logical delete instead of a physical delete.
+- `DynamicRedirectMixin` combined with `CreateView`/`UpdateView`/`DeleteView` now interpolates a `success_url` placeholder (e.g. `{id}`) and falls back to the object's `get_absolute_url()`, instead of returning the literal placeholder or raising `ImproperlyConfigured`.
 
 ## [3.3.0] - 2026-07-16
 

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -44,7 +44,12 @@ class DynamicRedirectMixin(RedirectURLMixin):
 
     def get_success_url(self):  # noqa: D102
         url = self.get_redirect_url()
-        return url or self.success_url or super().get_success_url()
+        if url:
+            return url
+        # Skip RedirectURLMixin.get_success_url() (needs next_page) and defer
+        # to the model/form view below it, e.g. ModelFormMixin's success_url
+        # interpolation and get_absolute_url() fallback.
+        return super(RedirectURLMixin, self).get_success_url()
 
 
 class RedirectToDetailMixin:

--- a/tests/models.py
+++ b/tests/models.py
@@ -6,6 +6,9 @@ from django_boost.models.fields import AutoOneToOneField
 class RelatedItemModel(models.Model):
     name = models.CharField(max_length=128)
 
+    def get_absolute_url(self):
+        return '/items/%d/' % self.pk
+
 
 class AutoOneToOneParentModel(models.Model):
     name = models.CharField(max_length=128)

--- a/tests/tests/views_mixins/tests.py
+++ b/tests/tests/views_mixins/tests.py
@@ -296,3 +296,43 @@ class JsonResponseMixinResponseClassTests(TestCase):
 
         response = V().get(RequestFactory().get("/"))
         self.assertIsInstance(response, MyJsonResponse)
+
+
+class DynamicRedirectMixinModelFormTests(TestCase):
+    """DynamicRedirectMixin must not bypass ModelFormMixin.get_success_url()'s
+    success_url interpolation or its get_absolute_url() fallback."""
+
+    def test_interpolates_success_url_placeholder(self):
+        from django.test import RequestFactory
+        from django.views.generic import CreateView
+
+        from django_boost.views.mixins import DynamicRedirectMixin
+        from tests.models import RelatedItemModel
+
+        class V(DynamicRedirectMixin, CreateView):
+            model = RelatedItemModel
+            fields = ['name']
+            success_url = '/items/{id}/'
+
+        view = V()
+        view.request = RequestFactory().post('/')
+        view.object = RelatedItemModel.objects.create(name='x')
+
+        self.assertEqual(view.get_success_url(), '/items/%d/' % view.object.pk)
+
+    def test_falls_back_to_get_absolute_url_when_success_url_unset(self):
+        from django.test import RequestFactory
+        from django.views.generic import CreateView
+
+        from django_boost.views.mixins import DynamicRedirectMixin
+        from tests.models import RelatedItemModel
+
+        class V(DynamicRedirectMixin, CreateView):
+            model = RelatedItemModel
+            fields = ['name']
+
+        view = V()
+        view.request = RequestFactory().post('/')
+        view.object = RelatedItemModel.objects.create(name='y')
+
+        self.assertEqual(view.get_success_url(), view.object.get_absolute_url())


### PR DESCRIPTION
## Summary

`DynamicRedirectMixin.get_success_url()` returned `self.success_url` directly (skipping `ModelFormMixin`'s `{placeholder}` interpolation) and, when unset, fell back to `RedirectURLMixin.get_success_url()` (which requires `next_page` and never reaches `get_absolute_url()`). Both break `CreateView`/`UpdateView`/`DeleteView` usage; existing tests only covered plain `FormView`.

## Verification

Reproduced and fixed via TDD in the devcontainer (Python 3.12 × Django 5.2.15): full suite (496 tests), flake8, and mypy all pass.