### PR TITLE
Fix float/decimal path converters producing exponential notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 - `SpaceLessMiddleware` no longer silently drops CDATA sections and processing instructions from HTML responses.
 - `DatabaseRouter` now picks up `DATABASE_APPS_MAPPING` changes made via `override_settings` at test/runtime instead of only reading it once when the router is first created.
 - `AnonymousRequiredMixin` views are no longer redirected to the login page by Django's `LoginRequiredMiddleware` (Django 5.1+) before the view can run.
+- The `float` and `decimal` path converters (and their signed/positive/negative variants) no longer raise `NoReverseMatch` for very small or very large values, such as `0.00001` or `1e16`.
 
 ## [3.4.1] - 2026-07-26
 

--- a/django_boost/urls/converters/_numeric.py
+++ b/django_boost/urls/converters/_numeric.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import decimal
 from typing import ClassVar, Generic, TypeVar
 
 _T = TypeVar('_T')
@@ -30,4 +31,12 @@ class BaseSignedNumericConverter(Generic[_T]):
         return self._parse(value)
 
     def to_url(self, value: _T | str) -> str:  # noqa: D102
-        return str(value)
+        # A string is passed through verbatim, so a malformed one still
+        # fails the reverse match. For an actual numeric value, str(value)
+        # can switch to exponential notation at extreme magnitudes (a float
+        # < 1e-4 or >= 1e16, or a Decimal with a positive exponent), which
+        # the fixed-point ``regex`` above rejects; re-rendering it through
+        # Decimal keeps it in fixed-point notation without rounding it.
+        if isinstance(value, str):
+            return value
+        return format(decimal.Decimal(str(value)), 'f')

--- a/tests/tests/urls/converters/test_decimal.py
+++ b/tests/tests/urls/converters/test_decimal.py
@@ -56,6 +56,17 @@ class TestDecimalConversion(TestCase):
         self.assertEqual(
             SignedDecimalConverter().to_url(decimal.Decimal('0')), '0')
 
+    def test_to_url_avoids_exponential_notation(self):
+        # Decimal's own str() switches to scientific notation once the
+        # adjusted exponent is < -6 or > 0; neither form matches the
+        # converter's regex, so reverse() must not produce them.
+        self.assertEqual(
+            SignedDecimalConverter().to_url(decimal.Decimal('1E-7')),
+            '0.0000001')
+        self.assertEqual(
+            SignedDecimalConverter().to_url(decimal.Decimal('1E+16')),
+            '10000000000000000')
+
 
 class TestDecimalRegex(TestCase):
 
@@ -151,3 +162,13 @@ class TestDecimalConverter(ConverterTestCase):
             reverse('non_positive_decimal',
                     kwargs={'non_positive_decimal': decimal.Decimal('0')}),
             '/non_positive_decimal/0')
+
+    def test_reverse_avoids_exponential_notation(self):
+        self.assertEqual(
+            reverse('signed_decimal',
+                    kwargs={'signed_decimal': decimal.Decimal('1E-7')}),
+            '/signed_decimal/0.0000001')
+        self.assertEqual(
+            reverse('signed_decimal',
+                    kwargs={'signed_decimal': decimal.Decimal('1E+16')}),
+            '/signed_decimal/10000000000000000')

--- a/tests/tests/urls/converters/test_float.py
+++ b/tests/tests/urls/converters/test_float.py
@@ -43,6 +43,13 @@ class TestFloatConversion(TestCase):
         self.assertEqual(PositiveFloatConverter().to_url(7.25), '7.25')
         self.assertEqual(SignedFloatConverter().to_url(0.0), '0.0')
 
+    def test_to_url_avoids_exponential_notation(self):
+        # str(0.00001) == '1e-05' and str(1e16) == '1e+16'; neither matches
+        # the converter's own regex, so reverse() must not produce them.
+        self.assertEqual(SignedFloatConverter().to_url(0.00001), '0.00001')
+        self.assertEqual(
+            SignedFloatConverter().to_url(1e16), '10000000000000000')
+
 
 class TestFloatRegex(TestCase):
 
@@ -134,3 +141,11 @@ class TestFloatConverter(ConverterTestCase):
         self.assertEqual(
             reverse('non_positive_float', kwargs={'non_positive_float': 0.0}),
             '/non_positive_float/0.0')
+
+    def test_reverse_avoids_exponential_notation(self):
+        self.assertEqual(
+            reverse('signed_float', kwargs={'signed_float': 0.00001}),
+            '/signed_float/0.00001')
+        self.assertEqual(
+            reverse('signed_float', kwargs={'signed_float': 1e16}),
+            '/signed_float/10000000000000000')


### PR DESCRIPTION
## Summary
`reverse()` raised `NoReverseMatch` for `float`/`decimal` path converter values whose `str()` uses exponential notation (e.g. `0.00001` -> `1e-05`, `1e16` -> `1e+16`, or a `Decimal` with a positive exponent), since that doesn't match the converters' fixed-point regex.

## Notes
The fix lives in the shared `BaseSignedNumericConverter.to_url` (`django_boost/urls/converters/_numeric.py`), not a float-only override: `Decimal`'s own `str()` has the same defect for extreme-enough values (adjusted exponent < -6, or an instance constructed with a positive exponent), so both float and decimal converters needed it. A raw string value is still passed through unchanged, so a malformed string (e.g. `'1.'` with a trailing dot) still fails to reverse as before.

## Verification
- `python manage.py test` — full suite green (523 tests)
- `flake8` and `mypy` — clean