### PR TITLE
:sparkles: Add deleted_since/deleted_before/deleted_between to LogicalDeletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ### Added
 
-- `LogicalDeletionQuerySet`/`LogicalDeletionManager` gained `deleted_since`, `deleted_before`, and `deleted_between` methods for filtering by deletion date outside the admin.
+- `LogicalDeletionQuerySet`/`LogicalDeletionManager` gained `deleted_since`, `deleted_before`, and `deleted_between` methods for filtering by deletion date.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Added
+
+- `LogicalDeletionQuerySet`/`LogicalDeletionManager` gained `deleted_since`, `deleted_before`, and `deleted_between` methods for filtering by deletion date outside the admin.
+
 ### Fixed
 
 - The `Toggleswitch` widget's visible label is now clickable; its `for` attribute now matches the input's `id`.

--- a/django_boost/admin/filters.py
+++ b/django_boost/admin/filters.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, time, timedelta
+from datetime import timedelta
 
 from django.contrib import admin
 from django.contrib.admin.filters import ListFilter
@@ -129,26 +129,17 @@ class LogicalDeletedDateFilter(admin.FieldListFilter):
         if self.from_value or self.to_value:
             return self._range_queryset(queryset)
 
-        today = self._local_today()
-        tomorrow = self._start_of_day(today + timedelta(days=1))
         period = self.value()
-        lookups = {}
         if period == 'all_deleted':
-            lookups[f'{self.field_path}__isnull'] = False
-        elif period == 'today':
-            lookups[f'{self.field_path}__gte'] = self._start_of_day(today)
-            lookups[f'{self.field_path}__lt'] = tomorrow
-        elif period in {'past_7_days', 'past_30_days', 'past_90_days'}:
+            return queryset.dead()
+        if period == 'today':
+            return queryset.deleted_since(1)
+        if period in {'past_7_days', 'past_30_days', 'past_90_days'}:
             days = int(period.split('_')[1])
-            lookups[f'{self.field_path}__gte'] = self._start_of_day(
-                today - timedelta(days=days - 1))
-            lookups[f'{self.field_path}__lt'] = tomorrow
-        elif period == 'older_than_90_days':
-            lookups[f'{self.field_path}__lt'] = self._start_of_day(
-                today - timedelta(days=89))
-        else:
-            return queryset
-        return queryset.filter(**lookups)
+            return queryset.deleted_since(days)
+        if period == 'older_than_90_days':
+            return queryset.deleted_before(self._local_today() - timedelta(days=89))
+        return queryset
 
     def _range_queryset(self, queryset):
         date_field = DateField(input_formats=['%Y-%m-%d'])
@@ -166,13 +157,7 @@ class LogicalDeletedDateFilter(admin.FieldListFilter):
             self.errors.append(_('Start date must be on or before end date.'))
             return queryset
 
-        lookups = {}
-        if start:
-            lookups[f'{self.field_path}__gte'] = self._start_of_day(start)
-        if end:
-            lookups[f'{self.field_path}__lt'] = self._start_of_day(
-                end + timedelta(days=1))
-        return queryset.filter(**lookups)
+        return queryset.deleted_between(start=start, end=end)
 
     @staticmethod
     def _local_today():
@@ -180,10 +165,3 @@ class LogicalDeletedDateFilter(admin.FieldListFilter):
         if timezone.is_aware(now):
             now = timezone.localtime(now)
         return now.date()
-
-    @staticmethod
-    def _start_of_day(value):
-        result = datetime.combine(value, time.min)
-        if timezone.is_aware(timezone.now()):
-            result = timezone.make_aware(result, timezone.get_current_timezone())
-        return result

--- a/django_boost/models/manager.py
+++ b/django_boost/models/manager.py
@@ -42,7 +42,11 @@ class LogicalDeletionManager(Manager):
         return self.get_queryset().deleted_before(date)
 
     def deleted_between(self, start=None, end=None):
-        """Return items whose delete flag falls within the inclusive local-calendar-day range ``[start, end]``."""
+        """Return items whose delete flag falls within the inclusive local-calendar-day range ``[start, end]``.
+
+        Either bound may be omitted to leave that side of the range open;
+        with both omitted, all logically deleted items are returned.
+        """
         return self.get_queryset().deleted_between(start=start, end=end)
 
     def revive(self):

--- a/django_boost/models/manager.py
+++ b/django_boost/models/manager.py
@@ -33,6 +33,18 @@ class LogicalDeletionManager(Manager):
         """Return logically deleted items queryset."""
         return self.get_queryset().dead()
 
+    def deleted_since(self, days):
+        """Return items whose delete flag falls within the past ``days`` calendar days, today inclusive."""
+        return self.get_queryset().deleted_since(days)
+
+    def deleted_before(self, date):
+        """Return items whose delete flag is strictly before the local start of ``date``."""
+        return self.get_queryset().deleted_before(date)
+
+    def deleted_between(self, start=None, end=None):
+        """Return items whose delete flag falls within the inclusive local-calendar-day range ``[start, end]``."""
+        return self.get_queryset().deleted_between(start=start, end=end)
+
     def revive(self):
         """Revive logical deleted items."""
         return self.get_queryset().revive()

--- a/django_boost/models/query.py
+++ b/django_boost/models/query.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import datetime
+
 import django
 from django.db.models.query import QuerySet
+from django.utils import timezone
 
 from django_boost.models.deletion import LogicalDeletionCollector
 
@@ -75,3 +78,54 @@ class LogicalDeletionQuerySet(QuerySet):
 
     revive.alters_data = True
     revive.queryset_only = True
+
+    def _filter_delete_flag(self, gte=None, lt=None):
+        field_name = self.get_delete_flag_field_name()
+        lookups = {}
+        if gte is not None:
+            lookups[f'{field_name}__gte'] = gte
+        if lt is not None:
+            lookups[f'{field_name}__lt'] = lt
+        return self.filter(**lookups)
+
+    def deleted_since(self, days):
+        """Return items whose delete flag falls within the past ``days`` calendar days, today inclusive."""
+        today = self._local_today()
+        since = today - datetime.timedelta(days=days - 1)
+        tomorrow = today + datetime.timedelta(days=1)
+        return self._filter_delete_flag(
+            gte=self._local_day_start(since), lt=self._local_day_start(tomorrow))
+
+    def deleted_before(self, date):
+        """Return items whose delete flag is strictly before the local start of ``date``."""
+        return self._filter_delete_flag(lt=self._local_day_start(self._as_date(date)))
+
+    def deleted_between(self, start=None, end=None):
+        """Return items whose delete flag falls within the inclusive local-calendar-day range ``[start, end]``."""
+        gte = self._local_day_start(self._as_date(start)) if start is not None else None
+        lt = None
+        if end is not None:
+            lt = self._local_day_start(self._as_date(end) + datetime.timedelta(days=1))
+        return self._filter_delete_flag(gte=gte, lt=lt)
+
+    @staticmethod
+    def _as_date(value):
+        if isinstance(value, datetime.datetime):
+            if timezone.is_aware(value):
+                value = timezone.localtime(value)
+            return value.date()
+        return value
+
+    @staticmethod
+    def _local_today():
+        now = timezone.now()
+        if timezone.is_aware(now):
+            now = timezone.localtime(now)
+        return now.date()
+
+    @staticmethod
+    def _local_day_start(date):
+        start = datetime.datetime.combine(date, datetime.time.min)
+        if timezone.is_aware(timezone.now()):
+            start = timezone.make_aware(start)
+        return start

--- a/django_boost/models/query.py
+++ b/django_boost/models/query.py
@@ -101,7 +101,13 @@ class LogicalDeletionQuerySet(QuerySet):
         return self._filter_delete_flag(lt=self._local_day_start(self._as_date(date)))
 
     def deleted_between(self, start=None, end=None):
-        """Return items whose delete flag falls within the inclusive local-calendar-day range ``[start, end]``."""
+        """Return items whose delete flag falls within the inclusive local-calendar-day range ``[start, end]``.
+
+        Either bound may be omitted to leave that side of the range open;
+        with both omitted, all logically deleted items are returned.
+        """
+        if start is None and end is None:
+            return self.dead()
         gte = self._local_day_start(self._as_date(start)) if start is not None else None
         lt = None
         if end is not None:

--- a/docs/model_mixins.rst
+++ b/docs/model_mixins.rst
@@ -115,9 +115,12 @@ To filter by when items were logically deleted, ``deleted_since``, ``deleted_bef
 ``deleted_between`` are available on both the manager and the queryset. All three compare
 against local calendar days (midnight to midnight in the current time zone). ``deleted_since``
 and ``deleted_between`` are inclusive of the day boundaries they name; ``deleted_before``
-excludes the named day itself.
+excludes the named day itself. Both bounds of ``deleted_between`` are optional: omitting one
+leaves that side of the range open, and omitting both returns all logically deleted items.
 
 ::
+
+  from datetime import date
 
   Store.objects.deleted_since(7) # deleted within the past 7 calendar days, today inclusive.
 

--- a/docs/model_mixins.rst
+++ b/docs/model_mixins.rst
@@ -110,3 +110,17 @@ If you want to retrieve only the logically deleted items, you can use the ``dead
   Store.objects.alive() # get not logically deleted items queryset.
 
   Store.objects.dead() # get logically deleted items queryset.
+
+To filter by when items were logically deleted, ``deleted_since``, ``deleted_before`` and
+``deleted_between`` are available on both the manager and the queryset. All three compare
+against local calendar days (midnight to midnight in the current time zone). ``deleted_since``
+and ``deleted_between`` are inclusive of the day boundaries they name; ``deleted_before``
+excludes the named day itself.
+
+::
+
+  Store.objects.deleted_since(7) # deleted within the past 7 calendar days, today inclusive.
+
+  Store.objects.deleted_before(date(2024, 1, 1)) # deleted before the start of that day.
+
+  Store.objects.deleted_between(date(2024, 1, 1), date(2024, 1, 31)) # deleted on or between those days.

--- a/tests/tests/logical_deletion/tests.py
+++ b/tests/tests/logical_deletion/tests.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import date, datetime, timedelta, timezone as datetime_timezone
+from unittest import mock
 
 import django
 from django.core.exceptions import ImproperlyConfigured
@@ -200,6 +201,98 @@ class TestLogicalDeletionManager(TestCase):
         self.assertEqual(len(self.model.objects.alive()), 10)
         self.assertEqual(len(self.model.objects.all()), 10)
         self._hard_delete()
+
+
+class TestLogicalDeletionDateLookups(TestCase):
+    """deleted_since/deleted_before/deleted_between on the queryset and manager."""
+
+    from .models import LogicalDeletionModel
+
+    model = LogicalDeletionModel
+    now = datetime(2026, 7, 16, 12, tzinfo=datetime_timezone.utc)
+
+    def setUp(self):
+        self.alive = self.model.objects.create(name='alive')
+        self.deleted = {
+            days: self.model.objects.create(
+                name=str(days), deleted_at=self.now - timedelta(days=days))
+            for days in (0, 6, 7, 8, 9)
+        }
+
+    def _ids(self, queryset):
+        return set(queryset.values_list('pk', flat=True))
+
+    def test_deleted_since_is_inclusive_of_today_and_the_boundary_day(self):
+        # deleted_since(9) covers today plus the 8 preceding days (offset 8
+        # inclusive); offset 9 falls outside that span.
+        with mock.patch('django_boost.models.query.timezone.now', return_value=self.now):
+            manager_ids = self._ids(self.model.objects.deleted_since(9))
+            queryset_ids = self._ids(
+                self.model.objects.filter(pk__gt=0).deleted_since(9))
+
+        expected = {self.deleted[days].pk for days in (0, 6, 7, 8)}
+        self.assertEqual(manager_ids, expected)
+        self.assertEqual(queryset_ids, expected)
+        self.assertNotIn(self.deleted[9].pk, manager_ids)
+        self.assertNotIn(self.alive.pk, manager_ids)
+
+    def test_deleted_before_excludes_the_boundary_day_itself(self):
+        boundary = self.now.date() - timedelta(days=7)
+        with mock.patch('django_boost.models.query.timezone.now', return_value=self.now):
+            manager_ids = self._ids(self.model.objects.deleted_before(boundary))
+            queryset_ids = self._ids(
+                self.model.objects.filter(pk__gt=0).deleted_before(boundary))
+
+        expected = {self.deleted[days].pk for days in (8, 9)}
+        self.assertEqual(manager_ids, expected)
+        self.assertEqual(queryset_ids, expected)
+        self.assertNotIn(self.deleted[7].pk, manager_ids)
+        self.assertNotIn(self.alive.pk, manager_ids)
+
+    def test_deleted_between_is_inclusive_of_both_boundary_days(self):
+        start = self.now.date() - timedelta(days=8)
+        end = self.now.date() - timedelta(days=7)
+        with mock.patch('django_boost.models.query.timezone.now', return_value=self.now):
+            manager_ids = self._ids(
+                self.model.objects.deleted_between(start=start, end=end))
+            queryset_ids = self._ids(
+                self.model.objects.filter(pk__gt=0).deleted_between(
+                    start=start, end=end))
+
+        expected = {self.deleted[days].pk for days in (7, 8)}
+        self.assertEqual(manager_ids, expected)
+        self.assertEqual(queryset_ids, expected)
+        self.assertNotIn(self.deleted[6].pk, manager_ids)  # day after end
+        self.assertNotIn(self.deleted[9].pk, manager_ids)  # day before start
+        self.assertNotIn(self.alive.pk, manager_ids)
+
+    def test_deleted_between_start_only_leaves_the_upper_bound_open(self):
+        start = self.now.date() - timedelta(days=8)
+        with mock.patch('django_boost.models.query.timezone.now', return_value=self.now):
+            ids = self._ids(self.model.objects.deleted_between(start=start))
+
+        self.assertEqual(ids, {self.deleted[days].pk for days in (0, 6, 7, 8)})
+        self.assertNotIn(self.deleted[9].pk, ids)
+        self.assertNotIn(self.alive.pk, ids)
+
+    def test_deleted_between_end_only_leaves_the_lower_bound_open(self):
+        end = self.now.date() - timedelta(days=7)
+        with mock.patch('django_boost.models.query.timezone.now', return_value=self.now):
+            ids = self._ids(self.model.objects.deleted_between(end=end))
+
+        self.assertEqual(ids, {self.deleted[days].pk for days in (7, 8, 9)})
+        self.assertNotIn(self.deleted[6].pk, ids)
+        self.assertNotIn(self.alive.pk, ids)
+
+    def test_deleted_since_excludes_a_future_dated_deletion(self):
+        # A deleted_at set ahead of "now" (e.g. a scheduled/backdated delete)
+        # must not count as within the past N days.
+        future = self.model.objects.create(
+            name='future', deleted_at=self.now + timedelta(days=5))
+        with mock.patch('django_boost.models.query.timezone.now', return_value=self.now):
+            ids = self._ids(self.model.objects.deleted_since(1))
+
+        self.assertNotIn(future.pk, ids)
 
 
 class TestLogicalDeletionDjangoDeleteCompatibility(TestCase):
@@ -440,6 +533,31 @@ class LogicalDeletionManagerCustomFieldTests(TestCase):
             queryset = CustomFieldModel.objects.filter(pk__gt=0).alive()
 
         self.assertEqual(queryset.get_delete_flag_field_name(), "removed_at")
+
+    def test_custom_delete_flag_field_reaches_date_lookups(self):
+        with isolate_apps("tests"):
+            class RemovedManager(LogicalDeletionManager):
+                delete_flag_field = "removed_at"
+
+            class CustomFieldModel(models.Model):
+                removed_at = models.DateTimeField(null=True, default=None)
+                objects = RemovedManager()
+
+                class Meta:
+                    app_label = "tests"
+
+            today = date(2026, 7, 16)
+            querysets = (
+                CustomFieldModel.objects.deleted_since(7),
+                CustomFieldModel.objects.deleted_before(today),
+                CustomFieldModel.objects.deleted_between(start=today, end=today),
+            )
+
+        # The generated SQL must reference removed_at, not the class default
+        # deleted_at, proving _filter_delete_flag() honors the custom field
+        # rather than hardcoding it.
+        for queryset in querysets:
+            self.assertIn("removed_at", str(queryset.query))
 
 
 class AltersDataTests(TestCase):

--- a/tests/tests/logical_deletion/tests.py
+++ b/tests/tests/logical_deletion/tests.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timedelta, timezone as datetime_timezone
 from unittest import mock
+from zoneinfo import ZoneInfo
 
 import django
 from django.core.exceptions import ImproperlyConfigured
@@ -9,6 +10,7 @@ from django.db.models.signals import post_delete, post_save, pre_delete, pre_sav
 from django.template import Context, Template
 from django.test import TestCase, override_settings
 from django.test.utils import isolate_apps
+from django.utils import timezone
 from django.utils.timezone import now
 
 from django_boost.models.deletion import get_logical_delete_field
@@ -209,7 +211,9 @@ class TestLogicalDeletionDateLookups(TestCase):
     from .models import LogicalDeletionModel
 
     model = LogicalDeletionModel
-    now = datetime(2026, 7, 16, 12, tzinfo=datetime_timezone.utc)
+    # A past date on purpose: if the timezone.now mock ever stopped
+    # applying, a frozen "today" would keep passing until the next day.
+    now = datetime(2026, 1, 15, 12, tzinfo=datetime_timezone.utc)
 
     def setUp(self):
         self.alive = self.model.objects.create(name='alive')
@@ -285,14 +289,39 @@ class TestLogicalDeletionDateLookups(TestCase):
         self.assertNotIn(self.alive.pk, ids)
 
     def test_deleted_since_excludes_a_future_dated_deletion(self):
-        # A deleted_at set ahead of "now" (e.g. a scheduled/backdated delete)
-        # must not count as within the past N days.
+        # A deleted_at on a future calendar day (e.g. a scheduled delete) must
+        # not count as within the past N days. A later time on the current day
+        # would still count: the window runs to the start of tomorrow.
         future = self.model.objects.create(
             name='future', deleted_at=self.now + timedelta(days=5))
         with mock.patch('django_boost.models.query.timezone.now', return_value=self.now):
             ids = self._ids(self.model.objects.deleted_since(1))
 
         self.assertNotIn(future.pk, ids)
+
+    def test_deleted_since_zero_days_matches_nothing(self):
+        with mock.patch('django_boost.models.query.timezone.now', return_value=self.now):
+            self.assertFalse(self.model.objects.deleted_since(0).exists())
+
+    def test_deleted_between_with_no_bounds_returns_all_deleted_items(self):
+        manager_ids = self._ids(self.model.objects.deleted_between())
+        queryset_ids = self._ids(
+            self.model.objects.filter(pk__gt=0).deleted_between())
+
+        expected = {item.pk for item in self.deleted.values()}
+        self.assertEqual(manager_ids, expected)
+        self.assertEqual(queryset_ids, expected)
+        self.assertNotIn(self.alive.pk, manager_ids)
+
+    def test_deleted_before_localizes_an_aware_datetime_boundary(self):
+        # 20:00 UTC on Jan 8 is already Jan 9 in Asia/Tokyo, so the cutoff must
+        # be the start of Jan 9 JST; the row deleted at Jan 8 12:00 UTC stays
+        # included.
+        boundary = datetime(2026, 1, 8, 20, tzinfo=datetime_timezone.utc)
+        with timezone.override(ZoneInfo('Asia/Tokyo')):
+            ids = self._ids(self.model.objects.deleted_before(boundary))
+
+        self.assertEqual(ids, {self.deleted[days].pk for days in (7, 8, 9)})
 
 
 class TestLogicalDeletionDjangoDeleteCompatibility(TestCase):
@@ -553,9 +582,8 @@ class LogicalDeletionManagerCustomFieldTests(TestCase):
                 CustomFieldModel.objects.deleted_between(start=today, end=today),
             )
 
-        # The generated SQL must reference removed_at, not the class default
-        # deleted_at, proving _filter_delete_flag() honors the custom field
-        # rather than hardcoding it.
+        # The generated SQL must reference removed_at, not the class-default
+        # deleted_at.
         for queryset in querysets:
             self.assertIn("removed_at", str(queryset.query))
 


### PR DESCRIPTION
## Summary
`LogicalDeletionQuerySet`/`LogicalDeletionManager` gain `deleted_since`, `deleted_before`, and `deleted_between` for filtering by deletion date, so application code (views, batch jobs) can reuse the same period logic the admin's `LogicalDeletedDateFilter` already offers. `LogicalDeletedDateFilter` is refactored to delegate to these methods instead of duplicating the local-calendar-day arithmetic.

## Notes
- All three methods compare against local calendar days (midnight to midnight in the current time zone), matching the admin filter's existing semantics.
- `deleted_since`/`deleted_between` are inclusive of the named boundary days; `deleted_before` excludes the named day.
- The admin refactor preserves the filter's exact prior behavior — `tests/tests/admin/test_filters.py` is unmodified and still passes.

## Verification
- `flake8 .`: clean
- `python manage.py test`: 505 tests, OK