### PR TITLE
:label: Type the contrib admin_tools app config (contrib.admin_tools.apps)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -130,6 +130,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.contrib.admin_tools.apps]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 # example/ is a development harness, but keep it type-checked so the sample app
 # continues to compile against django-boost's public APIs. Tests and migrations
 # are excluded above.


### PR DESCRIPTION
## Summary
Register `django_boost.contrib.admin_tools.apps` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout). No source change needed — `AdminToolsConfig` has no function defs, so it already satisfies `disallow_untyped_defs`/`disallow_incomplete_defs` as-is.

## Notes
The registry entry is inserted right after the existing `apps` block and before the `example.*` comment, deliberately isolated from other in-flight type-hint PRs so they can merge in any order without conflicting in mypy.ini.

## Verification
- `mypy django_boost` green
- `mypy --config-file=/dev/null --no-incremental --follow-imports=skip django_boost/contrib/admin_tools/apps.py` green (negative control)
- `flake8 django_boost/contrib/admin_tools/apps.py` clean
- `manage.py test` (501 tests) green