### PR TITLE
:wrench: Flip mypy.ini's TYPED-MODULE REGISTRY to an untyped-module denylist

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -29,273 +29,71 @@ ignore_errors = True
 [mypy-user_agents.*]
 ignore_missing_imports = True
 
-# === TYPED-MODULE REGISTRY (the ratchet) ===
-# Baseline is green: errors in the package are not reported until a module is
-# typed and registered. To adopt a module, add a block for it below (most
-# specific match wins over this wildcard), flip ignore_errors off, and turn on
-# strictness. This list IS the tracked set of typed modules.
+# === UNTYPED-MODULE DENYLIST (the ratchet) ===
+# Most of the package is typed now, so the default below is strict. Modules
+# not yet migrated are excluded here (most specific match wins over this
+# wildcard); to adopt one, delete its block and fix whatever mypy reports.
 [mypy-django_boost.*]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+warn_return_any = True
+
+[mypy-django_boost.http.response]
 ignore_errors = True
 
-[mypy-django_boost.urls.converters.*]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.models.deletion]
+ignore_errors = True
 
-[mypy-django_boost.admin]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.models.fields]
+ignore_errors = True
 
-[mypy-django_boost.urls.static]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.models.fields.related_descriptors]
+ignore_errors = True
 
-[mypy-django_boost.utils.itertools]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.models.manager]
+ignore_errors = True
 
-[mypy-django_boost.admin.filters]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.models.mixins]
+ignore_errors = True
 
-[mypy-django_boost.utils.version]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.models.query]
+ignore_errors = True
 
-[mypy-django_boost.management.mixins]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.shortcuts]
+ignore_errors = True
 
-[mypy-django_boost.utils.html]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.template.base]
+ignore_errors = True
 
-[mypy-django_boost.management.commands.deletemigrations]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.templatetags.boost]
+ignore_errors = True
 
-[mypy-django_boost.utils.functions.loop]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.templatetags.boost_query]
+ignore_errors = True
 
-[mypy-django_boost.forms.widgets]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.templatetags.boost_url]
+ignore_errors = True
 
-[mypy-django_boost.utils.functions.json]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.templatetags.mimetype]
+ignore_errors = True
 
-[mypy-django_boost.contrib.admin_tools.management.commands.listsuperuser]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.user_agents]
+ignore_errors = True
 
-[mypy-django_boost.admin_tools.management.commands.listsuperuser]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.views.base]
+ignore_errors = True
 
-[mypy-django_boost.utils]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.views.generic]
+ignore_errors = True
 
-[mypy-django_boost.contrib.admin_tools.management.commands.adminsitelog]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.views.mixins]
+ignore_errors = True
 
-[mypy-django_boost.management.commands.adminsitelog]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.core]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.admin_tools.apps]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.core.management]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.admin.mixins]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.db.router]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.validators]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.validators.*]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.admin.sites]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.admin.actions]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-# log_deletion (singular) needs a `# type: ignore[attr-defined]` on
-# django-stubs 5.1.3 + Django 4.2 (still declared there) but not on 6.0.6 +
-# Django 5.2 (removed, matching this local install) -- same cross-cell
-# tradeoff as django_boost.models/django_boost.forms.
-warn_unused_ignores = False
-
-[mypy-django_boost.test.testcase]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.management.templates]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.utils.attribute]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.management.commands.startapp_plus]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.middleware.html]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.middleware]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.context_processors]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.apps]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.contrib.admin_tools.apps]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.forms.mixins]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-# example/ is a development harness, but keep it type-checked so the sample app
-# continues to compile against django-boost's public APIs. Tests and migrations
-# are excluded above.
-[mypy-example.*]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.utils.functions]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.test]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.template]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.views.simple]
+ignore_errors = True
 
 [mypy-django_boost.models]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
 # AbstractUser.Meta needs a `# type: ignore[name-defined]` on django-stubs
 # 5.1.3 (CI's Django 4.2 cell) but not on 6.0.6 (CI's Django 5.2 cell,
 # matched by this local install) -- the same ignore is unavoidably "used"
@@ -303,112 +101,22 @@ warn_return_any = True
 # than fight both cells at once.
 warn_unused_ignores = False
 
-[mypy-django_boost.forms.fields]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
 [mypy-django_boost.forms]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
 # Same cross-stubs-version tradeoff as django_boost.models, for
 # BaseUserCreationForm.Meta/BaseUserChangeForm.Meta.
 warn_unused_ignores = False
 
-[mypy-django_boost.urls]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
+[mypy-django_boost.admin.actions]
+# log_deletion (singular) needs a `# type: ignore[attr-defined]` on
+# django-stubs 5.1.3 + Django 4.2 (still declared there) but not on 6.0.6 +
+# Django 5.2 (removed, matching this local install) -- same cross-cell
+# tradeoff as django_boost.models/django_boost.forms.
+warn_unused_ignores = False
 
-[mypy-django_boost.http]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.admin_tools]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.admin_tools.management]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.admin_tools.management.commands]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.contrib]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.contrib.admin_tools]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.contrib.admin_tools.management]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.contrib.admin_tools.management.commands]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.db]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.checks]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.management]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.management.commands]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.management.commands.migrate_emailuser]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.templatetags]
-ignore_errors = False
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_return_any = True
-
-[mypy-django_boost.views]
+# example/ is a development harness, but keep it type-checked so the sample app
+# continues to compile against django-boost's public APIs. Tests and migrations
+# are excluded above.
+[mypy-example.*]
 ignore_errors = False
 disallow_untyped_defs = True
 disallow_incomplete_defs = True


### PR DESCRIPTION
## Summary
Inverts `mypy.ini`'s per-module registry: 68/86 modules are typed now, so the file is strict by default (`[mypy-django_boost.*]`) and lists only the 18 modules still excluded, instead of listing all 59 typed ones.

## Notes
Behavior is unchanged — verified identical (green, 95 source files) on both CI mypy/django-stubs/Django cells before and after.