### PR TITLE
:label: Type the adminsitelog command (contrib.admin_tools + deprecated alias)

### DIFF
--- a/django_boost/contrib/admin_tools/management/commands/adminsitelog.py
+++ b/django_boost/contrib/admin_tools/management/commands/adminsitelog.py
@@ -2,31 +2,41 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from typing import Any, ClassVar
+
+from django.contrib.admin.models import LogEntry
 from django.core.exceptions import FieldError
-from django.core.management.base import CommandError
-from django.db.models.sql.query import get_field_names_from_opts
+from django.core.management.base import CommandError, CommandParser
+from django.db.models import Model
+from django.db.models.sql.query import get_field_names_from_opts  # type: ignore[attr-defined]
 from django.utils.translation import gettext_lazy as _
 
 from django_boost.core.management import BaseCommand
 from django_boost.management.mixins import ConfirmOptionMixin, OutputFormatMixin
 from django_boost.utils.attribute import getattr_chain, hasattr_chain
 
+# get_field_names_from_opts is an internal Django helper django-stubs doesn't
+# cover; the ignore above is the only way to use it under the plugin.
+
 
 class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
     """View and delete Django admin site log entries."""
 
     help = "Django admin site log"
-    COMPARISON_OPERATION = {"<=": "lte",
-                            ">=": "gte",
-                            "=": "exact",
-                            "<": "lt",
-                            ">": "gt", }
-    OUTPUT_FIELDS = ("id", "action", "detail", "user", "time")
+    COMPARISON_OPERATION: ClassVar[dict[str, str]] = {
+        "<=": "lte",
+        ">=": "gte",
+        "=": "exact",
+        "<": "lt",
+        ">": "gt",
+    }
+    OUTPUT_FIELDS: ClassVar[tuple[str, ...]] = ("id", "action", "detail", "user", "time")
 
-    def get_sortable_fields(self, model):  # noqa: D102
+    def get_sortable_fields(self, model: type[Model]) -> list[str]:  # noqa: D102
         return sorted(get_field_names_from_opts(model._meta))
 
-    def get_log_entry_model(self):
+    def get_log_entry_model(self) -> type[LogEntry]:
         """Return Django admin's ``LogEntry`` model, raising if ``django.contrib.admin`` isn't installed."""
         from django.apps import apps
         if not apps.is_installed("django.contrib.admin"):
@@ -36,19 +46,19 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
         from django.contrib.admin.models import LogEntry
         return LogEntry
 
-    def get_sortable_fields_help(self):
+    def get_sortable_fields_help(self) -> str:
         """Return the sortable field names for ``--help``, or a hint if admin isn't installed."""
         from django.apps import apps
         if not apps.is_installed("django.contrib.admin"):
             return "(requires 'django.contrib.admin' in INSTALLED_APPS)"
         return ", ".join(self.get_sortable_fields(self.get_log_entry_model()))
 
-    def _parse_filter(self, condition):
+    def _parse_filter(self, condition: str) -> dict[str, str]:
         # Split on the operator that appears leftmost in the condition (so a
         # comparison operator inside the value is not mistaken for the
         # field/value boundary); at the same position prefer the longer
         # operator so '>=' wins over '>'.
-        best = None
+        best: tuple[tuple[int, int], str] | None = None
         for op in self.COMPARISON_OPERATION:
             index = condition.find(op)
             if index != -1 and (best is None or (index, -len(op)) < best[0]):
@@ -63,33 +73,33 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
         return {"%s__%s" % (condition[:index], lookup):
                 condition[index + len(op):]}
 
-    def parse_filter(self, conditions):  # noqa: D102
-        parsed = {}
+    def parse_filter(self, conditions: Iterable[str]) -> dict[str, str]:  # noqa: D102
+        parsed: dict[str, str] = {}
         for condition in conditions:
             parsed.update(self._parse_filter(condition))
         return parsed
 
-    def get_row_data(self, log, **options):
+    def get_row_data(self, obj: LogEntry, **options: Any) -> dict[str, Any]:
         """Map a ``LogEntry`` to the OUTPUT_FIELDS row dict, classifying it as Added/Changed/Deleted."""
-        if log.is_addition():
+        if obj.is_addition():
             action = "Added"
-            detail = log.object_repr
-        elif log.is_change():
+            detail = obj.object_repr
+        elif obj.is_change():
             action = "Changed"
-            detail = "%s - %s" % (log.object_repr,
-                                  log.get_change_message())
+            detail = "%s - %s" % (obj.object_repr,
+                                  obj.get_change_message())
         else:  # log.is_deletion
             action = "Deleted"
-            detail = log.object_repr
+            detail = obj.object_repr
         return {
-            "id": log.id,
+            "id": obj.id,
             "action": action,
             "detail": detail,
-            "user": self._get_user_name(log.user, options['name_field']),
-            "time": log.action_time,
+            "user": self._get_user_name(obj.user, options['name_field']),
+            "time": obj.action_time,
         }
 
-    def print_log(self, log, **options):
+    def print_log(self, log: LogEntry, **options: Any) -> None:
         """Write one colorized ``id | action | object | user | time`` line for ``log``."""
         fmt = "{id} | {action} | {object} | {user} | {time}"
         fmap = self.get_row_data(log, **options)
@@ -102,12 +112,12 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
         fmap["object"] = fmap.pop("detail")
         self.stdout.write(fmt.format_map(fmap))
 
-    def print_text(self, rows, **options):  # noqa: D102
+    def print_text(self, rows: Iterable[Any], **options: Any) -> None:  # noqa: D102
         self.stdout.write(" | ".join(self.OUTPUT_FIELDS))
         for log in rows:
             self.print_log(log, **options)
 
-    def _get_user_name(self, user, name_field=None):
+    def _get_user_name(self, user: Any, name_field: str | None = None) -> Any:
         if name_field is not None:
             if hasattr_chain(user, name_field):
                 return getattr_chain(user, name_field)
@@ -118,8 +128,9 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
         for field in name_fields:
             if hasattr(user, field):
                 return getattr(user, field)
+        return None
 
-    def add_arguments(self, parser):  # noqa: D102
+    def add_arguments(self, parser: CommandParser) -> None:  # noqa: D102
         supported_fields_str = self.get_sortable_fields_help()
         parser.add_argument('-d', '--delete',
                             action='store_true', help='Delete displayed logs.')
@@ -148,7 +159,7 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
         self.add_format_option(parser)
         self.add_confirm_option(parser)
 
-    def handle(self, *args, **options):  # noqa: D102
+    def handle(self, *args: Any, **options: Any) -> None:  # noqa: D102
         LogEntry = self.get_log_entry_model()
         queryset = LogEntry.objects.all()
 
@@ -164,7 +175,7 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
             return
         self.print_formatted(queryset, **options)
         if options['delete']:
-            if self.confirm(message=_("Do you want to delete these logs"), **options):
+            if self.confirm(message=str(_("Do you want to delete these logs")), **options):
                 queryset.delete()
                 self.stderr.write('delete complete')
             else:

--- a/django_boost/management/commands/adminsitelog.py
+++ b/django_boost/management/commands/adminsitelog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import warnings
+from typing import Any
 
 from django.apps import apps
 
@@ -25,7 +26,7 @@ class Command(_Command):
     that have not migrated -- so correctly configured projects are not warned.
     """
 
-    def execute(self, *args, **options):  # noqa: D102
+    def execute(self, *args: Any, **options: Any) -> str | None:  # noqa: D102
         if not apps.is_installed(ADMIN_TOOLS_APP):
             warnings.warn(
                 "Running 'adminsitelog' from 'django_boost' is deprecated; add "

--- a/django_boost/management/mixins.py
+++ b/django_boost/management/mixins.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 import csv
+from collections.abc import Iterable, Mapping
 from io import StringIO
+from typing import Any, ClassVar, TYPE_CHECKING
 
-from django.core.management.base import CommandError
+from django.core.management.base import CommandError, CommandParser, OutputWrapper
+
+from django_boost.core.management import BaseCommand
+
+if TYPE_CHECKING:
+    _BaseCommandHost = BaseCommand
+else:
+    _BaseCommandHost = object
 
 
-class OutputFormatMixin:
+class OutputFormatMixin(_BaseCommandHost):
     """Add a ``--format`` option with shared text/csv/tsv rendering.
 
     Mix into a ``BaseCommand`` subclass -- it writes through ``self.stdout``
@@ -20,27 +29,27 @@ class OutputFormatMixin:
     dispatch are shared.
     """
 
-    TEXT_FORMAT = "text"
-    DELIMITED_FORMATS = {
+    TEXT_FORMAT: ClassVar[str] = "text"
+    DELIMITED_FORMATS: ClassVar[dict[str, str]] = {
         "csv": ",",
         "tsv": "\t",
     }
-    OUTPUT_FIELDS = ()
+    OUTPUT_FIELDS: ClassVar[tuple[str, ...]] = ()
 
-    def supported_formats(self):  # noqa: D102
+    def supported_formats(self) -> list[str]:  # noqa: D102
         return [self.TEXT_FORMAT, *self.DELIMITED_FORMATS]
 
-    def add_format_option(self, parser):  # noqa: D102
+    def add_format_option(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument('--format', choices=self.supported_formats(),
                             default=self.TEXT_FORMAT,
                             help="Output format.")
 
-    def get_row_data(self, obj, **options):  # noqa: D102
+    def get_row_data(self, obj: Any, **options: Any) -> Mapping[str, Any]:  # noqa: D102
         raise NotImplementedError(
             "%s must implement get_row_data() returning a mapping with keys %s"
             % (type(self).__name__, tuple(self.OUTPUT_FIELDS)))
 
-    def _row_values(self, obj, **options):
+    def _row_values(self, obj: Any, **options: Any) -> list[Any]:
         data = self.get_row_data(obj, **options)
         missing = [field for field in self.OUTPUT_FIELDS if field not in data]
         if missing:
@@ -49,14 +58,14 @@ class OutputFormatMixin:
                 % (type(self).__name__, ", ".join(missing)))
         return [data[field] for field in self.OUTPUT_FIELDS]
 
-    def print_text(self, rows, **options):  # noqa: D102
+    def print_text(self, rows: Iterable[Any], **options: Any) -> None:  # noqa: D102
         self.stdout.write(" | ".join(self.OUTPUT_FIELDS))
         for obj in rows:
             self.stdout.write(
                 " | ".join(str(value)
                            for value in self._row_values(obj, **options)))
 
-    def print_delimited(self, rows, delimiter, **options):  # noqa: D102
+    def print_delimited(self, rows: Iterable[Any], delimiter: str, **options: Any) -> None:  # noqa: D102
         stream = StringIO()
         writer = csv.writer(stream, delimiter=delimiter)
         writer.writerow(self.OUTPUT_FIELDS)
@@ -64,7 +73,7 @@ class OutputFormatMixin:
             writer.writerow(self._row_values(obj, **options))
         self.stdout.write(stream.getvalue(), ending="")
 
-    def print_formatted(self, rows, **options):  # noqa: D102
+    def print_formatted(self, rows: Iterable[Any], **options: Any) -> None:  # noqa: D102
         output_format = options["format"]
         if output_format == self.TEXT_FORMAT:
             self.print_text(rows, **options)
@@ -80,10 +89,10 @@ class OutputFormatMixin:
 class ConfirmOptionMixin:
     """Add a ``-y`` option and a ``confirm()`` helper that prompts unless it's set."""
 
-    def add_confirm_option(self, parser):  # noqa: D102
+    def add_confirm_option(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument('-y', action='store_true')
 
-    def confirm(self, message, **options):  # noqa: D102
+    def confirm(self, message: str, **options: Any) -> bool:  # noqa: D102
         if not options.get('y', False):
             answer = None
             while not answer or answer not in "yn":
@@ -97,13 +106,16 @@ class ConfirmOptionMixin:
         return True
 
 
-class QuitOptionMixin:
+class QuitOptionMixin(_BaseCommandHost):
     """Add a ``-q``/``--quit`` option that silences ``self.stdout``/``self.stderr``."""
 
-    def add_quit_option(self, parser):  # noqa: D102
+    def add_quit_option(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument('-q', '--quit', action='store_true',
                             help="Don't output to standard output.")
 
-    def if_needed_make_quit(self, **options):  # noqa: D102
+    def if_needed_make_quit(self, **options: Any) -> None:  # noqa: D102
         if options.get('quit', False):
-            self.stderr = self.stdout = StringIO()
+            # BaseCommand.stdout/.stderr are OutputWrapper (its write() takes
+            # an ending= kwarg plain StringIO.write doesn't); wrap the StringIO
+            # instead of assigning it directly.
+            self.stderr = self.stdout = OutputWrapper(StringIO())

--- a/mypy.ini
+++ b/mypy.ini
@@ -91,6 +91,18 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.contrib.admin_tools.management.commands.adminsitelog]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
+[mypy-django_boost.management.commands.adminsitelog]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.core]
 ignore_errors = False
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -61,6 +61,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.management.mixins]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.utils.html]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand)` against django-stubs, and register both `django_boost.contrib.admin_tools.management.commands.adminsitelog` (the real command) and `django_boost.management.commands.adminsitelog` (its deprecated `execute()`-overriding alias) in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
- Stacked on #460 (`feature/type-hint-management-mixins`): this triple mix (`OutputFormatMixin`, `ConfirmOptionMixin`, `BaseCommand`) is one of the combinations the mixin design was verified against; MRO linearizes cleanly.
- `get_field_names_from_opts` is an internal Django helper django-stubs doesn't cover; one `# type: ignore[attr-defined]` on the import, not fought around.
- `get_row_data`'s `obj` parameter (originally named `log`) had to keep the base's exact name, same lesson as the listsuperuser command (#462).
- `confirm()`'s `message=_('...')` passes a lazy `gettext_lazy` proxy where `ConfirmOptionMixin.confirm` declares `message: str`; wrapped with `str()` at the call site rather than widening the mixin's signature (that file belongs to the already-open `management.mixins` PR).
- The registry entries are inserted between the sibling `utils`/`core` blocks, isolated from other in-flight type-hint PRs.

## Verification
- `mypy django_boost` green
- `flake8` clean
- `manage.py test` (503 tests, including the 28 dedicated adminsitelog tests) green