### PR TITLE
:label: Type the user-agent context processor (context_processors)

### DIFF
--- a/django_boost/context_processors.py
+++ b/django_boost/context_processors.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from django.http import HttpRequest
+
 from django_boost.user_agents import parse_user_agent
 
 
-def user_agent(request):
+def user_agent(request: HttpRequest) -> dict[str, Any]:
     """Add parsed user-agent details (browser, device, OS, bot/mobile/tablet flags) to the template context."""
     agent = request.META.get('HTTP_USER_AGENT', '')
     user_agent = parse_user_agent(agent)

--- a/mypy.ini
+++ b/mypy.ini
@@ -124,6 +124,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.context_processors]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.apps]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `user_agent(request: HttpRequest) -> dict[str, Any]` and register `django_boost.context_processors` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
- `django_boost.user_agents` itself stays unregistered: the optional `user-agents` dependency ships no stubs, so `parse_user_agent`'s return is `Any` — annotating that module would only add a vacuous `-> Any` with no real safety.
- The registry entry is inserted right after the existing `middleware.html` block and before the `apps` block, deliberately isolated from other in-flight type-hint PRs so they can merge in any order without conflicting in mypy.ini.

## Verification
- `mypy django_boost` green
- `flake8 django_boost/context_processors.py` clean
- `manage.py test` (501 tests) green