### PR TITLE
:label: Type the deprecated admin_tools app config (admin_tools.apps)

### DIFF
--- a/django_boost/admin_tools/apps.py
+++ b/django_boost/admin_tools/apps.py
@@ -12,7 +12,7 @@ class AdminToolsConfig(AppConfig):
 
     name = 'django_boost.admin_tools'
 
-    def ready(self):  # noqa: D102
+    def ready(self) -> None:  # noqa: D102
         warnings.warn(
             "'django_boost.admin_tools' is deprecated and will be removed in "
             "django-boost 4.0; use 'django_boost.contrib.admin_tools' instead.",

--- a/mypy.ini
+++ b/mypy.ini
@@ -91,6 +91,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.admin_tools.apps]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.core.management]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `AdminToolsConfig.ready()` and register `django_boost.admin_tools.apps` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout) — same shape as the already-typed `apps.py`, just on the deprecated alias package.

## Notes
The registry entry is inserted right after the existing `core` block, isolated from the still-open type-hint PRs' insertion points.

## Verification
- `mypy django_boost` green
- `mypy --config-file=/dev/null --no-incremental --follow-imports=skip django_boost/admin_tools/apps.py` green (negative control)
- `flake8 django_boost/admin_tools/apps.py` clean
- `manage.py test` (503 tests) green