### PR TITLE
:label: Type the numeric-base URL converters (urls.converters __init__)

### DIFF
--- a/django_boost/urls/converters/__init__.py
+++ b/django_boost/urls/converters/__init__.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from typing import ClassVar, TYPE_CHECKING, cast
+
 from django.urls import register_converter
+
+if TYPE_CHECKING:
+    from django.urls.converters import _Converter
 
 from django_boost.urls.converters.date import DateConverter
 from django_boost.urls.converters.decimal import (
@@ -25,9 +30,9 @@ class HexConverter:
     ``NoReverseMatch``.
     """
 
-    regex = '[0-9a-fA-F]+'
+    regex: ClassVar[str] = '[0-9a-fA-F]+'
 
-    def to_url(self, value):  # noqa: D102
+    def to_url(self, value: int | str) -> str:  # noqa: D102
         if isinstance(value, int):
             return hex(value)[2:]
         return str(value)
@@ -40,9 +45,9 @@ class OctConverter:
     ``NoReverseMatch``.
     """
 
-    regex = '[0-7]+'
+    regex: ClassVar[str] = '[0-7]+'
 
-    def to_url(self, value):  # noqa: D102
+    def to_url(self, value: int | str) -> str:  # noqa: D102
         if isinstance(value, int):
             return oct(value)[2:]
         return str(value)
@@ -55,45 +60,49 @@ class BinConverter:
     ``NoReverseMatch``.
     """
 
-    regex = '[01]+'
+    regex: ClassVar[str] = '[01]+'
 
-    def to_url(self, value):  # noqa: D102
+    def to_url(self, value: int | str) -> str:  # noqa: D102
         if isinstance(value, int):
             return bin(value)[2:]
         return str(value)
 
 
 class HexIntConverter(HexConverter):  # noqa: D101
-    def to_python(self, value):  # noqa: D102
+    def to_python(self, value: str) -> int:  # noqa: D102
         return int(value, 16)
 
 
 class OctIntConverter(OctConverter):  # noqa: D101
-    def to_python(self, value):  # noqa: D102
+    def to_python(self, value: str) -> int:  # noqa: D102
         return int(value, 8)
 
 
 class BinIntConverter(BinConverter):  # noqa: D101
-    def to_python(self, value):  # noqa: D102
+    def to_python(self, value: str) -> int:  # noqa: D102
         return int(value, 2)
 
 
 class HexStrConverter(HexConverter):  # noqa: D101
-    def to_python(self, value):  # noqa: D102
+    def to_python(self, value: str) -> str:  # noqa: D102
         return value
 
 
 class OctStrConverter(OctConverter):  # noqa: D101
-    def to_python(self, value):  # noqa: D102
+    def to_python(self, value: str) -> str:  # noqa: D102
         return value
 
 
 class BinStrConverter(BinConverter):  # noqa: D101
-    def to_python(self, value):  # noqa: D102
+    def to_python(self, value: str) -> str:  # noqa: D102
         return value
 
 
-BOOST_CONVERTERS = {
+# The converters mix ClassVar[str] regex (this package's local convention,
+# e.g. integer.py) with plain-str regex; mypy's type[X] <: type[_Converter]
+# check only recognizes the latter, so the heterogeneous mapping needs one
+# cast to assert what's structurally already true.
+BOOST_CONVERTERS = cast("dict[str, type[_Converter]]", {
     'bin': BinIntConverter,
     'oct': OctIntConverter,
     'hex': HexIntConverter,
@@ -121,10 +130,10 @@ BOOST_CONVERTERS = {
     'non_negative_decimal': NonNegativeDecimalConverter,
     'non_positive_decimal': NonPositiveDecimalConverter,
     'non_zero_decimal': NonZeroDecimalConverter,
-}
+})
 
 
-def register_boost_converters():
+def register_boost_converters() -> None:
     """Register all of django_boost's URL converters (``BOOST_CONVERTERS``) with Django."""
     for name, klass in BOOST_CONVERTERS.items():
         register_converter(klass, name)

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,9 +37,6 @@ ignore_missing_imports = True
 [mypy-django_boost.*]
 ignore_errors = True
 
-[mypy-django_boost.urls.converters]
-ignore_errors = True
-
 [mypy-django_boost.urls.converters.*]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `HexConverter`/`OctConverter`/`BinConverter` and their Int/Str subclasses, and drop the `[mypy-django_boost.urls.converters]` `ignore_errors=True` override now that the package's own `__init__` type-checks under the existing `urls.converters.*` block (issue #164 rollout).

## Notes
- The mypy.ini change only deletes a pre-existing, self-contained block, so it can't conflict with other in-flight type-hint PRs touching different parts of the registry.
- `BOOST_CONVERTERS` mixes converters using this package's `ClassVar[str]` regex convention (e.g. `integer.py`) with plain-`str` regex; mypy's `type[X] <: type[_Converter]` check (django-stubs' registration Protocol) only recognizes the latter, so the heterogeneous mapping needs one `cast()` to assert what's structurally already true.

## Verification
- `mypy django_boost` green
- `flake8 django_boost/urls/converters/__init__.py` clean
- `manage.py test` (499 tests) green