### PR TITLE
:label: Type the management command mixins (management.mixins)

### DIFF
--- a/django_boost/management/mixins.py
+++ b/django_boost/management/mixins.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 import csv
+from collections.abc import Iterable, Mapping
 from io import StringIO
+from typing import Any, ClassVar, TYPE_CHECKING
 
-from django.core.management.base import CommandError
+from django.core.management.base import CommandError, CommandParser, OutputWrapper
+
+from django_boost.core.management import BaseCommand
+
+if TYPE_CHECKING:
+    _BaseCommandHost = BaseCommand
+else:
+    _BaseCommandHost = object
 
 
-class OutputFormatMixin:
+class OutputFormatMixin(_BaseCommandHost):
     """Add a ``--format`` option with shared text/csv/tsv rendering.
 
     Mix into a ``BaseCommand`` subclass -- it writes through ``self.stdout``
@@ -20,27 +29,27 @@ class OutputFormatMixin:
     dispatch are shared.
     """
 
-    TEXT_FORMAT = "text"
-    DELIMITED_FORMATS = {
+    TEXT_FORMAT: ClassVar[str] = "text"
+    DELIMITED_FORMATS: ClassVar[dict[str, str]] = {
         "csv": ",",
         "tsv": "\t",
     }
-    OUTPUT_FIELDS = ()
+    OUTPUT_FIELDS: ClassVar[tuple[str, ...]] = ()
 
-    def supported_formats(self):  # noqa: D102
+    def supported_formats(self) -> list[str]:  # noqa: D102
         return [self.TEXT_FORMAT, *self.DELIMITED_FORMATS]
 
-    def add_format_option(self, parser):  # noqa: D102
+    def add_format_option(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument('--format', choices=self.supported_formats(),
                             default=self.TEXT_FORMAT,
                             help="Output format.")
 
-    def get_row_data(self, obj, **options):  # noqa: D102
+    def get_row_data(self, obj: Any, **options: Any) -> Mapping[str, Any]:  # noqa: D102
         raise NotImplementedError(
             "%s must implement get_row_data() returning a mapping with keys %s"
             % (type(self).__name__, tuple(self.OUTPUT_FIELDS)))
 
-    def _row_values(self, obj, **options):
+    def _row_values(self, obj: Any, **options: Any) -> list[Any]:
         data = self.get_row_data(obj, **options)
         missing = [field for field in self.OUTPUT_FIELDS if field not in data]
         if missing:
@@ -49,14 +58,14 @@ class OutputFormatMixin:
                 % (type(self).__name__, ", ".join(missing)))
         return [data[field] for field in self.OUTPUT_FIELDS]
 
-    def print_text(self, rows, **options):  # noqa: D102
+    def print_text(self, rows: Iterable[Any], **options: Any) -> None:  # noqa: D102
         self.stdout.write(" | ".join(self.OUTPUT_FIELDS))
         for obj in rows:
             self.stdout.write(
                 " | ".join(str(value)
                            for value in self._row_values(obj, **options)))
 
-    def print_delimited(self, rows, delimiter, **options):  # noqa: D102
+    def print_delimited(self, rows: Iterable[Any], delimiter: str, **options: Any) -> None:  # noqa: D102
         stream = StringIO()
         writer = csv.writer(stream, delimiter=delimiter)
         writer.writerow(self.OUTPUT_FIELDS)
@@ -64,7 +73,7 @@ class OutputFormatMixin:
             writer.writerow(self._row_values(obj, **options))
         self.stdout.write(stream.getvalue(), ending="")
 
-    def print_formatted(self, rows, **options):  # noqa: D102
+    def print_formatted(self, rows: Iterable[Any], **options: Any) -> None:  # noqa: D102
         output_format = options["format"]
         if output_format == self.TEXT_FORMAT:
             self.print_text(rows, **options)
@@ -80,10 +89,10 @@ class OutputFormatMixin:
 class ConfirmOptionMixin:
     """Add a ``-y`` option and a ``confirm()`` helper that prompts unless it's set."""
 
-    def add_confirm_option(self, parser):  # noqa: D102
+    def add_confirm_option(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument('-y', action='store_true')
 
-    def confirm(self, message, **options):  # noqa: D102
+    def confirm(self, message: str, **options: Any) -> bool:  # noqa: D102
         if not options.get('y', False):
             answer = None
             while not answer or answer not in "yn":
@@ -97,13 +106,16 @@ class ConfirmOptionMixin:
         return True
 
 
-class QuitOptionMixin:
+class QuitOptionMixin(_BaseCommandHost):
     """Add a ``-q``/``--quit`` option that silences ``self.stdout``/``self.stderr``."""
 
-    def add_quit_option(self, parser):  # noqa: D102
+    def add_quit_option(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument('-q', '--quit', action='store_true',
                             help="Don't output to standard output.")
 
-    def if_needed_make_quit(self, **options):  # noqa: D102
+    def if_needed_make_quit(self, **options: Any) -> None:  # noqa: D102
         if options.get('quit', False):
-            self.stderr = self.stdout = StringIO()
+            # BaseCommand.stdout/.stderr are OutputWrapper (its write() takes
+            # an ending= kwarg plain StringIO.write doesn't); wrap the StringIO
+            # instead of assigning it directly.
+            self.stderr = self.stdout = OutputWrapper(StringIO())

--- a/mypy.ini
+++ b/mypy.ini
@@ -61,6 +61,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.management.mixins]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.utils.html]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `OutputFormatMixin`/`ConfirmOptionMixin`/`QuitOptionMixin`, and register `django_boost.management.mixins` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
- `OutputFormatMixin` and `QuitOptionMixin` touch `self.stdout`/`self.stderr` (attributes their eventual `BaseCommand` host provides, not declared on the mixin itself), so both use a `TYPE_CHECKING`-only fake base (`_BaseCommandHost = BaseCommand if TYPE_CHECKING else object`, runtime base stays `object`) rather than a hand-rolled Protocol — every real consumer genuinely mixes these with `django_boost.core.management.BaseCommand`/`AppCommand`, so the concrete class stays in sync with django-stubs automatically. A scoped `self: BaseCommand` annotation on just `if_needed_make_quit` (without the class-level fake base) doesn't work — mypy rejects it ("erased type of self is not a supertype of its class") since `QuitOptionMixin` has no real base to make `BaseCommand` a valid self-type.
- `ConfirmOptionMixin` needs neither (no cross-cutting host access at all).
- One real bug found and fixed: `QuitOptionMixin.if_needed_make_quit` assigned a plain `io.StringIO` to `self.stdout`/`self.stderr`, but `BaseCommand` types (and Django itself constructs) them as `OutputWrapper`, whose `write()` accepts an `ending=` kwarg plain `StringIO.write` doesn't — wrapped it (`OutputWrapper(StringIO())`) to close a latent `TypeError` if this mixin is ever combined with `OutputFormatMixin`.
- The registry entry is inserted between the sibling `utils.version`/`utils.html` blocks, isolated from other in-flight type-hint PRs.

## Verification
- `mypy django_boost` green
- `flake8 django_boost/management/mixins.py` clean
- `manage.py test` (503 tests, including the 22 dedicated mixin/command tests) green