### PR TITLE
Accept datetime.date in the date path converter's reverse()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Fixed
 
 - The `Toggleswitch` widget's visible label is now clickable; its `for` attribute now matches the input's `id`.
+- The `date` path converter now accepts a `datetime.date` value (e.g. from a `DateField`) in `reverse()`, instead of raising `NoReverseMatch`.
 
 ## [3.3.1] - 2026-07-17
 

--- a/django_boost/urls/converters/date.py
+++ b/django_boost/urls/converters/date.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import ClassVar
 
 REGEX_LEAP_YEAR = r"(([48](00)?)|(([2468][048]|[13579][26])(00)?)|([1-9][0-9]?(0[48]|[2468][048]|[13579][26])))"
@@ -38,9 +38,9 @@ class DateConverter:
 
     regex: ClassVar[str] = REGEX_DATE
 
-    def to_url(self, value: datetime | str) -> str:
-        """Render ``value`` as ``Y/M/D``, accepting either a ``datetime`` or an already-formatted string."""
-        if isinstance(value, datetime):
+    def to_url(self, value: date | str) -> str:
+        """Render ``value`` as ``Y/M/D``, accepting either a ``date``/``datetime`` or an already-formatted string."""
+        if isinstance(value, date):
             return f"{value.year}/{value.month}/{value.day}"
         return str(value)
 

--- a/tests/tests/urls/converters/test_date.py
+++ b/tests/tests/urls/converters/test_date.py
@@ -1,6 +1,6 @@
 import re
 from calendar import isleap as _isleap
-from datetime import datetime
+from datetime import date, datetime
 
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
@@ -36,6 +36,11 @@ class TestDateConverter(ConverterTestCase):
     def test_reverses_short_year_datetime(self):
         url = reverse('date', kwargs={'date': datetime(48, 2, 29)})
         self.assertEqual(url, '/date/48/2/29')
+        self.assertStatusCodeEqual(self.client.get(url), 200)
+
+    def test_reverses_date(self):
+        url = reverse('date', kwargs={'date': date(2020, 1, 5)})
+        self.assertEqual(url, '/date/2020/1/5')
         self.assertStatusCodeEqual(self.client.get(url), 200)
 
 


### PR DESCRIPTION
## Summary

`DateConverter.to_url()` special-cased `datetime`, but `date` is `datetime`'s base class (not the other way around), so passing a plain `date` — the type a `DateField` value actually is — fell through to `str(value)` (hyphen-separated) instead of the `/`-separated format the converter's `regex` requires, making `reverse()` raise `NoReverseMatch`.

## Verification

Reproduced and fixed via TDD in the devcontainer (Python 3.12 × Django 5.2.15): full suite (499 tests), flake8, and mypy all pass.