### PR TITLE
Fix adminsitelog deprecation warning wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `register_all()` no longer registers a model merely imported into a `models.py` module (e.g. for a foreign key reference) — only models actually defined there.
 - `adminsitelog --filter`/`--exclude` with a value that doesn't match the field's type now reports a clear command error instead of a raw traceback.
+- The `adminsitelog` deprecation warning now correctly instructs users to replace `django_boost.admin_tools` with `django_boost.contrib.admin_tools` in `INSTALLED_APPS`, instead of suggesting to add the new app alongside the old one (which raised `ImproperlyConfigured` on startup).
 
 ## [3.4.0] - 2026-07-19
 

--- a/django_boost/management/commands/adminsitelog.py
+++ b/django_boost/management/commands/adminsitelog.py
@@ -29,8 +29,9 @@ class Command(_Command):
     def execute(self, *args: Any, **options: Any) -> str | None:  # noqa: D102
         if not apps.is_installed(ADMIN_TOOLS_APP):
             warnings.warn(
-                "Running 'adminsitelog' from 'django_boost' is deprecated; add "
-                "'django_boost.contrib.admin_tools' to INSTALLED_APPS. The "
+                "Running 'adminsitelog' from 'django_boost' is deprecated; "
+                "replace 'django_boost.admin_tools' with "
+                "'django_boost.contrib.admin_tools' in INSTALLED_APPS. The "
                 "'django_boost' command alias will be removed in "
                 "django-boost 4.0.",
                 DeprecationWarning,

--- a/tests/tests/management/commands/test_adminsitelog_deprecation.py
+++ b/tests/tests/management/commands/test_adminsitelog_deprecation.py
@@ -50,3 +50,24 @@ class TestAdminSiteLogLegacyAlias(TestCase):
             with self.assertWarns(DeprecationWarning):
                 call_command(
                     'adminsitelog', stdout=StringIO(), stderr=StringIO())
+
+    def test_warning_tells_user_to_replace_not_add_the_app(self):
+        # Both apps default their app_label to 'admin_tools' (neither
+        # AppConfig sets an explicit label), so they cannot coexist in
+        # INSTALLED_APPS; the message must say "replace", not "add".
+        apps_without_contrib = [
+            app for app in settings.INSTALLED_APPS
+            if app != 'django_boost.contrib.admin_tools']
+        self.addCleanup(get_commands.cache_clear)
+        with override_settings(INSTALLED_APPS=apps_without_contrib):
+            get_commands.cache_clear()
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                call_command(
+                    'adminsitelog', stdout=StringIO(), stderr=StringIO())
+        messages = [str(w.message) for w in _deprecations(caught)]
+        self.assertTrue(any(
+            "replace 'django_boost.admin_tools' with "
+            "'django_boost.contrib.admin_tools'" in message
+            for message in messages
+        ), messages)


### PR DESCRIPTION
## Summary
The `adminsitelog` deprecation warning told users to add `django_boost.contrib.admin_tools` to `INSTALLED_APPS`, but the legacy `django_boost.admin_tools` and the new app both default to the same app_label, so adding the new app alongside the old one raises `ImproperlyConfigured: Application labels aren't unique`. The message now says to replace the old app instead.