### PR TITLE
:label: Type the app-template overlay command (management.templates)

### DIFF
--- a/django_boost/management/templates.py
+++ b/django_boost/management/templates.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import tempfile
 from os import path
+from typing import Any, cast
 
 from django.core.management.templates import TemplateCommand as DjangoTemplateCommand
 
@@ -16,25 +17,28 @@ from django_boost.core.management import CommandVersion
 class TemplateCommand(CommandVersion, DjangoTemplateCommand):
     """Django's own ``TemplateCommand`` plus ``--version`` support and a django-boost app template default."""
 
-    def handle_template(self, template, subdir):
+    def handle_template(self, template: str | None, subdir: str | None) -> str:
         """Resolve the template directory, overlaying django-boost's extras onto the built-in default."""
         base = super().handle_template(template, subdir)
         # Only enhance the built-in template; a user-supplied --template is left untouched.
         if template is not None:
             return base
+        assert subdir is not None
         overlay = path.join(django_boost.__path__[0], 'conf', subdir)
         if not path.isdir(overlay):
             return base
         return self._compose(base, overlay)
 
-    def _compose(self, base, overlay):
+    def _compose(self, base: str, overlay: str) -> str:
         """Layer django-boost's extra files onto Django's base template.
 
         Files already shipped by ``base`` win, so anything Django starts
         providing under the same name supersedes our overlay automatically.
         """
         composed = tempfile.mkdtemp()
-        self.paths_to_remove.append(composed)
+        # django-stubs types TemplateCommand.paths_to_remove as Sequence[Any],
+        # but Django's own __init__ always assigns a real list.
+        cast(list[Any], self.paths_to_remove).append(composed)
         shutil.copytree(base, composed, dirs_exist_ok=True)
         for root, _dirs, files in os.walk(overlay):
             rel = path.relpath(root, overlay)

--- a/mypy.ini
+++ b/mypy.ini
@@ -121,6 +121,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.management.templates]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.utils.attribute]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `TemplateCommand.handle_template`/`_compose` against django-stubs' `TemplateCommand` signatures, and register `django_boost.management.templates` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
- `handle_template`'s `subdir` can be `None` per django-stubs' signature, but this override always needs a real one past the early-return; added an explicit `assert` instead of silently defaulting.
- django-stubs types `TemplateCommand.paths_to_remove` as `Sequence[Any]`, but Django's own `__init__` always assigns a real `list`; `cast()` the one `.append()` call rather than fighting the stub.
- The registry entry is inserted between the sibling `test.testcase`/`utils.attribute` blocks, isolated from other in-flight type-hint PRs.

## Verification
- `mypy django_boost` green
- `flake8 django_boost/management/templates.py` clean
- `manage.py test` (503 tests) green