### PR TITLE
:label: Type the deletemigrations command (management.commands.deletemigrations)

### DIFF
--- a/django_boost/management/commands/deletemigrations.py
+++ b/django_boost/management/commands/deletemigrations.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import os
+from typing import Any
 
+from django.core.management.base import CommandParser
 from django.db.migrations.loader import MIGRATIONS_MODULE_NAME
 from django.utils.translation import gettext as _
 
@@ -14,13 +16,13 @@ from django_boost.management.mixins import ConfirmOptionMixin, QuitOptionMixin
 class Command(ConfirmOptionMixin, QuitOptionMixin, AppCommand):  # noqa: D101
     help = "delete migration files."
 
-    def add_arguments(self, parser):  # noqa: D102
+    def add_arguments(self, parser: CommandParser) -> None:  # noqa: D102
         super().add_arguments(parser)
         self.add_quit_option(parser)
         self.add_confirm_option(parser)
 
     @staticmethod
-    def _migration_files(migration_dir):
+    def _migration_files(migration_dir: str) -> list[str]:
         # Only the top-level migration modules; do not descend into nested
         # packages (e.g. a migrations/helpers/ holding non-migration modules),
         # which os.walk would sweep in and delete.
@@ -34,7 +36,7 @@ class Command(ConfirmOptionMixin, QuitOptionMixin, AppCommand):  # noqa: D101
             file_list.append(path)
         return file_list
 
-    def handle_app_config(self, app_config, **options):  # noqa: D102
+    def handle_app_config(self, app_config: Any, **options: Any) -> str | None:  # noqa: D102
         self.if_needed_make_quit(**options)
         app_path = app_config.path
         migration_dir = os.path.join(app_path, MIGRATIONS_MODULE_NAME)
@@ -46,10 +48,11 @@ class Command(ConfirmOptionMixin, QuitOptionMixin, AppCommand):  # noqa: D101
         if not file_list:
             self.stderr.write(
                 'No migration files detected in %s' % app_config.name)
-            return
+            return None
         if self.confirm(message=_("Do you wish to delete?"), **options):
             for file in file_list:
                 os.remove(file)
             self.stdout.write(self.style.SUCCESS('file deleted.'))
         else:
             self.stderr.write('job canceled.')
+        return None

--- a/django_boost/management/mixins.py
+++ b/django_boost/management/mixins.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 import csv
+from collections.abc import Iterable, Mapping
 from io import StringIO
+from typing import Any, ClassVar, TYPE_CHECKING
 
-from django.core.management.base import CommandError
+from django.core.management.base import CommandError, CommandParser, OutputWrapper
+
+from django_boost.core.management import BaseCommand
+
+if TYPE_CHECKING:
+    _BaseCommandHost = BaseCommand
+else:
+    _BaseCommandHost = object
 
 
-class OutputFormatMixin:
+class OutputFormatMixin(_BaseCommandHost):
     """Add a ``--format`` option with shared text/csv/tsv rendering.
 
     Mix into a ``BaseCommand`` subclass -- it writes through ``self.stdout``
@@ -20,27 +29,27 @@ class OutputFormatMixin:
     dispatch are shared.
     """
 
-    TEXT_FORMAT = "text"
-    DELIMITED_FORMATS = {
+    TEXT_FORMAT: ClassVar[str] = "text"
+    DELIMITED_FORMATS: ClassVar[dict[str, str]] = {
         "csv": ",",
         "tsv": "\t",
     }
-    OUTPUT_FIELDS = ()
+    OUTPUT_FIELDS: ClassVar[tuple[str, ...]] = ()
 
-    def supported_formats(self):  # noqa: D102
+    def supported_formats(self) -> list[str]:  # noqa: D102
         return [self.TEXT_FORMAT, *self.DELIMITED_FORMATS]
 
-    def add_format_option(self, parser):  # noqa: D102
+    def add_format_option(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument('--format', choices=self.supported_formats(),
                             default=self.TEXT_FORMAT,
                             help="Output format.")
 
-    def get_row_data(self, obj, **options):  # noqa: D102
+    def get_row_data(self, obj: Any, **options: Any) -> Mapping[str, Any]:  # noqa: D102
         raise NotImplementedError(
             "%s must implement get_row_data() returning a mapping with keys %s"
             % (type(self).__name__, tuple(self.OUTPUT_FIELDS)))
 
-    def _row_values(self, obj, **options):
+    def _row_values(self, obj: Any, **options: Any) -> list[Any]:
         data = self.get_row_data(obj, **options)
         missing = [field for field in self.OUTPUT_FIELDS if field not in data]
         if missing:
@@ -49,14 +58,14 @@ class OutputFormatMixin:
                 % (type(self).__name__, ", ".join(missing)))
         return [data[field] for field in self.OUTPUT_FIELDS]
 
-    def print_text(self, rows, **options):  # noqa: D102
+    def print_text(self, rows: Iterable[Any], **options: Any) -> None:  # noqa: D102
         self.stdout.write(" | ".join(self.OUTPUT_FIELDS))
         for obj in rows:
             self.stdout.write(
                 " | ".join(str(value)
                            for value in self._row_values(obj, **options)))
 
-    def print_delimited(self, rows, delimiter, **options):  # noqa: D102
+    def print_delimited(self, rows: Iterable[Any], delimiter: str, **options: Any) -> None:  # noqa: D102
         stream = StringIO()
         writer = csv.writer(stream, delimiter=delimiter)
         writer.writerow(self.OUTPUT_FIELDS)
@@ -64,7 +73,7 @@ class OutputFormatMixin:
             writer.writerow(self._row_values(obj, **options))
         self.stdout.write(stream.getvalue(), ending="")
 
-    def print_formatted(self, rows, **options):  # noqa: D102
+    def print_formatted(self, rows: Iterable[Any], **options: Any) -> None:  # noqa: D102
         output_format = options["format"]
         if output_format == self.TEXT_FORMAT:
             self.print_text(rows, **options)
@@ -80,10 +89,10 @@ class OutputFormatMixin:
 class ConfirmOptionMixin:
     """Add a ``-y`` option and a ``confirm()`` helper that prompts unless it's set."""
 
-    def add_confirm_option(self, parser):  # noqa: D102
+    def add_confirm_option(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument('-y', action='store_true')
 
-    def confirm(self, message, **options):  # noqa: D102
+    def confirm(self, message: str, **options: Any) -> bool:  # noqa: D102
         if not options.get('y', False):
             answer = None
             while not answer or answer not in "yn":
@@ -97,13 +106,16 @@ class ConfirmOptionMixin:
         return True
 
 
-class QuitOptionMixin:
+class QuitOptionMixin(_BaseCommandHost):
     """Add a ``-q``/``--quit`` option that silences ``self.stdout``/``self.stderr``."""
 
-    def add_quit_option(self, parser):  # noqa: D102
+    def add_quit_option(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument('-q', '--quit', action='store_true',
                             help="Don't output to standard output.")
 
-    def if_needed_make_quit(self, **options):  # noqa: D102
+    def if_needed_make_quit(self, **options: Any) -> None:  # noqa: D102
         if options.get('quit', False):
-            self.stderr = self.stdout = StringIO()
+            # BaseCommand.stdout/.stderr are OutputWrapper (its write() takes
+            # an ending= kwarg plain StringIO.write doesn't); wrap the StringIO
+            # instead of assigning it directly.
+            self.stderr = self.stdout = OutputWrapper(StringIO())

--- a/mypy.ini
+++ b/mypy.ini
@@ -73,6 +73,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.management.commands.deletemigrations]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.utils.functions.loop]
 ignore_errors = False
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -61,6 +61,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.management.mixins]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.utils.html]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `Command` against django-stubs' `AppCommand` signatures (`add_arguments`/`handle_app_config`), and register `django_boost.management.commands.deletemigrations` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
- Stacked on #460 (`feature/type-hint-management-mixins`): `Command(ConfirmOptionMixin, QuitOptionMixin, AppCommand)`'s MRO linearizes cleanly against the mixins' new `TYPE_CHECKING`-only fake base, confirming the design held for this real consumer.
- `handle_app_config`'s declared `-> str | None` return needs every path to return explicitly (mypy doesn't treat a bare `return` or falling off the end as automatically satisfying an Optional return) — changed the bare `return` to `return None` and added an explicit `return None` at the end.
- The registry entry is inserted between the sibling `utils.html`/`utils.functions.loop` blocks, isolated from other in-flight type-hint PRs.

## Verification
- `mypy django_boost` green
- `flake8 django_boost/management/commands/deletemigrations.py` clean
- `manage.py test` (503 tests) green