### PR TITLE
:label: Type the admin package (admin __init__)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -43,6 +43,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.admin]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.urls.static]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Register `django_boost.admin` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout). No source change needed — `EmailUserAdmin`/`LogicalDeletionModelAdmin` have no function defs.

## Notes
- Stacked on #464 (`feature/type-hint-admin-mixins`): `LogicalDeletionModelAdmin(LogicalDeletionModelAdminMixin, admin.ModelAdmin)`'s MRO — the exact combination `admin.mixins`' fake-base design was built for — linearizes cleanly with zero casts or ignores.
- The registry entry is inserted between the sibling `urls.converters.*`/`urls.static` blocks, isolated from other in-flight type-hint PRs.

## Verification
- `mypy django_boost` green
- `flake8 django_boost/admin/__init__.py` clean
- `manage.py test` (505 tests) green