### PR TITLE
Release 3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+## [3.4.1] - 2026-07-26
+
 ### Fixed
 
 - `register_all()` no longer registers a model merely imported into a `models.py` module (e.g. for a foreign key reference) — only models actually defined there.
@@ -524,7 +526,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - First release.
 
-[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.4.0...HEAD
+[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.4.1...HEAD
+[3.4.1]: https://github.com/ChanTsune/django-boost/compare/v3.4.0...v3.4.1
 [3.4.0]: https://github.com/ChanTsune/django-boost/compare/v3.3.1...v3.4.0
 [3.3.1]: https://github.com/ChanTsune/django-boost/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/ChanTsune/django-boost/compare/v3.2.4...v3.3.0

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django_boost.utils.version import _Version, get_version
 
-VERSION: _Version = (3, 4, 0, 'final', 0)
+VERSION: _Version = (3, 4, 1, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
## Summary

Patch release bundling the bug fixes accumulated since 3.4.0.

### Fixed

- `register_all()` no longer registers a model merely imported into a `models.py` module (e.g. for a foreign key reference) — only models actually defined there.
- `adminsitelog --filter`/`--exclude` with a value that doesn't match the field's type now reports a clear command error instead of a raw traceback.
- The `adminsitelog` deprecation warning now correctly instructs users to replace `django_boost.admin_tools` with `django_boost.contrib.admin_tools` in `INSTALLED_APPS`, instead of suggesting to add the new app alongside the old one (which raised `ImproperlyConfigured` on startup).
- `migrate_emailuser` no longer crashes before running `migrate` on a fresh, unmigrated database.