### PR TITLE
:label: Type the hard-delete admin action (admin.actions)

### DIFF
--- a/django_boost/admin/actions.py
+++ b/django_boost/admin/actions.py
@@ -2,15 +2,33 @@
 
 from __future__ import annotations
 
-from django.contrib import messages
+from typing import TYPE_CHECKING
+
+from django.contrib import admin, messages
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import model_ngettext
 from django.core.exceptions import PermissionDenied
+from django.db.models import QuerySet
+from django.http import HttpRequest, HttpResponse
 from django.template.response import TemplateResponse
 from django.utils.translation import gettext as _, gettext_lazy
 
+if TYPE_CHECKING:
+    # mixins.py imports hard_delete_selected from this module at runtime, so
+    # a real import of LogicalDeletionModelAdminMixin back here would be
+    # circular. Declared locally instead of under TYPE_CHECKING import: mypy
+    # doesn't resolve the mixin's own TYPE_CHECKING-only base across an
+    # import cycle, even a type-only one, so this restates its shape
+    # (ModelAdmin + hard_delete_queryset) without depending on mixins.py.
+    class _HardDeleteModelAdmin(admin.ModelAdmin):
+        def hard_delete_queryset(self, request: HttpRequest, queryset: QuerySet) -> None: ...
 
-def hard_delete_selected(modeladmin, request, queryset):
+
+def hard_delete_selected(
+    modeladmin: _HardDeleteModelAdmin,
+    request: HttpRequest,
+    queryset: QuerySet,
+) -> HttpResponse | None:
     """Admin action that physically deletes the selection, bypassing logical deletion."""
     opts = modeladmin.model._meta
     app_label = opts.app_label
@@ -28,12 +46,13 @@ def hard_delete_selected(modeladmin, request, queryset):
         if n:
             # log_deletions() replaced the per-object log_deletion() in Django
             # 5.1 (log_deletion() is deprecated); prefer it when available,
-            # falling back on Django 4.2/5.0.
+            # falling back on Django 4.2/5.0. django-stubs no longer declares
+            # the deprecated log_deletion, hence the ignore on that branch.
             if hasattr(modeladmin, 'log_deletions'):
                 modeladmin.log_deletions(request, queryset)
             else:
                 for obj in queryset:
-                    modeladmin.log_deletion(request, obj, str(obj))
+                    modeladmin.log_deletion(request, obj, str(obj))  # type: ignore[attr-defined]
             modeladmin.hard_delete_queryset(request, queryset)
             modeladmin.message_user(request, _("Successfully deleted %(count)d %(items)s.") % {
                 "count": n, "items": model_ngettext(modeladmin.opts, n)
@@ -73,5 +92,6 @@ def hard_delete_selected(modeladmin, request, queryset):
     ], context)
 
 
-hard_delete_selected.allowed_permissions = ('delete',)
-hard_delete_selected.short_description = gettext_lazy("Hard delete selected %(verbose_name_plural)s")
+hard_delete_selected.allowed_permissions = ('delete',)  # type: ignore[attr-defined]
+hard_delete_selected.short_description = (  # type: ignore[attr-defined]
+    gettext_lazy("Hard delete selected %(verbose_name_plural)s"))

--- a/mypy.ini
+++ b/mypy.ini
@@ -145,6 +145,17 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.admin.actions]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+# log_deletion (singular) needs a `# type: ignore[attr-defined]` on
+# django-stubs 5.1.3 + Django 4.2 (still declared there) but not on 6.0.6 +
+# Django 5.2 (removed, matching this local install) -- same cross-cell
+# tradeoff as django_boost.models/django_boost.forms.
+warn_unused_ignores = False
+
 [mypy-django_boost.test.testcase]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `hard_delete_selected(modeladmin, request, queryset)` and register `django_boost.admin.actions` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
- `modeladmin` is typed against a `TYPE_CHECKING`-only local class combining `admin.ModelAdmin` with `hard_delete_queryset` — restating `LogicalDeletionModelAdminMixin`'s shape rather than importing it, since `mixins.py` imports this module at runtime (`hard_delete_selected` is registered as its action) and mypy doesn't resolve the mixin's own fake base across an import cycle, even when the back-reference here is `TYPE_CHECKING`-only.
- Two real Django/stub gaps, both narrow:
  - The deprecated `log_deletion` (singular) fallback branch needs `# type: ignore[attr-defined]` on django-stubs 6.0.6 (Django 5.2, removed) but not on 5.1.3 (Django 4.2, still declared) — same cross-cell tradeoff as `django_boost.models`/`forms`, so `warn_unused_ignores` is disabled for this module too.
  - `hard_delete_selected.allowed_permissions`/`.short_description` are Django's own convention of attaching action metadata directly to the function object; mypy doesn't allow arbitrary attribute assignment on a plain function, so each needs its own ignore.
- The registry entry is inserted between the sibling `admin.sites`/`test.testcase` blocks, isolated from other in-flight type-hint PRs.
- Verified against both `mypy==2.1.0+django-stubs==6.0.6` and `mypy==1.15.0+django-stubs==5.1.3+Django==4.2`.

## Verification
- `mypy django_boost` green on both stub environments
- `flake8 django_boost/admin/actions.py` clean
- `manage.py test` (508 tests, including the 2 dedicated hard-delete logging tests) green on both Django versions