### PR TITLE
Build releases and docs with uv; drop requirements/

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,9 +1,0 @@
-{
-  "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
-      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
-    }
-  }
-}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "daily"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,21 +22,14 @@ jobs:
           GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'
       - uses: actions/checkout@v7
         if: ${{ steps.create_release.outputs.created == 'true' }}
-      - name: Set up Python
+      - name: Install uv
         if: ${{ steps.create_release.outputs.created == 'true' }}
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.x'
-      - name: Install dependencies
-        if: ${{ steps.create_release.outputs.created == 'true' }}
-        run: |
-          python -m pip install --upgrade pip
-          pip install build twine
+        uses: astral-sh/setup-uv@v7
       - name: Build and publish
         if: ${{ steps.create_release.outputs.created == 'true' }}
         env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          UV_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          python -m build
-          twine upload dist/*
+          uv build
+          uv publish

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,12 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.10"
+  jobs:
+    # uv targets RTD's own virtualenv so the stock Sphinx build steps
+    # (and `formats: all`) keep working; only the install step is overridden.
+    install:
+      - pip install uv
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --frozen --no-dev --group docs
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -17,8 +23,3 @@ sphinx:
 
 # If using Sphinx, optionally build your docs in additional formats
 formats: all
-
-# Optionally declare the Python requirements required to build your docs
-python:
-   install:
-   - requirements: requirements/docs.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,0 @@
-Django>=4.2,<6; python_version < "3.13"
-Django>=5.1,<6; python_version >= "3.13"

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,6 +1,0 @@
-wheel
-setuptools
-pillow
-tox-travis
-coverage
-user-agents>=2.0

--- a/requirements/develop.txt
+++ b/requirements/develop.txt
@@ -1,9 +1,0 @@
--r base.txt
-tox
-autopep8
-user-agents>=2.0
-# Pinned to the primary type-check (Django 5.2); CI also runs a Django 4.2 cell
-# on its own stubs pin — see .github/workflows/test.yml.
-mypy==2.1.0
-django-stubs[compatible-mypy]==6.0.7
-django-stubs-ext==6.0.7

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,0 @@
--r base.txt
-Sphinx>=2.0
-sphinx_rtd_theme


### PR DESCRIPTION
Stacked on #494.

## Summary
The release workflow builds and publishes with `uv build` / `uv publish` (same PyPI credential secrets, via `UV_PUBLISH_*`), Read the Docs installs via `uv sync --group docs` targeting its own virtualenv, and the now-unreferenced `requirements/` directory is removed.

## Notes
- Only RTD's install step is overridden, so the stock Sphinx build and `formats: all` are unchanged.
- The publish path runs for real only on the next `Release X.Y.Z` commit.

## Verification
- `uv build` locally: wheel file list identical to a pre-migration baseline build; version `3.3.2a0`.
- Sphinx HTML build passes in the devcontainer via the docs dependency group.
- `grep -rn "requirements/"` over the tree: no references remain.