### PR TITLE
:label: Type the app config helper (apps)

### DIFF
--- a/django_boost/apps.py
+++ b/django_boost/apps.py
@@ -18,7 +18,7 @@ class DjangoBoostConfig(AppConfig):
     # migration of the user table's primary key.
     default_auto_field = 'django.db.models.AutoField'
 
-    def ready(self):
+    def ready(self) -> None:
         """Register django_boost's system checks (``django_boost.checks.CHECKS``)."""
         for check in CHECKS:
             checks.register(check, self.name)

--- a/mypy.ini
+++ b/mypy.ini
@@ -118,6 +118,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.apps]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 # example/ is a development harness, but keep it type-checked so the sample app
 # continues to compile against django-boost's public APIs. Tests and migrations
 # are excluded above.


### PR DESCRIPTION
## Summary
Annotate `DjangoBoostConfig.ready()` and register `django_boost.apps` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Verification
- `mypy django_boost` green
- `mypy --config-file=/dev/null --no-incremental --follow-imports=skip django_boost/apps.py` green (negative control)
- `flake8 django_boost/apps.py` clean
- `manage.py test` (498 tests) green