### PR TITLE
:label: Type the model/JSON conversion helpers (utils.functions.json)

### DIFF
--- a/django_boost/utils/functions/json.py
+++ b/django_boost/utils/functions/json.py
@@ -2,12 +2,37 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection, Mapping
+from typing import Any, TypeVar, overload
+
 from django.db import models
 
 __all__ = ["json_to_model", "model_to_json"]
 
+_M = TypeVar("_M", bound=models.Model)
 
-def model_to_json(model, fields=(), exclude=()):
+
+@overload
+def model_to_json(
+    model: models.Model,
+    fields: Collection[str] = ...,
+    exclude: Collection[str] = ...,
+) -> dict[str, Any]: ...
+
+
+@overload
+def model_to_json(
+    model: models.QuerySet[models.Model],
+    fields: Collection[str] = ...,
+    exclude: Collection[str] = ...,
+) -> list[dict[str, Any]]: ...
+
+
+def model_to_json(
+    model: models.Model | models.QuerySet[models.Model],
+    fields: Collection[str] = (),
+    exclude: Collection[str] = (),
+) -> dict[str, Any] | list[dict[str, Any]]:
     """
     Take Model or Model.QuerySet as an argument.
 
@@ -15,7 +40,7 @@ def model_to_json(model, fields=(), exclude=()):
     """
     if isinstance(model, models.Model):
         opts = model._meta
-        json_data = {}
+        json_data: dict[str, Any] = {}
         for f in opts.fields:
             if fields and f.name not in fields:
                 continue
@@ -25,8 +50,7 @@ def model_to_json(model, fields=(), exclude=()):
         return json_data
 
     elif isinstance(model, models.QuerySet):
-        json_data = [model_to_json(m, fields, exclude) for m in model]
-        return json_data
+        return [model_to_json(m, fields, exclude) for m in model]
 
     raise TypeError(
         'model_to_json() argument must be a Model or QuerySet, not %s'
@@ -34,7 +58,12 @@ def model_to_json(model, fields=(), exclude=()):
     )
 
 
-def json_to_model(model_class, dic, fields=(), exclude=()):
+def json_to_model(
+    model_class: type[_M],
+    dic: Mapping[str, Any],
+    fields: Collection[str] = (),
+    exclude: Collection[str] = (),
+) -> _M:
     """Build an unsaved ``model_class`` instance from a dict shaped like ``model_to_json``'s output."""
     model = model_class()
     for f in model._meta.fields:

--- a/mypy.ini
+++ b/mypy.ini
@@ -70,6 +70,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.utils.functions.json]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.utils]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `model_to_json`/`json_to_model` and register `django_boost.utils.functions.json` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout). This completes the `utils.functions` package (`loop` was already typed).

## Notes
- `model_to_json` uses two `@overload` signatures (`Model -> dict[str, Any]`, `QuerySet -> list[dict[str, Any]]`); `json_to_model` uses a `TypeVar` bound to `Model` (`type[_M] -> _M`). The ORM boundary is carried with zero casts/ignores.
- The registry entry is inserted right after the sibling `utils.functions.loop` block, deliberately isolated from other in-flight type-hint PRs so they can merge in any order without conflicting in mypy.ini.

## Verification
- `mypy django_boost` green (an `assert_type` probe confirmed the return types are real, not `Any`)
- `flake8 django_boost/utils/functions/json.py` clean
- `manage.py test` (499 tests) green