### PR TITLE
:label: Type the form mixins (forms.mixins)

### DIFF
--- a/django_boost/forms/mixins.py
+++ b/django_boost/forms/mixins.py
@@ -2,24 +2,36 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+from typing import Any, ClassVar, TYPE_CHECKING, cast
+
+from django import forms
 from django.core.exceptions import (ImproperlyConfigured,
                                     MultipleObjectsReturned,
                                     ObjectDoesNotExist)
+from django.db.models import Model, QuerySet
 from django.forms import fields_for_model
 
 from django_boost.utils.attribute import getattr_chain
 
+if TYPE_CHECKING:
+    _FormHost = forms.Form
+    _ModelFormHost = forms.ModelForm
+else:
+    _FormHost = object
+    _ModelFormHost = object
 
-class FormUserKwargsMixin:
+
+class FormUserKwargsMixin(_FormHost):
     """Mixin that pulls a ``user`` keyword argument into ``self.user``."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Pop the ``user`` keyword argument into ``self.user`` before delegating to the form."""
         self.user = kwargs.pop('user')
         super().__init__(*args, **kwargs)
 
 
-class FieldRenameMixin:
+class FieldRenameMixin(_FormHost):
     """
     ``FieldRenameMixin`` that changes form field names.
 
@@ -41,9 +53,9 @@ class FieldRenameMixin:
       MyForm().cleaned_data["token-id"]
     """
 
-    rename_fields = {}
+    rename_fields: ClassVar[dict[str, str]] = {}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Rename fields in ``self.fields`` per ``rename_fields`` after the form initializes."""
         super().__init__(*args, **kwargs)
         for key, value in self.rename_fields.items():
@@ -52,7 +64,7 @@ class FieldRenameMixin:
                 del self.fields[key]
 
 
-class MatchedObjectGetMixin:
+class MatchedObjectGetMixin(_ModelFormHost):
     """
     MatchedObjectGetMixin.
 
@@ -60,18 +72,18 @@ class MatchedObjectGetMixin:
     returns model object or queryset that matches the conditions.
     """
 
-    model = None
-    queryset = None
-    raise_exception = False
-    field_lookup = {}
+    model: ClassVar[type[Model] | None] = None
+    queryset: ClassVar[QuerySet[Any] | None] = None
+    raise_exception: ClassVar[bool] = False
+    field_lookup: ClassVar[dict[str, str]] = {}
 
-    def get_queryset(self):
+    def get_queryset(self) -> QuerySet[Any]:
         """Return ``queryset``, or fall back to ``model``'s/the form's own default manager."""
         if self.queryset is None:
             if self.model:
-                return self.model._default_manager.all()
+                return cast("QuerySet[Any]", self.model._default_manager.all())
             elif hasattr(self, '_meta') and self._meta.model:
-                return self._meta.model._default_manager.all()
+                return cast("QuerySet[Any]", self._meta.model._default_manager.all())
             else:
                 raise ImproperlyConfigured(
                     "%(cls)s is missing a QuerySet. Define "
@@ -83,20 +95,20 @@ class MatchedObjectGetMixin:
         self.model_class = self.queryset.model
         return self.queryset.all()
 
-    def _replace_fields(self, form_data):
+    def _replace_fields(self, form_data: Mapping[str, Any]) -> dict[str, Any]:
         filter_data = {}
         for k, v in form_data.items():
             filter_data[self.field_lookup.get(k, k)] = v
         return filter_data
 
-    def get_list(self, queryset=None):
+    def get_list(self, queryset: QuerySet[Any] | None = None) -> QuerySet[Any]:
         """Return matched object queryset."""
         if queryset is None:
             queryset = self.get_queryset()
         filter_data = self._replace_fields(self.cleaned_data)
         return queryset.filter(**filter_data)
 
-    def get_object(self, queryset=None):
+    def get_object(self, queryset: QuerySet[Any] | None = None) -> Any | None:
         """Return matched object."""
         try:
             return self.get_list(queryset).get()
@@ -106,7 +118,7 @@ class MatchedObjectGetMixin:
             return None
 
 
-class RelatedModelInlineMixin:
+class RelatedModelInlineMixin(_ModelFormHost):
     """
     Mixin that treat two related `Model`'s as a single `Model`.
 
@@ -132,12 +144,13 @@ class RelatedModelInlineMixin:
     ```
     """
 
-    inline_fields = None
+    inline_fields: ClassVar[dict[str, Sequence[str]] | None] = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Add form fields for each related model's ``inline_fields`` after the form initializes."""
         super().__init__(*args, **kwargs)
-        self._related_field_model = {}
+        self._related_field_model: dict[str, type[Model]] = {}
+        assert self.inline_fields is not None
         for field, related_fields in self.inline_fields.items():
             model = self._meta.model
             try:  # reverse relation
@@ -156,12 +169,14 @@ class RelatedModelInlineMixin:
                         default=None))
                 self.fields['%s_%s' % (field, field_name)] = field_object
 
-    def save(self, commit=True):
+    def save(self, commit: bool = True) -> Any:
         """Save the form, then create/update each related model from its ``inline_fields``."""
         object = super().save(commit=False)
+        assert self.inline_fields is not None
+        inline_fields = self.inline_fields
 
-        def save_inline():
-            for field, related_fields in self.inline_fields.items():
+        def save_inline() -> None:
+            for field, related_fields in inline_fields.items():
                 related_model = self._related_field_model[field]
                 rel_opts = related_model._meta
                 pk_field_name = rel_opts.pk.attname
@@ -176,6 +191,7 @@ class RelatedModelInlineMixin:
                             if f.related_model == type(object):
                                 name = f.name
                                 object.save()
+                        assert name is not None
                         target_field = related_model(**{name: object})
                 elif getattr(object, rel_pk_field_name) is None:
                     target_field = related_model()
@@ -195,7 +211,10 @@ class RelatedModelInlineMixin:
 
         if commit:
             save_inline()
-            self._save_m2m()
+            # _save_m2m is BaseModelForm's real internal worker (what Django's
+            # own save() calls); django-stubs only declares the public
+            # save_m2m, so this needs an ignore rather than the stub's name.
+            self._save_m2m()  # type: ignore[attr-defined]
         else:
             # Honor Django's ModelForm.save(commit=False) contract: perform no
             # DB writes now and defer them (plus the base form's own m2m) to
@@ -203,13 +222,16 @@ class RelatedModelInlineMixin:
             # target row exists.
             base_save_m2m = self.save_m2m
 
-            def save_m2m():
+            def save_m2m() -> None:
                 base_save_m2m()
                 save_inline()
-            self.save_m2m = save_m2m
+            # Same dynamic patch Django's own ModelForm.save(commit=False)
+            # does (self.save_m2m = self._save_m2m); django-stubs types
+            # save_m2m as a fixed method, so overwriting it needs an ignore.
+            self.save_m2m = save_m2m  # type: ignore[method-assign]
         return object
 
-    def _is_many_to_many(self, rel_opts, field_name):
+    def _is_many_to_many(self, rel_opts: Any, field_name: str) -> bool:
         for f in rel_opts.many_to_many:
             if f.attname == field_name:
                 return True

--- a/mypy.ini
+++ b/mypy.ini
@@ -145,6 +145,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.forms.mixins]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 # example/ is a development harness, but keep it type-checked so the sample app
 # continues to compile against django-boost's public APIs. Tests and migrations
 # are excluded above.


### PR DESCRIPTION
## Summary
Annotate `FormUserKwargsMixin`/`FieldRenameMixin` (host: `forms.Form`) and `MatchedObjectGetMixin`/`RelatedModelInlineMixin` (host: `forms.ModelForm`), and register `django_boost.forms.mixins` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
- All four are cooperative-inheritance mixins with no base of their own — same `TYPE_CHECKING`-only fake-base pattern as `management.mixins`/`admin.mixins` (`_FormHost`/`_ModelFormHost`, runtime base stays `object`), matching every real consumer in `tests/`/`docs/`.
- `RelatedModelInlineMixin.save()` returns `Any` rather than preserving the mixed-in `ModelForm`'s concrete model type: `forms.ModelForm` is `Generic`, but its `Meta.model` → concrete-type inference is a `mypy_django_plugin` hook wired to `ModelForm` subclasses specifically, not to arbitrary `Generic` mixins — making the mixin itself `Generic` would require every real caller to explicitly parameterize it (a real API change), which none of the existing callers do. Accepting `Any` matches what the fake, unparameterized `ModelForm` base already returns from `super().save()`.
- Two real Django/stub gaps hit, both matching Django's own `ModelForm.save()` implementation rather than something novel:
  - `self._save_m2m()` (`BaseModelForm`'s real internal worker, called by Django's own `save()`) isn't in django-stubs, which only declares the public `save_m2m` — one `# type: ignore[attr-defined]`.
  - `self.save_m2m = save_m2m` replicates Django's own dynamic patch (`self.save_m2m = self._save_m2m` in `ModelForm.save(commit=False)`); typed as a fixed method by django-stubs, so overwriting it needs `# type: ignore[method-assign]`.
- `get_queryset`'s two `_default_manager.all()` calls needed a cast to `QuerySet[Any]` (`warn_return_any` flags the plugin's untyped-manager `Any` leak); the reverse-relation model lookup's `name` local needed an assert before use in `**{name: object}` (mypy requires `str` dict-unpack keys statically).
- The registry entry is inserted between the sibling `contrib.admin_tools.apps`/`example.*` blocks, isolated from other in-flight type-hint PRs.

## Verification
- `mypy django_boost` green
- `flake8 django_boost/forms/mixins.py` clean
- `manage.py test` (505 tests, including the 15 dedicated forms_mixins tests) green