### PR TITLE
:label: Type the middleware package (middleware __init__)

### DIFF
--- a/django_boost/middleware/__init__.py
+++ b/django_boost/middleware/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from django.conf import settings
-from django.http import HttpResponsePermanentRedirect
+from django.http import HttpRequest, HttpResponseBase, HttpResponsePermanentRedirect
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import get_template
 from django.utils.deprecation import MiddlewareMixin
@@ -55,7 +55,7 @@ class RedirectCorrectHostnameMiddleware(MiddlewareMixin):
     but it is useful when the setting is troublesome or when using services such as heroku.
     """
 
-    def process_request(self, request):  # noqa: D102
+    def process_request(self, request: HttpRequest) -> HttpResponsePermanentRedirect | None:  # noqa: D102
         # Return the redirect from process_request rather than overriding
         # __call__, so MiddlewareMixin's own __call__/__acall__ short-circuit
         # correctly under both WSGI and ASGI. A synchronous __call__ override
@@ -92,7 +92,7 @@ class HttpStatusCodeExceptionMiddleware(MiddlewareMixin):
 
     """
 
-    def get_template_from_status_code(self, status_code, request=None):
+    def get_template_from_status_code(self, status_code: int, request: HttpRequest | None = None) -> str:
         """Render the status page template for ``status_code``, falling back to a plain-text message."""
         message = STATUS_MESSAGES[status_code]
         try:
@@ -107,7 +107,7 @@ class HttpStatusCodeExceptionMiddleware(MiddlewareMixin):
         except TemplateDoesNotExist:
             return "%s %s" % (status_code, message)
 
-    def process_exception(self, request, e):
+    def process_exception(self, request: HttpRequest, e: Exception) -> HttpResponseBase | None:
         """Turn an ``HttpExceptionBase`` into its response, or a redirect for ``HttpRedirectExceptionBase``."""
         if isinstance(e, HttpRedirectExceptionBase):
             return e.response_class(e.url)

--- a/mypy.ini
+++ b/mypy.ini
@@ -139,6 +139,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.middleware]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.context_processors]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `RedirectCorrectHostnameMiddleware.process_request` and `HttpStatusCodeExceptionMiddleware.get_template_from_status_code`/`process_exception` against django-stubs' `MiddlewareMixin`/`HttpRequest`/`HttpResponseBase`, and register `django_boost.middleware` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
- `process_request`/`process_exception` are Django's conventional hook names (`MiddlewareMixin` discovers them via `hasattr`, not a declared base method), so no override-compatibility constraints apply.
- `django_boost.http.response` (`HttpExceptionBase`/`HttpRedirectExceptionBase`/`Http405`) stays unregistered (Tier B-heavy), but its unannotated attributes still carry usable inferred types from this typed consumer's perspective — no casts needed.
- The registry entry is inserted between the sibling `middleware.html`/`context_processors` blocks, isolated from other in-flight type-hint PRs.
- Verified against both `mypy==2.1.0+django-stubs==6.0.6` and `mypy==1.15.0+django-stubs==5.1.3+Django==4.2` (this rollout's other CI cell) — both clean, learned from the earlier round of CI failures.

## Verification
- `mypy django_boost` green on both stub environments
- `flake8 django_boost/middleware/__init__.py` clean
- `manage.py test` (507 tests, including the 25 dedicated middleware tests) green on both Django versions