### PR TITLE
Release 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+## [3.3.1] - 2026-07-17
+
 ### Fixed
 
 - Saving a `RelatedModelInlineMixin` form no longer discards the base model's own many-to-many field values.
@@ -502,7 +504,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - First release.
 
-[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.3.0...HEAD
+[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.3.1...HEAD
+[3.3.1]: https://github.com/ChanTsune/django-boost/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/ChanTsune/django-boost/compare/v3.2.4...v3.3.0
 [3.2.4]: https://github.com/ChanTsune/django-boost/compare/v3.2.3...v3.2.4
 [3.2.3]: https://github.com/ChanTsune/django-boost/compare/v3.2.2...v3.2.3

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django_boost.utils.version import get_version
 
-VERSION = (3, 3, 1, 'alpha', 0)
+VERSION = (3, 3, 1, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
## Summary
Finalizes VERSION to `3.3.1` (final) and moves the CHANGELOG's Unreleased Fixed entries under a dated `[3.3.1]` section.