### PR TITLE
:label: Type the listsuperuser command (contrib.admin_tools + deprecated alias)

### DIFF
--- a/django_boost/contrib/admin_tools/management/commands/listsuperuser.py
+++ b/django_boost/contrib/admin_tools/management/commands/listsuperuser.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AbstractUser
+from django.core.management.base import CommandParser
+from django.db.models import QuerySet
 
 from django_boost.core.management import BaseCommand
 from django_boost.management.mixins import OutputFormatMixin
@@ -14,22 +19,25 @@ class Command(OutputFormatMixin, BaseCommand):
     help = "List super users."
     OUTPUT_FIELDS = ("email", "active", "staff", "last_login")
 
-    def add_arguments(self, parser):  # noqa: D102
+    def add_arguments(self, parser: CommandParser) -> None:  # noqa: D102
         self.add_format_option(parser)
 
-    def get_queryset(self):  # noqa: D102
-        User = get_user_model()
+    def get_queryset(self) -> QuerySet[AbstractUser]:  # noqa: D102
+        # get_user_model() is only guaranteed to be AbstractBaseUser, but
+        # listing superusers inherently needs is_staff/is_superuser/
+        # USERNAME_FIELD, which live on AbstractUser (via PermissionsMixin).
+        User = cast(type[AbstractUser], get_user_model())
         return User.objects.filter(
             is_superuser=True).order_by(User.USERNAME_FIELD)
 
-    def get_row_data(self, user, **options):  # noqa: D102
-        email_field = user.get_email_field_name()
+    def get_row_data(self, obj: AbstractUser, **options: Any) -> dict[str, str]:  # noqa: D102
+        email_field = obj.get_email_field_name()
         return {
-            "email": getattr(user, email_field, "") or "",
-            "active": "yes" if user.is_active else "no",
-            "staff": "yes" if user.is_staff else "no",
-            "last_login": str(user.last_login) if user.last_login else "(never)",
+            "email": getattr(obj, email_field, "") or "",
+            "active": "yes" if obj.is_active else "no",
+            "staff": "yes" if obj.is_staff else "no",
+            "last_login": str(obj.last_login) if obj.last_login else "(never)",
         }
 
-    def handle(self, *args, **options):  # noqa: D102
+    def handle(self, *args: Any, **options: Any) -> None:  # noqa: D102
         self.print_formatted(self.get_queryset(), **options)

--- a/django_boost/management/mixins.py
+++ b/django_boost/management/mixins.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 import csv
+from collections.abc import Iterable, Mapping
 from io import StringIO
+from typing import Any, ClassVar, TYPE_CHECKING
 
-from django.core.management.base import CommandError
+from django.core.management.base import CommandError, CommandParser, OutputWrapper
+
+from django_boost.core.management import BaseCommand
+
+if TYPE_CHECKING:
+    _BaseCommandHost = BaseCommand
+else:
+    _BaseCommandHost = object
 
 
-class OutputFormatMixin:
+class OutputFormatMixin(_BaseCommandHost):
     """Add a ``--format`` option with shared text/csv/tsv rendering.
 
     Mix into a ``BaseCommand`` subclass -- it writes through ``self.stdout``
@@ -20,27 +29,27 @@ class OutputFormatMixin:
     dispatch are shared.
     """
 
-    TEXT_FORMAT = "text"
-    DELIMITED_FORMATS = {
+    TEXT_FORMAT: ClassVar[str] = "text"
+    DELIMITED_FORMATS: ClassVar[dict[str, str]] = {
         "csv": ",",
         "tsv": "\t",
     }
-    OUTPUT_FIELDS = ()
+    OUTPUT_FIELDS: ClassVar[tuple[str, ...]] = ()
 
-    def supported_formats(self):  # noqa: D102
+    def supported_formats(self) -> list[str]:  # noqa: D102
         return [self.TEXT_FORMAT, *self.DELIMITED_FORMATS]
 
-    def add_format_option(self, parser):  # noqa: D102
+    def add_format_option(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument('--format', choices=self.supported_formats(),
                             default=self.TEXT_FORMAT,
                             help="Output format.")
 
-    def get_row_data(self, obj, **options):  # noqa: D102
+    def get_row_data(self, obj: Any, **options: Any) -> Mapping[str, Any]:  # noqa: D102
         raise NotImplementedError(
             "%s must implement get_row_data() returning a mapping with keys %s"
             % (type(self).__name__, tuple(self.OUTPUT_FIELDS)))
 
-    def _row_values(self, obj, **options):
+    def _row_values(self, obj: Any, **options: Any) -> list[Any]:
         data = self.get_row_data(obj, **options)
         missing = [field for field in self.OUTPUT_FIELDS if field not in data]
         if missing:
@@ -49,14 +58,14 @@ class OutputFormatMixin:
                 % (type(self).__name__, ", ".join(missing)))
         return [data[field] for field in self.OUTPUT_FIELDS]
 
-    def print_text(self, rows, **options):  # noqa: D102
+    def print_text(self, rows: Iterable[Any], **options: Any) -> None:  # noqa: D102
         self.stdout.write(" | ".join(self.OUTPUT_FIELDS))
         for obj in rows:
             self.stdout.write(
                 " | ".join(str(value)
                            for value in self._row_values(obj, **options)))
 
-    def print_delimited(self, rows, delimiter, **options):  # noqa: D102
+    def print_delimited(self, rows: Iterable[Any], delimiter: str, **options: Any) -> None:  # noqa: D102
         stream = StringIO()
         writer = csv.writer(stream, delimiter=delimiter)
         writer.writerow(self.OUTPUT_FIELDS)
@@ -64,7 +73,7 @@ class OutputFormatMixin:
             writer.writerow(self._row_values(obj, **options))
         self.stdout.write(stream.getvalue(), ending="")
 
-    def print_formatted(self, rows, **options):  # noqa: D102
+    def print_formatted(self, rows: Iterable[Any], **options: Any) -> None:  # noqa: D102
         output_format = options["format"]
         if output_format == self.TEXT_FORMAT:
             self.print_text(rows, **options)
@@ -80,10 +89,10 @@ class OutputFormatMixin:
 class ConfirmOptionMixin:
     """Add a ``-y`` option and a ``confirm()`` helper that prompts unless it's set."""
 
-    def add_confirm_option(self, parser):  # noqa: D102
+    def add_confirm_option(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument('-y', action='store_true')
 
-    def confirm(self, message, **options):  # noqa: D102
+    def confirm(self, message: str, **options: Any) -> bool:  # noqa: D102
         if not options.get('y', False):
             answer = None
             while not answer or answer not in "yn":
@@ -97,13 +106,16 @@ class ConfirmOptionMixin:
         return True
 
 
-class QuitOptionMixin:
+class QuitOptionMixin(_BaseCommandHost):
     """Add a ``-q``/``--quit`` option that silences ``self.stdout``/``self.stderr``."""
 
-    def add_quit_option(self, parser):  # noqa: D102
+    def add_quit_option(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument('-q', '--quit', action='store_true',
                             help="Don't output to standard output.")
 
-    def if_needed_make_quit(self, **options):  # noqa: D102
+    def if_needed_make_quit(self, **options: Any) -> None:  # noqa: D102
         if options.get('quit', False):
-            self.stderr = self.stdout = StringIO()
+            # BaseCommand.stdout/.stderr are OutputWrapper (its write() takes
+            # an ending= kwarg plain StringIO.write doesn't); wrap the StringIO
+            # instead of assigning it directly.
+            self.stderr = self.stdout = OutputWrapper(StringIO())

--- a/mypy.ini
+++ b/mypy.ini
@@ -85,6 +85,18 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.contrib.admin_tools.management.commands.listsuperuser]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
+[mypy-django_boost.admin_tools.management.commands.listsuperuser]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.utils]
 ignore_errors = False
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -61,6 +61,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.management.mixins]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.utils.html]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `Command` against `OutputFormatMixin`/`BaseCommand`, and register both `django_boost.contrib.admin_tools.management.commands.listsuperuser` (the real command) and `django_boost.admin_tools.management.commands.listsuperuser` (its deprecated re-export alias — zero defs, register-only) in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
- Stacked on #460 (`feature/type-hint-management-mixins`): `Command(OutputFormatMixin, BaseCommand)`'s MRO linearizes cleanly against the mixin's new `TYPE_CHECKING`-only fake base.
- `get_user_model()` is only guaranteed to be `AbstractBaseUser`, but listing superusers inherently needs `is_staff`/`is_superuser`/`USERNAME_FIELD`, which live on `AbstractUser` (via `PermissionsMixin`); cast the one call rather than widen every signature to the lowest common denominator.
- `get_row_data`'s override initially renamed the base's `obj` parameter to `user`, but mypy rejects renaming a positional-or-keyword parameter in an override regardless of type (`OutputFormatMixin.get_row_data`'s own callers could pass it by keyword) — kept the parameter name as `obj` to match the base exactly.
- The registry entries are inserted between the sibling `utils.functions.json`/`utils` blocks, isolated from other in-flight type-hint PRs.

## Verification
- `mypy django_boost` green
- `flake8` clean
- `manage.py test` (503 tests, including the 8 dedicated listsuperuser tests) green