### PR TITLE
Fix migrate_emailuser crash on a fresh, unmigrated database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `register_all()` no longer registers a model merely imported into a `models.py` module (e.g. for a foreign key reference) — only models actually defined there.
 - `adminsitelog --filter`/`--exclude` with a value that doesn't match the field's type now reports a clear command error instead of a raw traceback.
 - The `adminsitelog` deprecation warning now correctly instructs users to replace `django_boost.admin_tools` with `django_boost.contrib.admin_tools` in `INSTALLED_APPS`, instead of suggesting to add the new app alongside the old one (which raised `ImproperlyConfigured` on startup).
+- `migrate_emailuser` no longer crashes before running `migrate` on a fresh, unmigrated database.
 
 ## [3.4.0] - 2026-07-19
 

--- a/django_boost/management/commands/migrate_emailuser.py
+++ b/django_boost/management/commands/migrate_emailuser.py
@@ -71,14 +71,14 @@ class Command(BaseCommand):  # noqa: D101
         target_app, target_model = target.split(".", 1)
         model_name = target_model.lower()
 
-        adopted = adopt_content_type(
-            using, LEGACY_APP_LABEL, LEGACY_MODEL, target_app, model_name)
-        if adopted:
-            self.stdout.write(
-                "Adopted content type %s.%s -> %s.%s (permissions preserved)."
-                % (LEGACY_APP_LABEL, LEGACY_MODEL, target_app, model_name))
-
         if LEGACY_TABLE in connections[using].introspection.table_names():
+            adopted = adopt_content_type(
+                using, LEGACY_APP_LABEL, LEGACY_MODEL, target_app, model_name)
+            if adopted:
+                self.stdout.write(
+                    "Adopted content type %s.%s -> %s.%s (permissions preserved)."
+                    % (LEGACY_APP_LABEL, LEGACY_MODEL, target_app, model_name))
+
             migration = options["target_migration"]
             if record_migration_applied(using, target_app, migration):
                 self.stdout.write(

--- a/tests/tests/management/commands/test_migrate_emailuser.py
+++ b/tests/tests/management/commands/test_migrate_emailuser.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.db import DEFAULT_DB_ALIAS, connections
+from django.db import DEFAULT_DB_ALIAS, OperationalError, connections
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import override_settings
 
@@ -85,3 +85,20 @@ class MigrateEmailUserCommandTests(TestCase):
         names = [c[0] for c in manager.mock_calls]
         self.assertLess(names.index("adopt"), names.index("migrate"))
         self.assertLess(names.index("record"), names.index("migrate"))
+
+    @override_settings(AUTH_USER_MODEL="accounts.User")
+    def test_skips_adopt_content_type_on_fresh_unmigrated_database(self):
+        # On a fresh database, ContentType.objects...exists() (used internally by
+        # adopt_content_type) would raise this same error, before ever reaching the
+        # final call_command("migrate", ...) that would create the table.
+        module = "django_boost.management.commands.migrate_emailuser"
+        with patch(module + ".connections") as mock_connections, \
+                patch(module + ".adopt_content_type") as adopt, \
+                patch(module + ".call_command") as migrate:
+            mock_connections[DEFAULT_DB_ALIAS].introspection.table_names.return_value = []
+            adopt.side_effect = OperationalError("no such table: django_content_type")
+
+            call_command("migrate_emailuser", stdout=StringIO())
+
+        adopt.assert_not_called()
+        migrate.assert_called_once_with("migrate", database=DEFAULT_DB_ALIAS)


### PR DESCRIPTION
## Summary
`migrate_emailuser` no longer crashes with `OperationalError` (no such table: `django_content_type`) when run against a fresh database that hasn't been migrated yet; it now only adopts the legacy content type once the legacy table is confirmed present, matching its documented purpose of being safely re-runnable before the initial migrate.