### PR TITLE
Release 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-07-19
+
 ### Added
 
 - `LogicalDeletionQuerySet`/`LogicalDeletionManager` gained `deleted_since`, `deleted_before`, and `deleted_between` methods for filtering by deletion date.
@@ -515,7 +517,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - First release.
 
-[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.3.1...HEAD
+[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.4.0...HEAD
+[3.4.0]: https://github.com/ChanTsune/django-boost/compare/v3.3.1...v3.4.0
 [3.3.1]: https://github.com/ChanTsune/django-boost/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/ChanTsune/django-boost/compare/v3.2.4...v3.3.0
 [3.2.4]: https://github.com/ChanTsune/django-boost/compare/v3.2.3...v3.2.4

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django_boost.utils.version import _Version, get_version
 
-VERSION: _Version = (3, 3, 2, 'alpha', 0)
+VERSION: _Version = (3, 4, 0, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
## Summary
Finalizes VERSION to `3.4.0` (final, minor bump — the accumulated Unreleased changes include a new backward-compatible feature) and moves the CHANGELOG's Unreleased entries under a dated `[3.4.0]` section.