### PR TITLE
:bookmark: Release 3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 ## [Unreleased]
 
+## [3.4.2] - 2026-09-06
+
 ### Fixed
 
 - `SpaceLessMiddleware` no longer silently drops CDATA sections and processing instructions from HTML responses.
@@ -533,7 +535,8 @@ Version numbers follow [PEP 440](https://peps.python.org/pep-0440/).
 
 - First release.
 
-[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.4.1...HEAD
+[Unreleased]: https://github.com/ChanTsune/django-boost/compare/v3.4.2...HEAD
+[3.4.2]: https://github.com/ChanTsune/django-boost/compare/v3.4.1...v3.4.2
 [3.4.1]: https://github.com/ChanTsune/django-boost/compare/v3.4.0...v3.4.1
 [3.4.0]: https://github.com/ChanTsune/django-boost/compare/v3.3.1...v3.4.0
 [3.3.1]: https://github.com/ChanTsune/django-boost/compare/v3.3.0...v3.3.1

--- a/django_boost/__init__.py
+++ b/django_boost/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django_boost.utils.version import _Version, get_version
 
-VERSION: _Version = (3, 4, 1, 'final', 0)
+VERSION: _Version = (3, 4, 2, 'final', 0)
 
 
 __version__ = get_version()


### PR DESCRIPTION
## [3.4.2] - 2026-09-06

### Fixed

- `SpaceLessMiddleware` no longer silently drops CDATA sections and processing instructions from HTML responses.
- `DatabaseRouter` now picks up `DATABASE_APPS_MAPPING` changes made via `override_settings` at test/runtime instead of only reading it once when the router is first created.
- `AnonymousRequiredMixin` views are no longer redirected to the login page by Django's `LoginRequiredMiddleware` (Django 5.1+) before the view can run.
- The `float` and `decimal` path converters (and their signed/positive/negative variants) no longer raise `NoReverseMatch` for very small or very large values, such as `0.00001` or `1e16`.

### Verification
- `makemigrations --check`: pass (no changes, expected W050 only)
- `manage.py test`: 536 tests OK