### PR TITLE
Fix DatabaseRouter caching DATABASE_APPS_MAPPING at construction time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 ### Fixed
 
 - `SpaceLessMiddleware` no longer silently drops CDATA sections and processing instructions from HTML responses.
+- `DatabaseRouter` now picks up `DATABASE_APPS_MAPPING` changes made via `override_settings` at test/runtime instead of only reading it once when the router is first created.
 
 ## [3.4.1] - 2026-07-26
 

--- a/django_boost/db/router.py
+++ b/django_boost/db/router.py
@@ -12,10 +12,15 @@ from django.db.models import Model
 class DatabaseRouter:
     """Route Django apps to database aliases from DATABASE_APPS_MAPPING."""
 
-    def __init__(self) -> None:
-        """Load the app-to-database mapping from ``settings.DATABASE_APPS_MAPPING``."""
-        self.db_map: dict[str, str] = getattr(
-            settings, "DATABASE_APPS_MAPPING", {})
+    @property
+    def db_map(self) -> dict[str, str]:
+        """Read ``settings.DATABASE_APPS_MAPPING`` fresh on every access.
+
+        Reading it here rather than caching it on ``self`` keeps the router
+        responsive to ``override_settings`` in tests, and at runtime to
+        anything that reassigns the setting.
+        """
+        return getattr(settings, "DATABASE_APPS_MAPPING", {})
 
     def db_for_read(self, model: type[Model], **hints: Any) -> str | None:  # noqa: D102
         return self.db_map.get(model._meta.app_label, None)

--- a/tests/tests/db/test_router.py
+++ b/tests/tests/db/test_router.py
@@ -49,6 +49,27 @@ class DatabaseRouterAllowMigrateTests(SimpleTestCase):
         self.assertIsNone(router.allow_migrate('otherdb', 'auth'))
 
 
+class DatabaseRouterDynamicMappingTests(SimpleTestCase):
+
+    def test_mapping_change_is_picked_up_by_an_already_constructed_router(self):
+        # The router instance predates the override, so this only passes if
+        # DATABASE_APPS_MAPPING is read fresh on each call rather than
+        # snapshotted at construction time.
+        router = DatabaseRouter()
+        with override_settings(DATABASE_APPS_MAPPING={'shop': 'shopdb'}):
+            self.assertTrue(router.allow_migrate('shopdb', 'shop'))
+            self.assertFalse(router.allow_migrate('default', 'shop'))
+
+    def test_mapping_seen_inside_override_does_not_leak_after_it_exits(self):
+        with override_settings(DATABASE_APPS_MAPPING={'shop': 'shopdb'}):
+            router = DatabaseRouter()
+            self.assertTrue(router.allow_migrate('shopdb', 'shop'))
+        # Back on the process-wide setting: the mapping seen during
+        # construction must not persist on the router past the override.
+        self.assertIsNone(router.allow_migrate('shopdb', 'shop'))
+        self.assertTrue(router.allow_migrate('example', 'example'))
+
+
 class DatabaseRouterConfiguredExampleTests(SimpleTestCase):
 
     def test_example_app_routes_to_configured_example_database(self):


### PR DESCRIPTION
## Summary
`DatabaseRouter` now reads `settings.DATABASE_APPS_MAPPING` on every routing call instead of snapshotting it once in `__init__`, so `override_settings(DATABASE_APPS_MAPPING=...)` changes take effect on already-constructed router instances and don't leak past the `override_settings` block.