### PR TITLE
:label: Type the static-file URL helpers (urls.static)

### DIFF
--- a/django_boost/urls/static.py
+++ b/django_boost/urls/static.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Sequence
 
 from django import urls
+from django.urls import URLPattern, URLResolver
 
 from django_boost.views.generic import StaticView
 
@@ -13,9 +15,9 @@ from django_boost.views.generic import StaticView
 class StaticFileConnector:
     """Builds a list of ``urls.path()`` entries for every file under a directory."""
 
-    def __init__(self, path):
+    def __init__(self, path: str) -> None:
         """Build a ``urls.re_path()`` entry for every file under ``path``."""
-        self._urls = []
+        self._urls: list[URLPattern] = []
 
         for base, _, files in os.walk(path):
             for file in files:
@@ -30,16 +32,18 @@ class StaticFileConnector:
                                  StaticView.as_view(static_name=full_path)))
 
     @property
-    def urls(self):  # noqa: D102
+    def urls(self) -> list[URLPattern]:  # noqa: D102
         return self._urls
 
 
-def load_static_files(path):
+def load_static_files(path: str) -> list[URLPattern]:
     """Return the ``urls.path()`` entries built by ``StaticFileConnector`` for every file under ``path``."""
     return StaticFileConnector(path).urls
 
 
-def include_static_files(path):
+def include_static_files(
+    path: str,
+) -> tuple[Sequence[URLResolver | URLPattern], str | None, str | None]:
     """
     Add to routing that static files under the directory specified by the absolute path.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -46,6 +46,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.urls.static]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.utils.itertools]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `StaticFileConnector`/`load_static_files`/`include_static_files` against django-stubs' `URLPattern`/`URLResolver` types, and register `django_boost.urls.static` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
The registry entry is inserted right after the existing `urls.converters.*` block, deliberately isolated from other in-flight type-hint PRs so they can merge in any order without conflicting in mypy.ini.

## Verification
- `mypy django_boost` green
- `mypy --config-file=/dev/null --no-incremental --follow-imports=skip django_boost/urls/static.py` green
- `flake8 django_boost/urls/static.py` clean
- `manage.py test` (499 tests) green