### PR TITLE
:label: Type the management command base classes (core.management)

### DIFF
--- a/django_boost/core/management.py
+++ b/django_boost/core/management.py
@@ -12,7 +12,7 @@ __all__ = ["BaseCommand", "AppCommand"]
 class CommandVersion:
     """Django-Boost command version."""
 
-    def get_version(self):
+    def get_version(self) -> str:
         return get_version()
 
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -82,6 +82,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.core.management]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.db.router]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `CommandVersion.get_version()` and register `django_boost.core.management` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
The registry entry is inserted right after the existing `core` block, deliberately isolated from other in-flight type-hint PRs so they can merge in any order without conflicting in mypy.ini.

## Verification
- `mypy django_boost` green
- `mypy --config-file=/dev/null --no-incremental --follow-imports=skip django_boost/core/management.py` green (negative control)
- `flake8 django_boost/core/management.py` clean
- `manage.py test` (499 tests) green