### PR TITLE
Exempt AnonymousRequiredMixin from LoginRequiredMiddleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - `SpaceLessMiddleware` no longer silently drops CDATA sections and processing instructions from HTML responses.
 - `DatabaseRouter` now picks up `DATABASE_APPS_MAPPING` changes made via `override_settings` at test/runtime instead of only reading it once when the router is first created.
+- `AnonymousRequiredMixin` views are no longer redirected to the login page by Django's `LoginRequiredMiddleware` (Django 5.1+) before the view can run.
 
 ## [3.4.1] - 2026-07-26
 

--- a/django_boost/views/mixins.py
+++ b/django_boost/views/mixins.py
@@ -6,6 +6,7 @@ import json
 from datetime import timedelta
 from typing import Sequence
 
+import django
 from django.conf import settings
 from django.contrib.auth import logout as auth_logout
 from django.contrib.auth.mixins import AccessMixin
@@ -20,6 +21,14 @@ from django.views.decorators.csrf import csrf_exempt
 
 from django_boost.http import HttpResponseUnsupportedMediaType
 from django_boost.user_agents import parse_user_agent
+
+if django.VERSION >= (5, 1):
+    from django.contrib.auth.decorators import login_not_required
+else:
+    # login_not_required was added in Django 5.1; on older versions there is
+    # no LoginRequiredMiddleware to exempt views from, so this is a no-op.
+    def login_not_required(view_func):
+        return view_func
 
 
 __all__ = ["CSRFExemptMixin", "DynamicRedirectMixin", "RedirectToDetailMixin",
@@ -170,6 +179,7 @@ class JsonResponseMixin:
     put = post
 
 
+@method_decorator(login_not_required, name="dispatch")
 class AnonymousRequiredMixin:
     """
     Require the user to be anonymous.

--- a/tests/tests/views_mixins/tests.py
+++ b/tests/tests/views_mixins/tests.py
@@ -1,5 +1,7 @@
 import os
+import unittest
 
+import django
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 
@@ -296,6 +298,30 @@ class JsonResponseMixinResponseClassTests(TestCase):
 
         response = V().get(RequestFactory().get("/"))
         self.assertIsInstance(response, MyJsonResponse)
+
+
+@unittest.skipUnless(django.VERSION >= (5, 1),
+                     "LoginRequiredMiddleware was added in Django 5.1")
+class AnonymousRequiredMixinLoginRequiredMiddlewareTests(TestCase):
+    """AnonymousRequiredMixin views are anonymous-only by definition, so
+    Django's opt-in LoginRequiredMiddleware must not gate them behind login."""
+
+    def test_passes_through_middleware_for_anonymous_user(self):
+        from django.contrib.auth.middleware import LoginRequiredMiddleware
+        from django.contrib.auth.models import AnonymousUser
+        from django.http import HttpResponse
+        from django.test import RequestFactory
+
+        from tests.tests.views_mixins.views import AnonymousRequiredView
+
+        request = RequestFactory().get('/anonymous_only/')
+        request.user = AnonymousUser()
+        middleware = LoginRequiredMiddleware(get_response=lambda r: HttpResponse())
+
+        result = middleware.process_view(
+            request, AnonymousRequiredView.as_view(), (), {})
+
+        self.assertIsNone(result)
 
 
 class DynamicRedirectMixinModelFormTests(TestCase):


### PR DESCRIPTION
## Summary
On Django 5.1+, `LoginRequiredMiddleware` redirected anonymous requests to `LOGIN_URL` before views using `AnonymousRequiredMixin` (e.g. a custom login/signup page) could run, causing a redirect loop. The mixin's `dispatch` is now marked `login_not_required` on Django >=5.1, so the middleware lets anonymous requests through to it.

## Notes
`login_not_required` doesn't exist before Django 5.1, so the decorator is a no-op on 4.2/5.0 (guarded by `django.VERSION`).