### PR TITLE
Route AutoOneToOneField auto-creation through the parent's database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - Saving a `RelatedModelInlineMixin` form no longer discards the base model's own many-to-many field values.
 - `LogicalDeletionManager` used on a model without `LogicalDeletionMixin` now performs a logical delete instead of a physical delete.
 - `DynamicRedirectMixin` combined with `CreateView`/`UpdateView`/`DeleteView` now interpolates a `success_url` placeholder (e.g. `{id}`) and falls back to the object's `get_absolute_url()`, instead of returning the literal placeholder or raising `ImproperlyConfigured`.
+- `AutoOneToOneField`'s auto-created related object is now created on the database the router resolves for the parent instance, instead of always the default database.
 
 ## [3.3.0] - 2026-07-16
 

--- a/django_boost/models/fields/related_descriptors.py
+++ b/django_boost/models/fields/related_descriptors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from django.db import router
 from django.db.models.fields.related_descriptors import (
     ReverseOneToOneDescriptor)
 from django.db.transaction import atomic
@@ -14,7 +15,6 @@ class AutoReverseOneToOneDescriptor(ReverseOneToOneDescriptor):
     The descriptor that handles the object creation for an AutoOneToOneField.
     """
 
-    @atomic
     def __get__(self, instance, cls=None):
         """Get the related object, creating it via ``get_or_create`` if it doesn't exist yet."""
         model = getattr(self.related, 'related_model', self.related.model)
@@ -25,8 +25,14 @@ class AutoReverseOneToOneDescriptor(ReverseOneToOneDescriptor):
                 # No parent pk to create the related object against; surface the
                 # same RelatedObjectDoesNotExist a plain OneToOneField would.
                 raise
-            obj, _ = model.objects.get_or_create(
-                **{self.related.field.name: instance})
+            # Route on the parent instance, matching the hint Django's own
+            # ReverseOneToOneDescriptor.get_queryset() uses for the read above,
+            # instead of always creating on the default alias.
+            db = router.db_for_write(model, instance=instance)
+            with atomic(using=db):
+                obj, _ = model._base_manager.db_manager(
+                    hints={'instance': instance}).get_or_create(
+                    **{self.related.field.name: instance})
 
             self.related.set_cached_value(instance, obj)
             self.related.field.set_cached_value(obj, instance)

--- a/tests/tests/models/fields/test_related_descriptors.py
+++ b/tests/tests/models/fields/test_related_descriptors.py
@@ -1,4 +1,6 @@
-from django.test import TestCase
+from unittest import mock
+
+from django.test import TestCase, TransactionTestCase, override_settings
 
 from tests.models import AutoOneToOneChildModel, AutoOneToOneParentModel
 
@@ -19,3 +21,80 @@ class AutoReverseOneToOneDescriptorTests(TestCase):
         child = parent.child
         self.assertIsInstance(child, AutoOneToOneChildModel)
         self.assertEqual(child.parent_id, parent.pk)
+
+
+class RoutingHintSpyRouter:
+    """Records the hints each db_for_write call receives, without deciding
+    anything itself (returns None so the default router still applies)."""
+
+    calls = []
+
+    def db_for_write(self, model, **hints):
+        type(self).calls.append(hints)
+        return None
+
+
+@override_settings(DATABASE_ROUTERS=[
+    'tests.tests.models.fields.test_related_descriptors.RoutingHintSpyRouter'])
+class AutoReverseOneToOneRoutingTests(TestCase):
+    """AutoReverseOneToOneDescriptor's creation path must hint db_for_write
+    with the parent instance, the same way Django's own reverse-descriptor
+    read path already does, so a hint-based router (e.g. sharding by
+    instance) can route the created row to the parent's database."""
+
+    def setUp(self):
+        RoutingHintSpyRouter.calls = []
+
+    def test_creation_hints_db_for_write_with_the_parent_instance(self):
+        parent = AutoOneToOneParentModel.objects.create(name='p')
+        RoutingHintSpyRouter.calls = []
+
+        parent.child
+
+        # The existence check get_or_create() performs before creating is the
+        # first db_for_write call; it must carry the instance hint so a
+        # hint-based router sees the same context Django's own read path
+        # already gets, instead of an unhinted lookup.
+        first_write_hints = RoutingHintSpyRouter.calls[0]
+        self.assertEqual(first_write_hints.get('instance'), parent)
+
+
+@override_settings(
+    DATABASE_APPS_MAPPING={'tests': 'example'},
+    # Re-set DATABASE_ROUTERS (even to its existing value) so the
+    # setting_changed signal forces DatabaseRouter to reload the mapping
+    # above; it snapshots DATABASE_APPS_MAPPING in __init__ otherwise.
+    DATABASE_ROUTERS=['django_boost.db.router.DatabaseRouter'])
+class AutoReverseOneToOneAtomicAliasTests(TransactionTestCase):
+    """The transaction guarding creation must target the alias the router
+    resolves for the parent, not be hardcoded to 'default'."""
+
+    databases = {'default', 'example'}
+
+    def setUp(self):
+        # The 'tests' app has no migrations of its own and was never synced
+        # onto 'example' at test-database setup time (it wasn't mapped there
+        # yet); sync it now so the rerouted writes below have a table to hit.
+        # TransactionTestCase (not TestCase): sqlite's schema editor cannot
+        # run inside the wrapping atomic() a plain TestCase would use here.
+        from django.core.management import call_command
+        call_command('migrate', run_syncdb=True, database='example',
+                     verbosity=0)
+
+    def test_atomic_targets_the_resolved_alias_not_default(self):
+        import django_boost.models.fields.related_descriptors as related_descriptors
+
+        used_aliases = []
+        real_atomic = related_descriptors.atomic
+
+        def spy_atomic(*args, **kwargs):
+            using = kwargs.get('using', args[0] if args else None)
+            used_aliases.append(using)
+            return real_atomic(*args, **kwargs)
+
+        parent = AutoOneToOneParentModel.objects.create(name='p')
+        with mock.patch.object(related_descriptors, 'atomic', spy_atomic):
+            parent.child
+
+        self.assertIn('example', used_aliases)
+        self.assertNotIn('default', used_aliases)


### PR DESCRIPTION
## Summary

`AutoReverseOneToOneDescriptor.__get__` wrapped itself in a bare `@atomic` (always the default alias) and called `model.objects.get_or_create()` with no routing hints, unlike Django's own reverse-descriptor read path, which hints `db_for_write` with the parent instance. In a multi-database setup, the related object could be created on the wrong alias, outside the transaction meant to guard its creation.

## Verification

Reproduced and fixed via TDD in the devcontainer (Python 3.12 × Django 5.2.15), using this repo's existing second `'example'` database alias to exercise real routing. Full suite (500 tests), flake8, and mypy all pass.