### PR TITLE
Fix adminsitelog raw traceback on invalid filter value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Fixed
 
 - `register_all()` no longer registers a model merely imported into a `models.py` module (e.g. for a foreign key reference) — only models actually defined there.
+- `adminsitelog --filter`/`--exclude` with a value that doesn't match the field's type now reports a clear command error instead of a raw traceback.
 
 ## [3.4.0] - 2026-07-19
 

--- a/django_boost/contrib/admin_tools/management/commands/adminsitelog.py
+++ b/django_boost/contrib/admin_tools/management/commands/adminsitelog.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from typing import Any, ClassVar
 
 from django.contrib.admin.models import LogEntry
-from django.core.exceptions import FieldError
+from django.core.exceptions import FieldError, ValidationError
 from django.core.management.base import CommandError, CommandParser
 from django.db.models import Model
 from django.db.models.sql.query import get_field_names_from_opts  # type: ignore[attr-defined]
@@ -167,7 +167,7 @@ class Command(OutputFormatMixin, ConfirmOptionMixin, BaseCommand):
             queryset = queryset.filter(**self.parse_filter(options['filter']))
             queryset = queryset.exclude(**self.parse_filter(options['exclude']))
             queryset = queryset.order_by(*options['order_by'])
-        except FieldError as e:
+        except (FieldError, ValidationError, ValueError) as e:
             raise CommandError(str(e))
 
         if queryset.count() == 0:

--- a/tests/tests/contrib/admin_tools/management/commands/test_adminsitelog.py
+++ b/tests/tests/contrib/admin_tools/management/commands/test_adminsitelog.py
@@ -154,6 +154,18 @@ class TestAdminSiteLog(TestCase):
             call_command(
                 'adminsitelog', '--filter', 'badfield=1', stdout=StringIO())
 
+    def test_invalid_filter_value_raises_command_error(self):
+        with self.assertRaises(CommandError):
+            call_command(
+                'adminsitelog', '--filter', 'action_time>=banana',
+                stdout=StringIO())
+
+    def test_invalid_filter_int_value_raises_command_error(self):
+        with self.assertRaises(CommandError):
+            call_command(
+                'adminsitelog', '--filter', 'action_flag=abc',
+                stdout=StringIO())
+
     def test_invalid_order_by_field_raises_command_error(self):
         with self.assertRaises(CommandError):
             call_command(


### PR DESCRIPTION
## Summary
`adminsitelog --filter`/`--exclude` with a value that doesn't match the field's type (e.g. `id=abc` or `action_time>=banana`) raised an uncaught `ValidationError`/`ValueError` instead of a clean `CommandError`, matching the existing handling for an invalid field name.