### PR TITLE
Preserve CDATA sections and processing instructions in SpaceLessMiddleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `SpaceLessMiddleware` no longer silently drops CDATA sections and processing instructions from HTML responses.
+
 ## [3.4.1] - 2026-07-26
 
 ### Fixed

--- a/django_boost/utils/html.py
+++ b/django_boost/utils/html.py
@@ -95,6 +95,18 @@ class HTMLSpaceLessCompressor(HTMLParser):
         # so the text on either side is stripped separately, as with a tag.
         self._end_run()
 
+    def unknown_decl(self, data: str) -> None:
+        """Preserve marked sections (e.g. CDATA in inline SVG/MathML) instead of the base no-op."""
+        self._end_run()
+        # HTMLParser strips the outer "<![" and "]]>" before calling this hook.
+        self.buffer.write("<![%s]]>" % data)
+
+    def handle_pi(self, data: str) -> None:
+        """Preserve processing instructions instead of the base no-op."""
+        self._end_run()
+        # HTMLParser strips the outer "<?" and trailing ">" before calling this hook.
+        self.buffer.write("<?%s>" % data)
+
     def _render_attrs(self, attrs: list[tuple[str, str | None]]) -> str:
         return ' '.join(
             name if value is None else '%s="%s"' % (name, escape(value))

--- a/tests/tests/utils/test_html.py
+++ b/tests/tests/utils/test_html.py
@@ -187,6 +187,21 @@ class SpaceLessStrayClosingTagTests(TestCase):
             '</style><style>p > a { color: red; }</style>')
 
 
+class SpaceLessCDataAndProcessingInstructionTests(TestCase):
+    """CDATA sections (valid in inline SVG/MathML) and processing
+    instructions must be preserved, not silently dropped."""
+
+    def test_cdata_section_is_preserved(self):
+        self.assertEqual(
+            strip_spaces_between_tags('<svg><text><![CDATA[a<b]]></text></svg>'),
+            '<svg><text><![CDATA[a<b]]></text></svg>')
+
+    def test_processing_instruction_is_preserved(self):
+        self.assertEqual(
+            strip_spaces_between_tags('a<?instruction?>b'),
+            'a<?instruction?>b')
+
+
 class SpaceLessStreamRawTextTests(TestCase):
     """script/style/textarea must stream identically to batch for any split."""
 


### PR DESCRIPTION
## Summary
`HTMLSpaceLessCompressor` silently dropped CDATA sections (valid in inline SVG/MathML foreign content) and processing instructions from compressed HTML, since `HTMLParser`'s `unknown_decl`/`handle_pi` hooks default to no-ops. Both are now preserved verbatim.