### PR TITLE
Fix register_all() registering imported models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `register_all()` no longer registers a model merely imported into a `models.py` module (e.g. for a foreign key reference) — only models actually defined there.
+
 ## [3.4.0] - 2026-07-19
 
 ### Added

--- a/django_boost/admin/sites.py
+++ b/django_boost/admin/sites.py
@@ -46,6 +46,10 @@ def register_all(
       register_all(models, admin_class=admin.CustomAdmin)
     """
     for _, klass in getmembers(models, isclass):
+        # Skip classes merely imported into `models` (e.g. for an FK reference)
+        # rather than defined there -- only the latter matches the docstring above.
+        if klass.__module__ != models.__name__:
+            continue
         if isinstance(klass, ModelBase) and not klass._meta.abstract:
             try:
                 admin.site.register(klass, admin_class, **options)

--- a/tests/tests/admin/sites/models.py
+++ b/tests/tests/admin/sites/models.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import Permission  # noqa: F401 -- imported, not defined, here
 from django.db import models
 
 

--- a/tests/tests/admin/sites/test_register_all.py
+++ b/tests/tests/admin/sites/test_register_all.py
@@ -21,3 +21,13 @@ class AdminTest(TestCase):
         register_all(models)  # AlreadyRegistered on the second call is swallowed.
 
         self.assertTrue(site.is_registered(models.TestModel))
+
+    def test_register_all_skips_models_imported_but_not_defined(self):
+        from django.contrib.auth.models import Permission
+
+        from django_boost.admin.sites import register_all
+        from . import models
+
+        register_all(models)
+
+        self.assertFalse(site.is_registered(Permission))


### PR DESCRIPTION
## Summary
`register_all()` scanned every class visible in a `models.py` module, so a model merely imported for an FK/type reference (e.g. `Permission`) got registered into the admin site alongside models actually defined there. It now only registers classes defined in that module, matching the documented contract.