### PR TITLE
Fix Toggleswitch's label not being associated with its input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The `Toggleswitch` widget's visible label is now clickable; its `for` attribute now matches the input's `id`.
+
 ## [3.3.1] - 2026-07-17
 
 ### Fixed

--- a/django_boost/templates/boost/forms/widgets/toggleswitch.html
+++ b/django_boost/templates/boost/forms/widgets/toggleswitch.html
@@ -1,5 +1,5 @@
 <input class="boost-tgl boost-tgl-light" type="{{ widget.type }}" name="{{ widget.name }}" {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}/>
-<label class="boost-tgl-btn" for="{{ widget.id }}"></label>
+<label class="boost-tgl-btn" for="{{ widget.attrs.id }}"></label>
 <style>
     .boost-tgl {
         display: none;

--- a/tests/tests/forms/test_widgets.py
+++ b/tests/tests/forms/test_widgets.py
@@ -1,0 +1,25 @@
+from django import forms
+
+from django_boost.forms.widgets import Toggleswitch
+from django_boost.test.testcase import TestCase
+
+
+class ToggleswitchTests(TestCase):
+
+    def test_label_for_matches_input_id(self):
+        class F(forms.Form):
+            t = forms.BooleanField(widget=Toggleswitch, required=False)
+
+        rendered = str(F()['t'])
+
+        self.assertIn('id="id_t"', rendered)
+        self.assertIn('for="id_t"', rendered)
+
+    def test_label_for_is_empty_without_an_id(self):
+        class F(forms.Form):
+            t = forms.BooleanField(widget=Toggleswitch, required=False)
+
+        rendered = str(F(auto_id=False)['t'])
+
+        self.assertNotIn(' id=', rendered)
+        self.assertIn('for=""', rendered)


### PR DESCRIPTION
## Summary

`toggleswitch.html`'s visible `<label>` referenced `{{ widget.id }}`, a key the widget template context never has (Django puts the id under `widget.attrs.id`), so `for` always rendered empty. Since the real checkbox is `display:none` and only the label is visible, this left the switch unclickable.

## Verification

Reproduced and fixed via TDD in the devcontainer (Python 3.12 × Django 5.2.15): full suite (500 tests), flake8, and mypy all pass.