### PR TITLE
:label: Type the custom form widgets (forms.widgets)

### DIFF
--- a/django_boost/forms/widgets.py
+++ b/django_boost/forms/widgets.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from django.core.files.uploadedfile import UploadedFile
 from django.forms.widgets import CheckboxInput, Input, RadioSelect
+from django.utils.datastructures import MultiValueDict
 
 __all__ = ["ColorInput", "InvertCheckboxInput", "PhoneNumberInput"]
 
@@ -28,19 +33,28 @@ class StarRateSelect(RadioSelect):
     option_template_name = "boost/forms/widgets/star_radio_input.html"
 
 
-def boolean_check(v):
+def boolean_check(v: Any) -> bool:
     return (v is False or v is None or v == '')
 
 
 class InvertCheckboxInput(CheckboxInput):
     """Returns false if checked, true if not checked."""
 
-    def __init__(self, attrs=None, check_test=None):
+    def __init__(
+        self,
+        attrs: dict[str, Any] | None = None,
+        check_test: Callable[[Any], bool] | None = None,
+    ) -> None:
         """Fall back to treating ``False``, ``None``, and ``''`` as checked when ``check_test`` is omitted."""
         super().__init__(attrs)
         self.check_test = boolean_check if check_test is None else check_test
 
-    def value_from_datadict(self, data, files, name):  # noqa: D102
+    def value_from_datadict(  # noqa: D102
+        self,
+        data: Mapping[str, Any],
+        files: MultiValueDict[str, UploadedFile],
+        name: str,
+    ) -> bool:
         return not super().value_from_datadict(data, files, name)
 
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -73,6 +73,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.forms.widgets]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.utils.functions.json]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `ColorInput`/`PhoneNumberInput`/`StarRateSelect`/`Toggleswitch` (no override methods) and `InvertCheckboxInput`'s `__init__`/`value_from_datadict` against django-stubs' `CheckboxInput` signatures, and register `django_boost.forms.widgets` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
Single inheritance throughout, no cooperative-inheritance concern. The registry entry is inserted between the sibling `utils.functions.loop`/`utils.functions.json` blocks, isolated from other in-flight type-hint PRs.

## Verification
- `mypy django_boost` green
- `mypy --config-file=/dev/null --no-incremental --follow-imports=skip django_boost/forms/widgets.py` green (negative control)
- `flake8 django_boost/forms/widgets.py` clean
- `manage.py test` (503 tests) green