### PR TITLE
:bookmark: Release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-07-16
+
 ### Added
 
 - `LogicalDeletionModelAdmin` now includes a deletion-date filter with today, 7/30/90-day, older-than-90-day, and inclusive custom-range options.
@@ -493,7 +495,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - First release.
 
-[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.2.4...HEAD
+[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.3.0...HEAD
+[3.3.0]: https://github.com/ChanTsune/django-boost/compare/v3.2.4...v3.3.0
 [3.2.4]: https://github.com/ChanTsune/django-boost/compare/v3.2.3...v3.2.4
 [3.2.3]: https://github.com/ChanTsune/django-boost/compare/v3.2.2...v3.2.3
 [3.2.2]: https://github.com/ChanTsune/django-boost/compare/v3.2.1...v3.2.2

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django_boost.utils.version import get_version
 
-VERSION = (3, 3, 0, 'alpha', 0)
+VERSION = (3, 3, 0, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
- Added
  - `LogicalDeletionModelAdmin` now includes a deletion-date filter with today, 7/30/90-day, older-than-90-day, and inclusive custom-range options.
  - Decimal path converters `decimal`, `signed_decimal`, `positive_decimal`, `negative_decimal`, `non_negative_decimal`, `non_positive_decimal` and `non_zero_decimal`, covering decimal ranges Django's built-in `float` converter cannot express; `decimal` is an alias of `non_negative_decimal`.
  - Float path converters `signed_float`, `positive_float`, `negative_float`, `non_negative_float`, `non_positive_float` and `non_zero_float`, symmetric with the existing signed-integer and decimal converter families; `float` is now an explicit alias of `non_negative_float` (same regex and behavior as before).
- Fixed
  - Comparing two `JsonValidator` (or two `NonZeroValidator`) instances no longer raises `AttributeError`.
  - The `mimetype` template filter now returns an empty string for an unknown extension (instead of the literal `None`) and accepts a non-string value instead of raising `TypeError`.
  - `ReAuthenticationRequiredMixin(logout=True)` no longer returns a 405 instead of logging out on Django 5.0+.
  - `LogicalDeletionMixin.revive`, `LogicalDeletionQuerySet.revive`, and `LogicalDeletionManager.delete`/`revive` can no longer be triggered by rendering a template variable, matching Django's own `delete`/`update`.