### PR TITLE
Fix JsonRequestMixin docstring to match its lenient default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `LogicalDeletionQuerySet`/`LogicalDeletionManager` gained `deleted_since`, `deleted_before`, and `deleted_between` methods for filtering by deletion date.
 
+### Changed
+
+- Documented that `JsonRequestMixin` does not restrict the request's Content-Type unless `strictly = True` is set.
+
 ### Fixed
 
 - The `Toggleswitch` widget's visible label is now clickable; its `for` attribute now matches the input's `id`.

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -118,7 +118,12 @@ class LimitedTermMixin:
 
 @method_decorator(csrf_exempt, name="dispatch")
 class JsonRequestMixin(AllowContentTypeMixin):
-    """Only allow json request mixin."""
+    """Mixin that exposes ``self.json``, the parsed JSON request body.
+
+    By default this does not restrict the request's Content-Type; set
+    ``strictly = True`` to reject requests whose Content-Type is not in
+    ``allowed_content_types`` (415).
+    """
 
     allowed_content_types = ["application/json"]
     strictly = False

--- a/docs/view_mixins.rst
+++ b/docs/view_mixins.rst
@@ -154,6 +154,8 @@ A specialized mixin for ``AllowContentTypeMixin`` for json.
 
 You can access the dictionary object parsed from the Json string sent by the client in ``self.json``
 
+By default this mixin does not restrict the request's Content-Type. Specify ``strictly = True`` if you want to limit the Content-Type to Json only.
+
 If you use for the purpose of API, ``JsonView`` is recommended.
 
 ResponseMixins
@@ -180,9 +182,3 @@ Returns the response in Json format
 The usage of ``extra_context`` and ``get_context_data`` is basically the same as ``TemplateView``.
 
 The difference is that ``TemplateView`` is passed directly to the template context, whereas ``JsonResponseMixin`` is a direct response.
-
-
-Specify ``strictly = True`` if you want to limit the Content-Type to Json only.
-
-
-If you use for the purpose of API ``JsonView`` below is recommended.

--- a/tests/tests/views_mixins/tests.py
+++ b/tests/tests/views_mixins/tests.py
@@ -79,6 +79,8 @@ class TestViewMixins(TestCase):
 
     def test_json_request(self):
         url = '/json_request/'
+        # Default content-type here is multipart/form-data (not JSON); this
+        # passes because JsonRequestMixin.strictly defaults to False.
         response = self.client.post(url)
         self.assertStatusCodeEqual(response, 302)
 


### PR DESCRIPTION
## Summary
`JsonRequestMixin`'s docstring said "Only allow json request mixin", but `strictly` defaults to `False`, so no Content-Type is rejected unless `strictly = True` is set. Updated the docstring and the matching `docs/view_mixins.rst` section to describe the actual default behavior; no behavior change.

## Verification
- `python manage.py test` (519 tests) and `flake8 .` both clean in the devcontainer (Python 3.12 x Django 4.2).