### PR TITLE
:label: Type the migrate_emailuser command (management.commands.migrate_emailuser)

### DIFF
--- a/django_boost/management/commands/migrate_emailuser.py
+++ b/django_boost/management/commands/migrate_emailuser.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from django.apps import apps
 from django.conf import settings
 from django.core.management import call_command
-from django.core.management.base import CommandError
+from django.core.management.base import CommandError, CommandParser
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.recorder import MigrationRecorder
 
@@ -17,7 +19,9 @@ LEGACY_MODEL = "emailuser"
 LEGACY_USER_MODEL = "django_boost.EmailUser"
 
 
-def adopt_content_type(using, from_label, from_model, to_label, to_model) -> int:
+def adopt_content_type(
+    using: str, from_label: str, from_model: str, to_label: str, to_model: str,
+) -> int:
     """Rename the legacy ContentType in place so its permissions carry over.
 
     Returns the number of rows updated (0 if nothing to adopt).
@@ -32,7 +36,7 @@ def adopt_content_type(using, from_label, from_model, to_label, to_model) -> int
         app_label=to_label, model=to_model)
 
 
-def record_migration_applied(using, app_label, name) -> bool:
+def record_migration_applied(using: str, app_label: str, name: str) -> bool:
     """Record a migration as applied without running it. Idempotent.
 
     Returns True if a new record was written, False if it was already present.
@@ -49,14 +53,14 @@ class Command(BaseCommand):  # noqa: D101
     help = ("Adopt the legacy django_boost_emailuser table and content type into your own "
             "AUTH_USER_MODEL app, then finish migrating.")
 
-    def add_arguments(self, parser):  # noqa: D102
+    def add_arguments(self, parser: CommandParser) -> None:  # noqa: D102
         parser.add_argument("--database", default=DEFAULT_DB_ALIAS)
         parser.add_argument(
             "--target-migration", default="0001_initial",
             help="Migration in the target app that creates the user model "
                  "(default: 0001_initial).")
 
-    def handle(self, *args, **options):  # noqa: D102
+    def handle(self, *args: Any, **options: Any) -> None:  # noqa: D102
         using = options["database"]
         target = getattr(settings, "AUTH_USER_MODEL", "") or ""
         if target == LEGACY_USER_MODEL or "." not in target:

--- a/mypy.ini
+++ b/mypy.ini
@@ -325,6 +325,12 @@ disallow_untyped_defs = True
 disallow_incomplete_defs = True
 warn_return_any = True
 
+[mypy-django_boost.management.commands.migrate_emailuser]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
 [mypy-django_boost.templatetags]
 ignore_errors = False
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary
Annotate `adopt_content_type`/`record_migration_applied` (both already had partial `-> int`/`-> bool` return annotations; added the missing parameter types) and `Command.add_arguments`/`handle` against django-stubs' `CommandParser`/`BaseCommand`, and register `django_boost.management.commands.migrate_emailuser` in mypy.ini's TYPED-MODULE REGISTRY (issue #164 rollout).

## Notes
- No casts or ignores needed.
- The registry entry is inserted between the sibling `management.commands`/`templatetags` blocks, isolated from other in-flight type-hint PRs.
- Verified against both `mypy==2.1.0+django-stubs==6.0.6` and `mypy==1.15.0+django-stubs==5.1.3+Django==4.2` — both clean on the first pass.

This closes out the "Medium, not yet scheduled" tier from the rollout's remaining-modules inventory (`middleware`, `admin.actions`, `checks`, `migrate_emailuser` all now typed); everything left is Tier B-heavy/heaviest (`models/*`, `views/*`, `templatetags/*`, `http.response`, `shortcuts`, `template.base`) or intentionally skipped (`user_agents`).

## Verification
- `mypy django_boost` green on both stub environments
- `flake8 django_boost/management/commands/migrate_emailuser.py` clean
- `manage.py test` (508 tests) green on both Django versions