### PR TITLE
Fix negative raw-text depth counter corrupting later script/style blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - The `Toggleswitch` widget's visible label is now clickable; its `for` attribute now matches the input's `id`.
 - The `date` path converter now accepts a `datetime.date` value (e.g. from a `DateField`) in `reverse()`, instead of raising `NoReverseMatch`.
+- `strip_spaces_between_tags`/`compress_stream` no longer corrupt a `<script>` or `<style>` block that follows an unmatched stray closing tag earlier in the document.
 
 ## [3.3.1] - 2026-07-17
 

--- a/django_boost/utils/html.py
+++ b/django_boost/utils/html.py
@@ -70,10 +70,13 @@ class HTMLSpaceLessCompressor(HTMLParser):
     def handle_endtag(self, tag: str) -> None:  # noqa: D102
         self._end_run()
         self.buffer.write("</%s>" % tag)
+        # Clamped at 0: a stray closing tag with no matching opener (malformed
+        # input) must not send the counter negative, or the next legitimate
+        # element of that kind would be misread as outside its region.
         if tag in self.RAW_TEXT_ELEMENTS:
-            self._raw_depth -= 1
+            self._raw_depth = max(0, self._raw_depth - 1)
         elif tag in self.WHITESPACE_PRESERVING_ELEMENTS:
-            self._preserve_depth -= 1
+            self._preserve_depth = max(0, self._preserve_depth - 1)
 
     def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:  # noqa: D102
         self._end_run()

--- a/tests/tests/utils/test_html.py
+++ b/tests/tests/utils/test_html.py
@@ -170,6 +170,23 @@ class SpaceLessRawTextElementTests(TestCase):
             '<textarea>  a  b  </textarea>')
 
 
+class SpaceLessStrayClosingTagTests(TestCase):
+    """A stray closing tag with no matching opener must not desync the
+    raw-text depth counter and corrupt a later, well-formed block."""
+
+    def test_stray_closing_script_tag_does_not_corrupt_later_script(self):
+        self.assertEqual(
+            strip_spaces_between_tags(
+                '</script><script>if(a<b)y()</script>'),
+            '</script><script>if(a<b)y()</script>')
+
+    def test_stray_closing_style_tag_does_not_corrupt_later_style(self):
+        self.assertEqual(
+            strip_spaces_between_tags(
+                '</style><style>p > a { color: red; }</style>'),
+            '</style><style>p > a { color: red; }</style>')
+
+
 class SpaceLessStreamRawTextTests(TestCase):
     """script/style/textarea must stream identically to batch for any split."""
 


### PR DESCRIPTION
## Summary
A stray closing `</script>`/`</style>` tag with no matching opener could send `HTMLSpaceLessCompressor`'s internal depth counter negative; the next well-formed `<script>`/`<style>` block was then treated as regular text and HTML-escaped, corrupting its contents. The decrement is now clamped at zero.