### PR TITLE
:label: Type the logical-deletion admin filters (admin.filters)

### DIFF
--- a/django_boost/admin/filters.py
+++ b/django_boost/admin/filters.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import date, timedelta
+from typing import Any, Iterator, TYPE_CHECKING, cast
 
 from django.contrib import admin
 from django.contrib.admin.filters import ListFilter
+from django.contrib.admin.views.main import ChangeList
 from django.core.exceptions import ValidationError
+from django.db.models import Model, QuerySet
 from django.forms import DateField
+from django.http import HttpRequest
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from django_boost.models.query import LogicalDeletionQuerySet
+
+if TYPE_CHECKING:
+    from django.contrib.admin.filters import _ListFilterChoices
 
 __all__ = ["LogicalDeletedDateFilter", "LogicalDeletedFilter"]
 
@@ -21,23 +29,30 @@ class LogicalDeletedFilter(admin.SimpleListFilter):
     title = 'delete state'
     parameter_name = 'delete_state'
 
-    def lookups(self, request, model_admin):  # noqa: D102
+    def lookups(  # noqa: D102
+        self, request: HttpRequest, model_admin: admin.ModelAdmin,
+    ) -> tuple[tuple[str, str], tuple[str, str]]:
         return (
             ('alive', ('Alive')),
             ('dead', ('Dead')),
         )
 
-    def queryset(self, request, queryset):  # noqa: D102
+    def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet | None:  # noqa: D102
         value = self.value()
+        # SimpleListFilter's declared queryset type is the base QuerySet, but
+        # this filter only ever attaches to LogicalDeletionMixin models, whose
+        # managers return LogicalDeletionQuerySet (alive()/dead()).
+        qs = cast(LogicalDeletionQuerySet, queryset)
         if value == 'alive':
-            return queryset.alive()
+            return cast(QuerySet, qs.alive())
         if value == 'dead':
-            return queryset.dead()
+            return cast(QuerySet, qs.dead())
+        return None
 
-    def choices(self, changelist):  # noqa: D102
+    def choices(self, changelist: ChangeList) -> Iterator[_ListFilterChoices]:  # noqa: D102
         for index, choice in enumerate(super().choices(changelist)):
             if index == 1:
-                choice = dict(choice)
+                choice = cast("_ListFilterChoices", dict(choice))
                 choice['query_string'] = changelist.get_query_string(
                     {self.parameter_name: 'alive'},
                     [
@@ -52,6 +67,11 @@ class LogicalDeletedFilter(admin.SimpleListFilter):
 class LogicalDeletedDateFilter(admin.FieldListFilter):
     """Filter logically deleted objects by common periods or an inclusive date range."""
 
+    # This filter only ever stores plain strings (see __init__), unlike the
+    # base ListFilter.used_parameters: dict[str, object] -- same narrowing
+    # django-stubs itself applies for SimpleListFilter.
+    used_parameters: dict[str, str]  # type: ignore[assignment]
+
     template = 'boost/admin/logical_deleted_date_filter.html'
     title = _('deleted date')
 
@@ -59,7 +79,18 @@ class LogicalDeletedDateFilter(admin.FieldListFilter):
     from_parameter = 'deleted_from'
     to_parameter = 'deleted_to'
 
-    def __init__(self, field, request, params, model, model_admin, field_path):  # noqa: D107
+    def __init__(  # noqa: D107
+        self,
+        field: Any,
+        request: HttpRequest,
+        # django-stubs types ListFilter.__init__'s params as dict[str, str] on
+        # 5.1.3 (CI's Django 4.2 cell) but dict[str, list[str]] on 6.0.6 (CI's
+        # Django 5.2 cell); dict[str, Any] satisfies both.
+        params: dict[str, Any],
+        model: type[Model],
+        model_admin: admin.ModelAdmin,
+        field_path: str,
+    ) -> None:
         self.field = field
         self.field_path = field_path
         self.lookup_choices = (
@@ -73,10 +104,8 @@ class LogicalDeletedDateFilter(admin.FieldListFilter):
         ListFilter.__init__(self, request, params, model, model_admin)
         for parameter in self.expected_parameters():
             if parameter in params:
-                value = params.pop(parameter)
-                if isinstance(value, (list, tuple)):
-                    value = value[-1]
-                self.used_parameters[parameter] = value
+                raw = params.pop(parameter)
+                self.used_parameters[parameter] = raw[-1] if isinstance(raw, (list, tuple)) else raw
 
         excluded = set(self.expected_parameters()) | {'delete_state', 'p'}
         self.preserved_parameters = [
@@ -85,16 +114,18 @@ class LogicalDeletedDateFilter(admin.FieldListFilter):
             if key not in excluded
             for value in values
         ]
-        self.errors = []
+        self.errors: list[Any] = []
 
-    def expected_parameters(self):  # noqa: D102
+    def expected_parameters(self) -> list[str | None]:  # noqa: D102
         return [self.period_parameter, self.from_parameter, self.to_parameter]
 
-    def has_output(self):  # noqa: D102
+    def has_output(self) -> bool:  # noqa: D102
         return True
 
-    def choices(self, changelist):  # noqa: D102
-        own_parameters = self.expected_parameters()
+    def choices(self, changelist: ChangeList) -> Iterator[_ListFilterChoices]:  # noqa: D102
+        # expected_parameters()'s return type is widened to match the base
+        # ListFilter signature, but this override never actually includes None.
+        own_parameters = cast("list[str]", self.expected_parameters())
         has_range = bool(self.from_value or self.to_value)
         yield {
             'selected': self.value() is None and not has_range,
@@ -111,39 +142,43 @@ class LogicalDeletedDateFilter(admin.FieldListFilter):
                 'display': title,
             }
 
-    def value(self):
+    def value(self) -> str | None:
         """Return the selected preset period."""
         return self.used_parameters.get(self.period_parameter)
 
     @property
-    def from_value(self):
+    def from_value(self) -> str:
         """Return the submitted inclusive start date."""
         return self.used_parameters.get(self.from_parameter, '')
 
     @property
-    def to_value(self):
+    def to_value(self) -> str:
         """Return the submitted inclusive end date."""
         return self.used_parameters.get(self.to_parameter, '')
 
-    def queryset(self, request, queryset):  # noqa: D102
+    def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet:  # noqa: D102
+        # LogicalDeletedDateFilter only ever attaches to LogicalDeletionMixin
+        # models, same as LogicalDeletedFilter above.
+        qs = cast(LogicalDeletionQuerySet, queryset)
         if self.from_value or self.to_value:
-            return self._range_queryset(queryset)
+            return self._range_queryset(qs)
 
         period = self.value()
         if period == 'all_deleted':
-            return queryset.dead()
+            return cast(QuerySet, qs.dead())
         if period == 'today':
-            return queryset.deleted_since(1)
+            return cast(QuerySet, qs.deleted_since(1))
         if period in {'past_7_days', 'past_30_days', 'past_90_days'}:
             days = int(period.split('_')[1])
-            return queryset.deleted_since(days)
+            return cast(QuerySet, qs.deleted_since(days))
         if period == 'older_than_90_days':
-            return queryset.deleted_before(self._local_today() - timedelta(days=89))
-        return queryset
+            return cast(QuerySet, qs.deleted_before(self._local_today() - timedelta(days=89)))
+        return cast(QuerySet, qs)
 
-    def _range_queryset(self, queryset):
+    def _range_queryset(self, queryset: LogicalDeletionQuerySet) -> QuerySet:
         date_field = DateField(input_formats=['%Y-%m-%d'])
-        start = end = None
+        start: date | None = None
+        end: date | None = None
         try:
             if self.from_value:
                 start = date_field.clean(self.from_value)
@@ -151,16 +186,16 @@ class LogicalDeletedDateFilter(admin.FieldListFilter):
                 end = date_field.clean(self.to_value)
         except ValidationError as error:
             self.errors.extend(error.messages)
-            return queryset
+            return cast(QuerySet, queryset)
 
         if start and end and start > end:
             self.errors.append(_('Start date must be on or before end date.'))
-            return queryset
+            return cast(QuerySet, queryset)
 
-        return queryset.deleted_between(start=start, end=end)
+        return cast(QuerySet, queryset.deleted_between(start=start, end=end))
 
     @staticmethod
-    def _local_today():
+    def _local_today() -> date:
         now = timezone.now()
         if timezone.is_aware(now):
             now = timezone.localtime(now)

--- a/mypy.ini
+++ b/mypy.ini
@@ -61,6 +61,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.admin.filters]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.utils.version]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `LogicalDeletedFilter`/`LogicalDeletedDateFilter` against django-stubs' `SimpleListFilter`/`FieldListFilter`, and register `django_boost.admin.filters` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
Single inheritance throughout, no cooperative-inheritance concern. A few casts, each tied to a specific stub-vs-runtime gap:
- `LogicalDeletedFilter.queryset`: `SimpleListFilter.queryset` is declared against the base `QuerySet`, but this filter only ever attaches to `LogicalDeletionMixin` models (`LogicalDeletionQuerySet.alive()`/`.dead()`).
- `LogicalDeletedDateFilter.used_parameters` is narrowed to `dict[str, str]` (same narrowing django-stubs itself applies to `SimpleListFilter`, with the same `# type: ignore[assignment]`) since this filter only ever stores plain strings.
- `choices()`'s `dict(choice)` copy and `expected_parameters()`'s widened `list[str | None]` override (`list` is invariant, so `list[str]` can't override `list[str | None]` even though every element really is `str`) each need one cast to hand back the narrower shape callers expect.

The registry entry is inserted between the sibling `utils.itertools`/`utils.version` blocks, isolated from other in-flight type-hint PRs.

## Verification
- `mypy django_boost` green
- `flake8 django_boost/admin/filters.py` clean
- `manage.py test` (503 tests, including the 21 dedicated filter tests) green