### PR TITLE
Fix RedirectCorrectHostnameMiddleware redirecting to http://None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - The `Toggleswitch` widget's visible label is now clickable; its `for` attribute now matches the input's `id`.
 - The `date` path converter now accepts a `datetime.date` value (e.g. from a `DateField`) in `reverse()`, instead of raising `NoReverseMatch`.
 - `strip_spaces_between_tags`/`compress_stream` no longer corrupt a `<script>` or `<style>` block that follows an unmatched stray closing tag earlier in the document.
+- `RedirectCorrectHostnameMiddleware` no longer redirects every request to a literal `http://None/...` URL when `CORRECT_HOST` is unset or `None`.
 
 ## [3.3.1] - 2026-07-17
 

--- a/django_boost/middleware/__init__.py
+++ b/django_boost/middleware/__init__.py
@@ -61,11 +61,12 @@ class RedirectCorrectHostnameMiddleware(MiddlewareMixin):
         # correctly under both WSGI and ASGI. A synchronous __call__ override
         # would return a bare HttpResponse on the async path, which Django then
         # awaits -> TypeError.
-        enabled = not settings.DEBUG and hasattr(settings, 'CORRECT_HOST')
-        if enabled and request.get_host() != settings.CORRECT_HOST:
+        correct_host = getattr(settings, 'CORRECT_HOST', None)
+        enabled = not settings.DEBUG and correct_host
+        if enabled and request.get_host() != correct_host:
             return HttpResponsePermanentRedirect(
                 '{scheme}://{host}{path}'.format(scheme=request.scheme,
-                                                 host=settings.CORRECT_HOST,
+                                                 host=correct_host,
                                                  path=request.get_full_path()))
         return None
 

--- a/tests/tests/middleware/test_middleware.py
+++ b/tests/tests/middleware/test_middleware.py
@@ -134,6 +134,15 @@ class RedirectCorrectHostnameMiddlewareTests(SimpleTestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    @override_settings(DEBUG=False, CORRECT_HOST=None, ALLOWED_HOSTS=["*"])
+    def test_no_redirect_when_correct_host_is_none(self):
+        """CORRECT_HOST=os.environ.get(...) with an unset var must not redirect to 'None'."""
+        response = self._middleware()(
+            self.factory.get("/", HTTP_HOST="wrong.example.com"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(self.downstream), 1)
+
     def _async_middleware(self):
         async def get_response(request):
             self.downstream.append(request)


### PR DESCRIPTION
## Summary
`RedirectCorrectHostnameMiddleware` only checked that `CORRECT_HOST` existed via `hasattr()`, so setting it to `None` (e.g. `CORRECT_HOST = os.environ.get('CORRECT_HOST')` with the env var unset) redirected every request to a literal `http://None/...` URL. It now also requires the value to be truthy before redirecting.